### PR TITLE
Fixes ENYO-898 - Re-implement moon.Drawer using CSS transform

### DIFF
--- a/src/moonstone-samples/lib/DrawerSample.css
+++ b/src/moonstone-samples/lib/DrawerSample.css
@@ -1,0 +1,3 @@
+.sample-drawers-partial .moon-drawer-partial-client {
+	height: 138px;
+}

--- a/src/moonstone-samples/lib/DrawerSample.js
+++ b/src/moonstone-samples/lib/DrawerSample.js
@@ -20,19 +20,20 @@ module.exports = kind({
 			drawers: [
 				{
 					name: 'partialDrawer',
+					classes: 'sample-drawers-partial',
 					open: false,
 					controlsOpen: false,
 					onActivate: 'partialDrawerChanged',
 					onDeactivate: 'partialDrawerChanged',
 					handle: {name: 'handleButton', content: 'Partial drawer with long text truncation'},
 					components: [
-						{kind: Panel, classes: 'enyo-fit', title: 'Partial Drawer', components: [
+						{name: 'partialPanel', kind: Panel, classes: 'enyo-fit', renderOnShow: true, showing: false, title: 'Partial Drawer', components: [
 							{kind: Item, content: 'Item One'},
 							{kind: Item, content: 'Item Two'}
 						]}
 					],
 					controlDrawerComponents: [
-						{classes: 'moon-hspacing', components: [
+						{name: 'partialControls', renderOnShow: true, showing: false, classes: 'moon-hspacing', components: [
 							{kind: Button, name: 'openMoreButton', content: 'Open More', ontap: 'openMainDrawer'},
 							{kind: Button, content: 'Close', ontap: 'close'}
 						]}
@@ -117,17 +118,28 @@ module.exports = kind({
 		return true;
 	},
 	openMainDrawer: function () {
-		this.$.partialDrawer.setOpen(true);
+		this.$.partialDrawer.set('open', true);
 	},
 	close: function () {
-		if (this.$.partialDrawer.getOpen()) {
-			this.$.partialDrawer.setOpen(false);
+		if (this.$.partialDrawer.get('open')) {
+			this.$.partialDrawer.set('open', false);
 		} else {
-			this.$.partialDrawer.setControlsOpen(false);
+			this.$.partialDrawer.set('controlsOpen', false);
 		}
 	},
 	partialDrawerChanged: function () {
-		this.$.openMoreButton.setShowing(!this.$.partialDrawer.getOpen());
+		var open = this.$.partialDrawer.get('open'),
+			controlsOpen = this.$.partialDrawer.get('controlsOpen');
+
+		// This sample defers the rendering of partial drawer components to illustrate that feature.
+		// Explicitly show drawer controls to render it the first time. For the drawers to function
+		// correctly, the height of the control drawer has to be set via CSS. In this sample, that
+		// has been done via the moon-partial-drawer-client class. The height of the drawer content
+		// need not be explicitly set as it will fill the remaining space.
+		if (open || controlsOpen) this.$.partialControls.show();
+		if (open) this.$.partialPanel.show();
+
+		this.$.openMoreButton.set('showing', !open);
 	},
 	pickerChangedImg:function (sender, event){
 		this.$.drawers.set('src', event.selected.value);


### PR DESCRIPTION
## Issue

Animation logic was spread between Drawers and Drawer with reliance on
enyo/Drawer's implementation.
## Fix

Incorporate @KunmyonChoi's changes to use CSS transforms and refactor things a bit. Due to the need to coordinate the animation of a drawer and the client area of Drawers, we've tightly coupled the two controls and therefore made Drawer a private kind.
## Notes

For strawman, updated getters/setters to use new methods and added `renderOnShow` example code.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
