### PR TITLE
Directly apply the moonstone text color to the list anchors

### DIFF
--- a/src/moonstone-samples/lib/All.less
+++ b/src/moonstone-samples/lib/All.less
@@ -48,4 +48,5 @@
 
 .moon-sample-list-item {
 	text-decoration: none;
+	color: @moon-text-color;
 }

--- a/src/moonstone-samples/package.json
+++ b/src/moonstone-samples/package.json
@@ -3,6 +3,7 @@
 	"libPath": "../../lib",
 	"title": "Moonstone Samples",
 	"styles": [
+		"lib/*.less",
 		"lib/*.css"
 	],
 	"assets": [


### PR DESCRIPTION
...so they aren't blue any more.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
