### PR TITLE
ENYO-1618: Update LightPanels sample.

### DIFF
--- a/src/enyo-samples/lib/LightPanelsSample/LightPanelsSample.css
+++ b/src/enyo-samples/lib/LightPanelsSample/LightPanelsSample.css
@@ -1,61 +1,82 @@
-.enyo-light-panels {
+.light-panels-sample .light-panels-options {
+	position: fixed;
+	margin: 0 30%;
+	height: 50px;
+	width: 40%;
+	background-color: white;
+	border-radius: 0 0 100px 100px;
+	z-index: 1;
+}
+
+.light-panels-sample .vertical-options, .light-panels-sample .horizontal-options {
+	display: inline-block;
+	margin-top: 10px;
+	width: 50%;
+	text-align: center;
+}
+
+.light-panels-sample .vertical-options .enyo-checkbox, .light-panels-sample .horizontal-options .enyo-checkbox {
+	margin-left: 15px;
+}
+
+.light-panels-sample .enyo-light-panels {
 	width: 50%;
 }
 
-.enyo-light-panels.vertical {
+.light-panels-sample .enyo-light-panels.vertical {
 	left: 50%;
 }
 
-.light-panel {
+.light-panels-sample .light-panel {
 	border: 2px solid white;
 }
 
-.light-panel > * {
+.light-panels-sample .light-panel > * {
 	text-align: center;
 	font-size: 36px;
 	font-weight: bold;
 }
 
-.light-panel > * {
+.light-panels-sample .light-panel > * {
 	position: absolute;
 }
 
 /* horizontal orientation */
-.enyo-light-panels.horizontal .light-panel > * {
+.light-panels-sample .enyo-light-panels.horizontal .light-panel > * {
 	bottom: 50%;
 }
 
-.enyo-light-panels.horizontal .light-panel .label {
+.light-panels-sample .enyo-light-panels.horizontal .light-panel .label {
 	left: 50%;
 }
 
-.enyo-light-panels.horizontal .light-panel .enyo-tool-decorator.previous {
+.light-panels-sample .enyo-light-panels.horizontal .light-panel .enyo-tool-decorator.previous {
 	left: 0;
 }
 
-.enyo-light-panels.horizontal .light-panel .enyo-tool-decorator.next {
+.light-panels-sample .enyo-light-panels.horizontal .light-panel .enyo-tool-decorator.next {
 	right: 0;
 }
 
 /* vertical orientation */
-.enyo-light-panels.vertical .light-panel > * {
+.light-panels-sample .enyo-light-panels.vertical .light-panel > * {
 	left: 50%;
 }
 
-.enyo-light-panels.vertical .light-panel .label {
+.light-panels-sample .enyo-light-panels.vertical .light-panel .label {
 	margin-left: 32px;
 	bottom: 50%;
 }
 
-.enyo-light-panels.vertical .light-panel .enyo-tool-decorator {
+.light-panels-sample .enyo-light-panels.vertical .light-panel .enyo-tool-decorator {
 	position: absolute;
 	left: 50%;
 }
 
-.enyo-light-panels.vertical .light-panel .enyo-tool-decorator.previous {
+.light-panels-sample .enyo-light-panels.vertical .light-panel .enyo-tool-decorator.previous {
 	top: 0;
 }
 
-.enyo-light-panels.vertical .light-panel .enyo-tool-decorator.next {
+.light-panels-sample .enyo-light-panels.vertical .light-panel .enyo-tool-decorator.next {
 	bottom: 0;
 }

--- a/src/enyo-samples/lib/LightPanelsSample/LightPanelsSample.js
+++ b/src/enyo-samples/lib/LightPanelsSample/LightPanelsSample.js
@@ -3,39 +3,101 @@ var
 
 var
 	Button = require('enyo/Button'),
+	Checkbox = require('enyo/Checkbox'),
 	Control = require('enyo/Control'),
 	LightPanels = require('enyo/LightPanels');
 
 module.exports = kind({
 	name: 'enyo.sample.LightPanelsSample',
-	classes: 'light-panels-sample',
+	classes: 'light-panels-sample enyo-unselectable',
 	kind: Control,
 	components: [
-		{kind: LightPanels, name: 'lightHorizontal'},
-		{kind: LightPanels, name: 'lightVertical', orientation: 'vertical'}
+		{classes: 'light-panels-options', components: [
+			{classes: 'horizontal-options', components: [
+				{kind: Checkbox, name: 'cachingHorizontal', content: 'Caching', onchange: ''},
+				{kind: Checkbox, name: 'multipleHorizontal', content: 'Multiple', onchange: ''}
+			]},
+			{classes: 'vertical-options', components: [
+				{kind: Checkbox, name: 'cachingVertical', content: 'Caching', onchange: ''},
+				{kind: Checkbox, name: 'multipleVertical', content: 'Multiple', onchange: ''}
+			]}
+		]},
+		{classes: 'light-panels-set', components: [
+			{kind: LightPanels, name: 'lightHorizontal'},
+			{kind: LightPanels, name: 'lightVertical', orientation: 'vertical'}
+		]}
 	],
-	rendered: function () {
-		this.inherited(arguments);
-		this.pushSinglePanel(this.$.lightHorizontal);
-		this.pushSinglePanel(this.$.lightVertical);
-	},
+	bindings: [
+		{from: '$.cachingHorizontal.checked', to: '$.lightHorizontal.cacheViews'},
+		{from: '$.multipleHorizontal.checked', to: 'multipleHorizontal'},
+		{from: '$.cachingVertical.checked', to: '$.lightVertical.cacheViews'},
+		{from: '$.multipleVertical.checked', to: 'multipleVertical'}
+	],
+	rendered: kind.inherit(function (sup) {
+		return function () {
+			sup.apply(this, arguments);
+			this.pushSinglePanel(this.$.lightHorizontal);
+			this.pushSinglePanel(this.$.lightVertical);
+		};
+	}),
 	pushSinglePanel: function (panels) {
-		panels.pushPanels([{
+		panels.pushPanel({
 			classes: 'light-panel',
+			panelId: 'panel-' + panels.getPanels().length,
 			style: 'background-color: ' + this.bgcolors[Math.floor(Math.random() * this.bgcolors.length)],
 			components: [
 				{content: panels.getPanels().length, classes: 'label'},
 				{content: 'Prev', kind: Button, classes: 'previous', ontap: 'prevTapped'},
 				{content: 'Next', kind: Button, classes: 'next', ontap: 'nextTapped'}
 			]
-		}], {owner: this});
+		}, {owner: this});
+	},
+	pushMultiplePanels: function (panels) {
+		panels.pushPanels([
+			{
+				classes: 'light-panel',
+				panelId: 'panel-' + panels.getPanels().length,
+				style: 'background-color: ' + this.bgcolors[Math.floor(Math.random() * this.bgcolors.length)],
+				components: [
+					{content: panels.getPanels().length, classes: 'label'},
+					{content: 'Prev', kind: Button, classes: 'previous', ontap: 'prevTapped'},
+					{content: 'Next', kind: Button, classes: 'next', ontap: 'nextTapped'}
+				]
+			},
+			{
+				classes: 'light-panel',
+				panelId: 'panel-' + (panels.getPanels().length + 1),
+				style: 'background-color: ' + this.bgcolors[Math.floor(Math.random() * this.bgcolors.length)],
+				components: [
+					{content: panels.getPanels().length + 1, classes: 'label'},
+					{content: 'Prev', kind: Button, classes: 'previous', ontap: 'prevTapped'},
+					{content: 'Next', kind: Button, classes: 'next', ontap: 'nextTapped'}
+				]
+			},
+			{
+				classes: 'light-panel',
+				panelId: 'panel-' + (panels.getPanels().length + 2),
+				style: 'background-color: ' + this.bgcolors[Math.floor(Math.random() * this.bgcolors.length)],
+				components: [
+					{content: panels.getPanels().length + 2, classes: 'label'},
+					{content: 'Prev', kind: Button, classes: 'previous', ontap: 'prevTapped'},
+					{content: 'Next', kind: Button, classes: 'next', ontap: 'nextTapped'}
+				]
+			}
+		], {owner: this});
 	},
 	prevTapped: function (sender, ev) {
-		ev.originator.parent.parent.previous();
+		var panels = ev.originator.parent.parent;
+		panels.previous();
 		return true;
 	},
 	nextTapped: function (sender, ev) {
-		this.pushSinglePanel(ev.originator.parent.parent);
+		var panels = ev.originator.parent.parent;
+		if ((panels.name == 'lightHorizontal' && this.multipleHorizontal) || (panels.name == 'lightVertical' && this.multipleVertical)) {
+			this.pushMultiplePanels(panels);
+		} else {
+			this.pushSinglePanel(panels);
+		}
 		return true;
 	},
 	bgcolors: ['red', 'orange', 'yellow', 'green', 'blue', 'indigo', 'violet']


### PR DESCRIPTION
### Issue

The LightPanels sample was very basic and didn't test many of the LightPanels use cases.
### Fix

The sample has been expanded to test both `pushPanel` and `pushPanels`, as well as testing the case where `cacheViews` is not enabled (for the current use case of LightPanels, this is never disabled).
### Note

This requires some tweaks found in https://github.com/enyojs/enyo/pull/1162 to function properly.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
