### PR TITLE
Brought moonstone-extra up to date, moonstone samples comply better…

### DIFF
--- a/css/strawman-main.less
+++ b/css/strawman-main.less
@@ -1,6 +1,8 @@
 @strawman-enyo-blue: #08F;
 
 .strawman {
+	font-family: @moon-body-font-family, Helvetica, sans-serif;
+
 	&.home {
 		padding: 5%;
 		text-align: center;

--- a/moonstone-extra/index.js
+++ b/moonstone-extra/index.js
@@ -1,12 +1,12 @@
 var
-	strawman = require('./src');
-
-var 
 	ready = require('enyo/ready');
 
-ready(function(){
-	var names = window.document.location.search.substring(1).split('&');
-	var name = names[0];
-	var sample = strawman.samples[name] || strawman.List;
-	new sample().renderInto(document.body);
+var
+	strawman = require('./src');
+
+ready(function () {
+	var names = window.document.location.search.substring(1).split('&'),
+		name = names[0],
+		Sample = strawman.samples[name] || strawman.List;
+	new Sample().renderInto(document.body);
 });

--- a/moonstone-extra/src/index.js
+++ b/moonstone-extra/src/index.js
@@ -1,15 +1,16 @@
 var
-	strawman = require('../../src');
+	kind = require('enyo/kind');
 
 var
-	kind = require('enyo/kind');
+	strawman = require('../../src');
 
 var
 	oldSampler = require('../../src/moonstone-samples/lib/All');
 
 var
 	newSampler = kind({
-		kind: oldSampler
+		kind: oldSampler,
+		title: 'Moonstone Extra Samples'
 	});
 
 newSampler.samples = {

--- a/src/index.js
+++ b/src/index.js
@@ -23,13 +23,7 @@ var
 		title: 'Enyo Strawman - Samples Gallery',
 		classes: 'home',
 		listType: 'grid',
-		samples: samples,
-		create: function () {
-			this.inherited(arguments);
-			console.log("strawman grid:", this);
-			this.addClass('enyo-fitted');
-			this.removeClass('enyo-fit');
-		}
+		samples: samples
 	});
 
 History.set('enableBackHistoryAPI', false);

--- a/src/moonstone-samples/lib/All.js
+++ b/src/moonstone-samples/lib/All.js
@@ -92,6 +92,7 @@ var appRouter = kind({
 */
 module.exports = kind({
 	name: 'moon.sample.All',
+	title: 'Moonstone Samples',
 	classes: 'moon enyo-unselectable enyo-fit',
 	themes: {
 		'dark': 'moonstone-dark.css',
@@ -133,11 +134,12 @@ module.exports = kind({
 		{name: 'router', kind: appRouter, history: true, triggerOnStart: true}
 	],
 	bindings: [
-		{from: 'locales', to: '$.localeRepeater.collection'}
+		{from: 'locales', to: '$.localeRepeater.collection'},
+		{from: 'title', to: '$.listpanel.title'}
 	],
 	listTools: [
 		{kind: Panels, pattern: 'activity', classes: 'enyo-fit', components: [
-			{kind: Panel, title: 'Samples', headerType: 'small',
+			{kind: Panel, name: 'listpanel', headerType: 'small',
 				components: [
 					{name: 'list', kind: DataList, components: [
 						{kind: Anchor, classes: 'moon-sample-list-item enyo-border-box', bindings: [
@@ -264,7 +266,7 @@ module.exports = kind({
 			this.$.router.trigger({location: loc, change: true});
 			this.$.home.hide();
 			this.createComponent({name: s, kind: this.samples[s]}).render();
-			console.log('%c Created and Launched Sample', 'color:green;');
+			console.log('%c%s Created and Launched', 'color:green;', s);
 
 		} else {
 			this.createList();
@@ -283,6 +285,8 @@ module.exports = kind({
 			sheets[i].disabled = true;
 		}
 	},
+	// Theme detection and acquisition is not presently working and must be refactored to allow
+	// integration with the modular system, but is left in as a reminder and a starting point.
 	initializeThemes: function () {
 		var i,
 			theme = this.get('theme'),
@@ -311,8 +315,8 @@ module.exports = kind({
 		}
 	},
 	themeChanged: function (oldTheme, newTheme) {
-		this.themeNodeStore[oldTheme].disabled = true;
-		this.themeNodeStore[newTheme].disabled = false;
+		if (this.themeNodeStore[oldTheme]) { this.themeNodeStore[oldTheme].disabled = true; }
+		if (this.themeNodeStore[newTheme]) { this.themeNodeStore[newTheme].disabled = false; }
 	},
 	handleThemeTap: function (sender, ev) {
 		this.set('theme', ev.originator.owner.get('value') ? 'light' : 'dark');

--- a/src/strawman/SampleList/SampleList.js
+++ b/src/strawman/SampleList/SampleList.js
@@ -8,7 +8,6 @@ var
 
 module.exports = kind({
 	title: 'Samples',
-	classes: 'strawman',
 	listComponents: [
 		{name: 'title', kind: Title},
 		{name: 'back', kind: Anchor, classes: 'back-button', content: 'Back', href: './'},
@@ -23,11 +22,11 @@ module.exports = kind({
 
 		// Set whether we're looking at a list of libraries or the root
 		this._libList = !name;
-		// debugger;
 
 		if (this.samples[name]) {
 			this.createComponent({kind: this.samples[name]});
 		} else {
+			this.addClass('strawman');
 			this.createComponents(this.listComponents);
 			this.binding({from: 'title',       to: '$.title.content'});
 			this.binding({from: 'samples',     to: '$.list.samples'});
@@ -36,8 +35,6 @@ module.exports = kind({
 
 			// Don't show back if we're at home.
 			this.$.back.set('showing', !this._libList);
-			// console.log("SampleList:", c, this);
-			// debugger;
 		}
 	}
 });

--- a/src/strawman/SampleList/SampleList.less
+++ b/src/strawman/SampleList/SampleList.less
@@ -1,10 +1,24 @@
 .strawman {
-	// top: 5em;
-	//
+
 	.back-button {
 		position: absolute;
 		top: 0;
 		right: 0;
-		padding: 2em;
+		border-radius: 999px;
+		background-color: @strawman-enyo-blue;
+		margin: 10px;
+		line-height: 3.5em;
+		width: 3.5em;
+		text-align: center;
+		color: white;
+		text-decoration: none;
+		text-transform: lowercase;
+		opacity: 0.6;
+		transition: opacity 0.25s;
+		font-family: @moon-button-font-family;
+
+		&:hover {
+			opacity: 1;
+		}
 	}
 }

--- a/src/strawman/Title/Title.less
+++ b/src/strawman/Title/Title.less
@@ -1,4 +1,4 @@
 .strawman h1 {
 	padding: 0 2em;
-	font-family: Miso, "Miso Bold", "Helvetica Neue Bold", Helvetica, sans-serif;
+	font-family: @moon-header-font-family, "Helvetica Neue Bold", Helvetica, sans-serif;
 }


### PR DESCRIPTION
…with new format, pretty back button, shared fonts and usage, better strawman class-compartmentalization of styles.

Also:
- Addressed (not solved) a bug with throwing an error when attempting to switch themes. It now is at least smart enough to not error, though it doesn't actually _do_ anything. Saved code as an inert placeholder.
- Removed some forgotten devcruft.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
