### PR TITLE
ENYO-1027: Moon.DatePiker-Reset Date Does not collapse Picker

### DIFF
--- a/src/moonstone-samples/lib/DatePickerSample.js
+++ b/src/moonstone-samples/lib/DatePickerSample.js
@@ -104,6 +104,8 @@ module.exports = kind({
 	},
 	resetTapped: function(inSender, inEvent) {
 		this.$.picker.set('value', null);
+		this.$.picker.refresh();
+		this.$.picker.setOpen(false);
 		return true;
 	}
 });


### PR DESCRIPTION
Issue: on tap of reset date, date picker is not getting collapse and
date is not getting refreshed.

Fix: added required code in the sample.

DCO-1.1-Signed-Off-By: Srinivas V srinivas.v@lge.com
