### PR TITLE
ENYO-1981: Update sample to utilize enumeration.

### DIFF
--- a/src/enyo-samples/lib/LightPanelsSample/LightPanelsSample.js
+++ b/src/enyo-samples/lib/LightPanelsSample/LightPanelsSample.js
@@ -5,7 +5,8 @@ var
 	Button = require('enyo/Button'),
 	Checkbox = require('enyo/Checkbox'),
 	Control = require('enyo/Control'),
-	LightPanels = require('enyo/LightPanels');
+	LightPanels = require('enyo/LightPanels'),
+	Orientation = LightPanels.Orientation;
 
 module.exports = kind({
 	name: 'enyo.sample.LightPanelsSample',
@@ -24,7 +25,7 @@ module.exports = kind({
 		]},
 		{classes: 'light-panels-set', components: [
 			{kind: LightPanels, name: 'lightHorizontal'},
-			{kind: LightPanels, name: 'lightVertical', orientation: 'vertical'}
+			{kind: LightPanels, name: 'lightVertical', orientation: Orientation.VERTICAL}
 		]}
 	],
 	bindings: [


### PR DESCRIPTION
### Issue

Based on changes in https://github.com/enyojs/enyo/pull/1222, we are using enumerations for certain properties that should signify a specific, internal value.
### Fix

The sample has been updated to properly specify the desired property value.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
