### PR TITLE
Enyo-1709 Update samples based on ExpandableItem's update.

### DIFF
--- a/src/moonstone-samples/lib/AccordionSample.js
+++ b/src/moonstone-samples/lib/AccordionSample.js
@@ -6,6 +6,7 @@ var
 	Scroller = require('moonstone/Scroller'),
 	Divider = require('moonstone/Divider'),
 	Accordion = require('moonstone/Accordion'),
+	Item = require('moonstone/Item'),
 	SelectableItem = require('moonstone/SelectableItem');
 
 module.exports = kind({
@@ -16,40 +17,40 @@ module.exports = kind({
 			{kind: Divider, content: 'Not In Group'},
 			{components: [
 				{kind: Accordion, content: 'This is an accordion', components: [
-					{content: 'Item One'},
-					{content: 'Item Two'}
+					{kind: Item, content: 'Item One'},
+					{kind: Item, content: 'Item Two'}
 				]},
 				{kind: Accordion, content: 'Pre-expanded accordion', open:true, components: [
-					{content: 'Item Three'},
-					{content: 'Item Four'}
+					{kind: Item, content: 'Item Three'},
+					{kind: Item, content: 'Item Four'}
 				]},
 				{kind: Accordion, content: 'This is an lonnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnng title accordion', components: [
-					{content: 'Looooooooooooooooooooooooooooooooooooong Item One'},
-					{content: 'Loooooooooooooooooooooooooooooong Item Two'}
+					{kind: Item, content: 'Looooooooooooooooooooooooooooooooooooong Item One'},
+					{kind: Item, content: 'Loooooooooooooooooooooooooooooong Item Two'}
 				]},
 				{kind: Accordion, content: 'Disabled accordion', disabled: true, components: [
-					{content: 'Item One'},
-					{content: 'Item Two'}
+					{kind: Item, content: 'Item One'},
+					{kind: Item, content: 'Item Two'}
 				]}
 			]},
 			{classes: 'moon-1v'},
 			{kind: Divider, content: 'In Group'},
 			{kind: Group, highlander:true, components: [
 				{kind: Accordion, content: 'This is a grouped accordion', components: [
-					{content: 'Item One'},
-					{content: 'Item Two'}
+					{kind: Item, content: 'Item One'},
+					{kind: Item, content: 'Item Two'}
 				]},
 				{kind: Accordion, open:true, content: 'This is another grouped accordion', components: [
-					{content: 'Item Three'},
-					{content: 'Item Four'}
+					{kind: Item, content: 'Item Three'},
+					{kind: Item, content: 'Item Four'}
 				]},
 				{kind: Accordion, content: 'This is another grouped accordion', components: [
-					{content: 'Item Five'},
-					{content: 'Item Six'}
+					{kind: Item, content: 'Item Five'},
+					{kind: Item, content: 'Item Six'}
 				]},
 				{kind: Accordion, content: 'This is another lonnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnng title accordion', components: [
-					{content: 'Looooooooooooooooooooooooooooooooooooong Item Three'},
-					{content: 'Loooooooooooooooooooooooooooooong Item Four'}
+					{kind: Item, content: 'Looooooooooooooooooooooooooooooooooooong Item Three'},
+					{kind: Item, content: 'Loooooooooooooooooooooooooooooong Item Four'}
 				]}
 			]},
 			{classes: 'moon-1v'},
@@ -57,20 +58,20 @@ module.exports = kind({
 			{kind: Group, groupName: 'menuItems', components: [
 				{kind: Group, groupName: 'accordions', highlander:true, components: [
 					{kind: Accordion, groupName: 'accordions', content: 'This is a grouped accordion', defaultKind: SelectableItem, components: [
-						{content: 'Item One', groupName: 'menuItems'},
-						{content: 'Item Two', groupName: 'menuItems'}
+						{kind: Item, content: 'Item One', groupName: 'menuItems'},
+						{kind: Item, content: 'Item Two', groupName: 'menuItems'}
 					]},
 					{kind: Accordion, groupName: 'accordions', open:true, content: 'This is another grouped accordion', defaultKind: SelectableItem, components: [
-						{content: 'Item Three', groupName: 'menuItems'},
-						{content: 'Item Four', groupName: 'menuItems'}
+						{kind: Item, content: 'Item Three', groupName: 'menuItems'},
+						{kind: Item, content: 'Item Four', groupName: 'menuItems'}
 					]},
 					{kind: Accordion, groupName: 'accordions', content: 'This is another grouped accordion', defaultKind: SelectableItem, components: [
-						{content: 'Item Five', groupName: 'menuItems'},
-						{content: 'Item Six', groupName: 'menuItems'}
+						{kind: Item, content: 'Item Five', groupName: 'menuItems'},
+						{kind: Item, content: 'Item Six', groupName: 'menuItems'}
 					]},
 					{kind: Accordion, groupName: 'accordions', content: 'This is another lonnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnng title accordion', defaultKind: SelectableItem, components: [
-						{content: 'Looooooooooooooooooooooooooooooooooooong Item Three', groupName: 'menuItems'},
-						{content: 'Loooooooooooooooooooooooooooooong Item Four', groupName: 'menuItems'}
+						{kind: Item, content: 'Looooooooooooooooooooooooooooooooooooong Item Three', groupName: 'menuItems'},
+						{kind: Item, content: 'Loooooooooooooooooooooooooooooong Item Four', groupName: 'menuItems'}
 					]}
 				]}
 			]}

--- a/src/moonstone-samples/lib/ExpandableListItemSample.js
+++ b/src/moonstone-samples/lib/ExpandableListItemSample.js
@@ -9,6 +9,7 @@ var
 	BodyText = require('moonstone/BodyText'),
 	Divider = require('moonstone/Divider'),
 	ExpandableListItem = require('moonstone/ExpandableListItem'),
+	Item = require('moonstone/Item'),
 	Scroller = require('moonstone/Scroller');
 
 module.exports = kind({
@@ -22,47 +23,47 @@ module.exports = kind({
 		{kind: Scroller, horizontal: 'hidden', fit: true, components: [
 			{classes: 'moon-5h', components: [
 				{kind: ExpandableListItem, content: 'Expandable ListItem', components: [
-					{content: 'Item 1'},
-					{content: 'Item 2'},
-					{content: 'Item 3'}
+					{kind: Item, content: 'Item 1'},
+					{kind: Item, content: 'Item 2'},
+					{kind: Item, content: 'Item 3'}
 				]},
 				{kind: ExpandableListItem, disabled:true, content: 'Disabled ListItem', components: [
-					{content: 'Item 1'},
-					{content: 'Item 2'},
-					{content: 'Item 3'}
+					{kind: Item, content: 'Item 1'},
+					{kind: Item, content: 'Item 2'},
+					{kind: Item, content: 'Item 3'}
 				]},
 				{kind: ExpandableListItem, content: 'Pre-expanded ListItem', open: true, components: [
-					{content: 'Item 1'},
-					{content: 'Item 2'},
-					{content: 'Item 3'}
+					{kind: Item, content: 'Item 1'},
+					{kind: Item, content: 'Item 2'},
+					{kind: Item, content: 'Item 3'}
 				]},
 				{kind: ExpandableListItem, content: 'Bottom-locking', lockBottom: true, open: true, components: [
-					{content: 'Item 1'},
-					{content: 'Item 2'},
-					{content: 'Item 3'}
+					{kind: Item, content: 'Item 1'},
+					{kind: Item, content: 'Item 2'},
+					{kind: Item, content: 'Item 3'}
 				]},
 				{kind: ExpandableListItem, content: 'Auto-collapsing', autoCollapse: true, components: [
-					{content: 'Item 1'},
-					{content: 'Item 2'},
-					{content: 'Item 3'}
+					{kind: Item, content: 'Item 1'},
+					{kind: Item, content: 'Item 2'},
+					{kind: Item, content: 'Item 3'}
 				]},
 				{kind: Group, highlander: true, components: [
 					{kind: ExpandableListItem,  open: true,
 						content: 'This is a grouped ExpandableListItem', components: [
-							{content: 'Item One'},
-							{content: 'Item Two'}
+							{kind: Item, content: 'Item One'},
+							{kind: Item, content: 'Item Two'}
 						]
 					},
 					{kind: ExpandableListItem,
 						content: 'This is another grouped ExpandableListItem', components: [
-							{content: 'Item Three'},
-							{content: 'Item Four'}
+							{kind: Item, content: 'Item Three'},
+							{kind: Item, content: 'Item Four'}
 						]
 					},
 					{kind: ExpandableListItem,
 						content: 'This is yet another grouped ExpandableListItem', components: [
-							{content: 'Item Five'},
-							{content: 'Item Six'}
+							{kind: Item, content: 'Item Five'},
+							{kind: Item, content: 'Item Six'}
 						]
 					}
 				]}

--- a/src/moonstone-samples/lib/ScrollerVerticalSample.js
+++ b/src/moonstone-samples/lib/ScrollerVerticalSample.js
@@ -84,16 +84,16 @@ module.exports = kind({
 						{kind: Input, placeholder: 'Input'}
 					]},
 					{kind: Accordion, content: 'Accordion 1', defaultKind: SelectableItem, components: [
-						{content: 'Item One'},
-						{content: 'Item Two'}
+						{kind: Item, content: 'Item One'},
+						{kind: Item, content: 'Item Two'}
 					]},
 					{kind: Accordion, content: 'Accordion 2', defaultKind: SelectableItem, components: [
-						{content: 'Item Three'},
-						{content: 'Item Four'}
+						{kind: Item, content: 'Item Three'},
+						{kind: Item, content: 'Item Four'}
 					]},
 					{kind: Accordion, content: 'Accordion 3', defaultKind: SelectableItem, components: [
-						{content: 'Item Five'},
-						{content: 'Item Six'}
+						{kind: Item, content: 'Item Five'},
+						{kind: Item, content: 'Item Six'}
 					]},
 					{kind: Item, content: 'Item 1'},
 					{kind: Item, content: 'Item 2'},
@@ -133,16 +133,16 @@ module.exports = kind({
 					{kind: DatePicker, noneText: 'Pick a Date', content: 'Date Picker'},
 					{kind: TimePicker, noneText: 'Pick a Time', content: 'Time Picker'},
 					{kind: Accordion, content: 'Accordion 1', components: [
-						{content: 'Item One'},
-						{content: 'Item Two'}
+						{kind: Item, content: 'Item One'},
+						{kind: Item, content: 'Item Two'}
 					]},
 					{kind: Accordion, content: 'Accordion 2', components: [
-						{content: 'Item Three'},
-						{content: 'Item Four'}
+						{kind: Item, content: 'Item Three'},
+						{kind: Item, content: 'Item Four'}
 					]},
 					{kind: Accordion, content: 'Accordion 3', components: [
-						{content: 'Item Five'},
-						{content: 'Item Six'}
+						{kind: Item, content: 'Item Five'},
+						{kind: Item, content: 'Item Six'}
 					]}
 				]}
 			]}


### PR DESCRIPTION
moon.ExpandableListItem does not use `defaultKind` anymore.
So, we should update our sample which utilize that feature.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
