### PR TITLE
ENYO-1650: Prevent spotting of menu items when closed

### DIFF
--- a/src/moonstone-samples/lib/All.js
+++ b/src/moonstone-samples/lib/All.js
@@ -110,12 +110,12 @@ module.exports = kind({
 		}
 	},
 	components: [
-		{classes: 'moon-sample-persistant-hotspot', components: [
-			{classes: 'moon-sample-persistant-frame', spotlight: 'container', components: [
-				{kind: Button, content: 'Reload', small: true, spotlight: false, classes: 'moon-sample-persistant-locale-button', ontap: 'reload'},
-				{kind: Button, content: 'Back to List', small: true, spotlight: false, classes: 'moon-sample-persistant-locale-button', ontap: 'backToList'},
+		{classes: 'moon-sample-persistent-hotspot', components: [
+			{classes: 'moon-sample-persistent-frame', spotlight: 'container', components: [
+				{kind: Button, content: 'Reload', small: true, spotlight: false, classes: 'moon-sample-persistent-locale-button', ontap: 'reload'},
+				{kind: Button, content: 'Back to List', small: true, spotlight: false, classes: 'moon-sample-persistent-locale-button', ontap: 'backToList'},
 				{kind: ContextualPopupDecorator, components: [
-					{kind: Button, content: 'Set Locale', small: true, spotlight: false, classes: 'moon-sample-persistant-locale-button'},
+					{kind: Button, content: 'Set Locale', small: true, spotlight: false, classes: 'moon-sample-persistent-locale-button'},
 					{name: 'localePopup', kind: ContextualPopup, classes: 'moon-sample-locale-popup', components: [
 						{content: 'Set Locale', kind: Divider},
 						{name: 'localeRepeater', kind: DataRepeater, ontap: 'localeListTapped', selection: true, groupSelection: true, selectionProperty: 'selected', containerOptions: {kind: Scroller, classes: 'enyo-fill'}, fit: true, components: [
@@ -127,7 +127,7 @@ module.exports = kind({
 						]}
 					]}
 				]},
-				{kind: ToggleButton, toggleOffLabel: 'Dark Theme', toggleOnLabel: 'Light Theme', small: true, ontap: 'handleThemeTap'}
+				{kind: ToggleButton, toggleOffLabel: 'Dark Theme', toggleOnLabel: 'Light Theme', small: true, spotlight: false, ontap: 'handleThemeTap'}
 			]}
 		]},
 		{name: 'home'},

--- a/src/moonstone-samples/lib/All.less
+++ b/src/moonstone-samples/lib/All.less
@@ -1,4 +1,4 @@
-.moon-sample-persistant-hotspot {
+.moon-sample-persistent-hotspot {
 	position: fixed;
 	top: 0;
 	right: 0;
@@ -6,7 +6,7 @@
 	height: 20px;
 	width: 20px;
 }
-.moon-sample-persistant-frame {
+.moon-sample-persistent-frame {
 	position: absolute;
 	top: 0;
 	right: 0;
@@ -18,14 +18,14 @@
 	-webkit-transition: -webkit-transform 0.4s ease;
 	-webkit-transform: translateY(-150%);
 }
-.moon-sample-persistant-hotspot:hover .moon-sample-persistant-frame,
-.moon-sample-persistant-frame:hover {
+.moon-sample-persistent-hotspot:hover .moon-sample-persistent-frame,
+.moon-sample-persistent-frame:hover {
 	-webkit-transform: translateY(0%);
 }
-.moon-sample-persistant-frame .moon-button {
+.moon-sample-persistent-frame .moon-button {
 	margin-bottom: 10px;
 }
-.moon-sample-persistant-frame .moon-button:hover {
+.moon-sample-persistent-frame .moon-button:hover {
 	/* Simulate spotlight for the mouse, even though we've intentionally disabled it */
 	background-color: #cf0652;
 	color: #fff;


### PR DESCRIPTION
### Issue

The theme toggle button can be spotted when the hidden menu is not open, causing some issues when testing 5-way with samples.
### Fix

We set the initial spotlight value to false. Additionally, I made a tweak to correct the names of some of the classes for the menu.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
