### PR TITLE
ENYO-1027: Moon.DatePiker-Reset Date Does not collapse Picker

### DIFF
--- a/src/moonstone-samples/lib/DatePickerSample.js
+++ b/src/moonstone-samples/lib/DatePickerSample.js
@@ -104,7 +104,7 @@ module.exports = kind({
 	},
 	resetTapped: function(inSender, inEvent) {
 		this.$.picker.set('value', null);
-		this.$.picer.set('open', false);
+		this.$.picker.set('open', false);
 		return true;
 	}
 });

--- a/src/moonstone-samples/lib/DatePickerSample.js
+++ b/src/moonstone-samples/lib/DatePickerSample.js
@@ -104,6 +104,7 @@ module.exports = kind({
 	},
 	resetTapped: function(inSender, inEvent) {
 		this.$.picker.set('value', null);
+		this.$.picer.set('open', false);
 		return true;
 	}
 });


### PR DESCRIPTION
Updated PR as per comments.

Enyo-DCO-1.1-Signed-off-by: Srinivas V srinivas.v@lge.com
