### PR TITLE
ENYO-1880: Add animate property to sample.

### DIFF
--- a/src/enyo-samples/lib/LightPanelsSample/LightPanelsSample.css
+++ b/src/enyo-samples/lib/LightPanelsSample/LightPanelsSample.css
@@ -6,6 +6,7 @@
 	background-color: white;
 	border-radius: 0 0 100px 100px;
 	z-index: 1;
+	font-size: 16px;
 }
 
 .light-panels-sample .vertical-options, .light-panels-sample .horizontal-options {

--- a/src/enyo-samples/lib/LightPanelsSample/LightPanelsSample.js
+++ b/src/enyo-samples/lib/LightPanelsSample/LightPanelsSample.js
@@ -14,12 +14,14 @@ module.exports = kind({
 	components: [
 		{classes: 'light-panels-options', components: [
 			{classes: 'horizontal-options', components: [
-				{kind: Checkbox, name: 'cachingHorizontal', content: 'Caching', onchange: ''},
-				{kind: Checkbox, name: 'multipleHorizontal', content: 'Multiple', onchange: ''}
+				{kind: Checkbox, name: 'cachingHorizontal', content: 'Cache'},
+				{kind: Checkbox, name: 'multipleHorizontal', content: 'Multi'},
+				{kind: Checkbox, name: 'animateHorizontal', content: 'Animate'}
 			]},
 			{classes: 'vertical-options', components: [
-				{kind: Checkbox, name: 'cachingVertical', content: 'Caching', onchange: ''},
-				{kind: Checkbox, name: 'multipleVertical', content: 'Multiple', onchange: ''}
+				{kind: Checkbox, name: 'cachingVertical', content: 'Cache'},
+				{kind: Checkbox, name: 'multipleVertical', content: 'Multi'},
+				{kind: Checkbox, name: 'animateVertical', content: 'Animate'}
 			]}
 		]},
 		{classes: 'light-panels-set', components: [
@@ -30,8 +32,10 @@ module.exports = kind({
 	bindings: [
 		{from: '$.cachingHorizontal.checked', to: '$.lightHorizontal.cacheViews'},
 		{from: '$.multipleHorizontal.checked', to: 'multipleHorizontal'},
+		{from: '$.animateHorizontal.checked', to: '$.lightHorizontal.animate'},
 		{from: '$.cachingVertical.checked', to: '$.lightVertical.cacheViews'},
-		{from: '$.multipleVertical.checked', to: 'multipleVertical'}
+		{from: '$.multipleVertical.checked', to: 'multipleVertical'},
+		{from: '$.animateVertical.checked', to: '$.lightVertical.animate'}
 	],
 	rendered: kind.inherit(function (sup) {
 		return function () {

--- a/src/moonstone-samples/index.js
+++ b/src/moonstone-samples/index.js
@@ -41,6 +41,7 @@ var
 		ItemSample							: require('./lib/ItemSample'),
 		ItemOverlaySample					: require('./lib/ItemOverlaySample'),
 		LabeledTextItemSample				: require('./lib/LabeledTextItemSample'),
+		LightPanelsSample					: require('./lib/LightPanelsSample'),
 		ListActionsSample					: require('./lib/ListActionsSample'),
 		MarqueeSample						: require('./lib/MarqueeSample'),
 		NewDataListSample					: require('./lib/NewDataListSample'),

--- a/src/moonstone-samples/lib/LightPanelsSample.js
+++ b/src/moonstone-samples/lib/LightPanelsSample.js
@@ -1,0 +1,73 @@
+var
+	kind = require('enyo/kind'),
+	Control = require('enyo/Control');
+
+var
+	Button = require('moonstone/Button'),
+	Item = require('moonstone/Item'),
+	LightPanels = require('moonstone/LightPanels'),
+	Scroller = require('moonstone/Scroller');
+
+module.exports = kind({
+	name: 'moon.sample.LightPanelsSample',
+	classes: 'moon enyo-fit enyo-unselectable moon-light-panels-sample',
+	kind: Control,
+	components: [
+		{kind: LightPanels, name: 'panels'}
+	],
+	rendered: kind.inherit(function (sup) {
+		return function () {
+			sup.apply(this, arguments);
+			this.pushSinglePanel(true);
+		};
+	}),
+	pushSinglePanel: function (direct) {
+		var panels = this.$.panels,
+			id = panels.getPanels().length;
+
+		panels.pushPanel({
+			classes: 'light-panel',
+			panelId: 'panel-' + id,
+			title: 'Panel ' + id,
+			headerComponents: [
+				{
+					kind: Button,
+					content: 'Back',
+					small: true,
+					ontap: 'prevTapped'
+				}
+			],
+			clientComponents: [
+				{kind: Scroller, style: 'height:800px', components: [
+					{kind: Item, content: 'Item One', ontap: 'nextTapped'},
+					{kind: Item, content: 'Item Two', ontap: 'nextTapped'},
+					{kind: Item, content: 'Item Three', ontap: 'nextTapped'},
+					{kind: Item, content: 'Item Four', ontap: 'nextTapped'},
+					{kind: Item, content: 'Item Five', ontap: 'nextTapped'},
+					{kind: Item, content: 'Item Six', ontap: 'nextTapped'},
+					{kind: Item, content: 'Item Seven', ontap: 'nextTapped'},
+					{kind: Item, content: 'Item Eight', ontap: 'nextTapped'},
+					{kind: Item, content: 'Item Nine', ontap: 'nextTapped'},
+					{kind: Item, content: 'Item Eleven', ontap: 'nextTapped'},
+					{kind: Item, content: 'Item Twelve', ontap: 'nextTapped'},
+					{kind: Item, content: 'Item Thirteen', ontap: 'nextTapped'},
+					{kind: Item, content: 'Item Fourteen', ontap: 'nextTapped'},
+					{kind: Item, content: 'Item Fifteen', ontap: 'nextTapped'},
+					{kind: Item, content: 'Item Sixteen', ontap: 'nextTapped'},
+					{kind: Item, content: 'Item Seventeen', ontap: 'nextTapped'},
+					{kind: Item, content: 'Item Eighteen', ontap: 'nextTapped'},
+					{kind: Item, content: 'Item Nineteen', ontap: 'nextTapped'},
+					{kind: Item, content: 'Item Twenty', ontap: 'nextTapped'}
+				]}
+			]
+		}, {owner: this}, {direct: direct});
+	},
+	prevTapped: function (sender, ev) {
+		this.$.panels.previous();
+		return true;
+	},
+	nextTapped: function (sender, ev) {
+		this.pushSinglePanel();
+		return true;
+	}
+});


### PR DESCRIPTION
### Issue

We need a way to test whether or not the `animate` property is behaving properly in `LightPanels`. This will also test some new functions such as `animateTo`.
### Fix

The sample has been updated with the ability to toggle an `animate` property. This change is depedendent on https://github.com/enyojs/enyo/pull/1216.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
