### PR TITLE
ENYO-1563 : add moon.DayPicker component to ExpandablePickerSample

### DIFF
--- a/src/moonstone-samples/lib/ExpandablePickerSample.js
+++ b/src/moonstone-samples/lib/ExpandablePickerSample.js
@@ -13,7 +13,8 @@ var
 	Panel = require('moonstone/Panel'),
 	Panels = require('moonstone/Panels'),
 	Scroller = require('moonstone/Scroller'),
-	TimePicker = require('moonstone/TimePicker');
+	TimePicker = require('moonstone/TimePicker'),
+	DayPicker = require('moonstone/DayPicker');
 
 module.exports = kind({
 	name: 'moon.sample.ExpandablePickerSample',
@@ -61,6 +62,7 @@ module.exports = kind({
 						{kind: ExpandableIntegerPicker, disabled:true, autoCollapse: true, content: 'Disabled Integer Picker', value: 2, min: 1, max: 15, unit: 'sec'},
 						{kind: DatePicker, noneText: 'Pick a Date', content: 'Date Picker'},
 						{kind: TimePicker, noneText: 'Pick a Date', content: 'Time Picker'},
+						{kind: DayPicker, noneText: "Pick a Day", content: "Day Picker"},
 						{kind: ExpandableInput, noneText: 'Enter text', content: 'Expandable Input', placeholder: 'Enter text'},
 						{kind: ExpandableDataPicker, content: 'Expandable Data Picker', noneText: 'Nothing Selected', components: [
 							{bindings: [
@@ -116,6 +118,7 @@ module.exports = kind({
 							{kind: ExpandableIntegerPicker, disabled:true, autoCollapse: true, content: 'Disabled Integer Picker', value: 2, min: 1, max: 15, unit: 'sec'},
 							{kind: DatePicker, noneText: 'Pick a Date', content: 'Date Picker'},
 							{kind: TimePicker, noneText: 'Pick a Date', content: 'Time Picker'},
+							{kind: DayPicker, noneText: "Pick a Day", content: "Day Picker"},
 							{kind: ExpandableInput, noneText: 'Enter text', content: 'Expandable Input', placeholder: 'Enter text'},
 							{kind: ExpandableDataPicker, content: 'Expandable Data Picker', noneText: 'Nothing Selected', components: [
 								{bindings: [


### PR DESCRIPTION
### Issue

There is a requirement for supporting string overlay on Expandable picker in Dreadlocks.
(Especially, it target expandable picker which can select day of the week and shows representative value )
### Fix

For resolving the requirement, make a new kind and update the sample.

DCO-1.1-Signed-Off-By: Sungbae Cho sb.cho@lge.com
