### PR TITLE
ENYO-2017 : add accessibilitySample in enyo-strawman/moonstone-samples

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+require('enyo/options').accessibility = true;
+
 var
 	ready = require('enyo/ready');
 

--- a/src/moonstone-samples/index.js
+++ b/src/moonstone-samples/index.js
@@ -1,6 +1,7 @@
 var
 	Sampler = require('./lib/All'),
 	samples = {
+		AccessibilitySample					: require('./lib/AccessibilitySample'),
 		AccordionSample						: require('./lib/AccordionSample'),
 		ActivityPanelsSample				: require('./lib/ActivityPanelsSample'),
 		ActivityPanelsWithVideoSample		: require('./lib/ActivityPanelsWithVideoSample'),

--- a/src/moonstone-samples/lib/AccessibilitySample.js
+++ b/src/moonstone-samples/lib/AccessibilitySample.js
@@ -1,0 +1,80 @@
+var
+	kind = require('enyo/kind'),
+	Control = require('enyo/Control');
+
+var
+	FittableRows = require('layout/FittableRows');
+
+var
+	BodyText = require('moonstone/BodyText'),
+	Divider = require('moonstone/Divider'),
+	Icon = require('moonstone/Icon'),
+	Item = require('moonstone/Item'),
+	Button = require('moonstone/Button'),
+	Header = require('moonstone/Header'),
+	ToggleButton = require('moonstone/ToggleButton'),
+	IconButton = require('moonstone/IconButton'),
+	Scroller = require('moonstone/Scroller');
+
+module.exports = kind({
+	name: 'moon.sample.AccessibilitySample',
+	kind: FittableRows,
+	classes: 'moon enyo-unselectable enyo-fit',
+	labelText : 'Label',
+	hintText : 'Hint',
+	components: [
+		{kind: Header, name: 'header', content: 'Accessibility', type: 'small', components: [
+			{name: 'labelButton', kind: Button, small: true, minWidth: false, content: 'Set Label', ontap: 'labelButtonTapped'},
+			{name: 'hintButton', kind: Button, small: true, minWidth: false, content: 'Set Hint', ontap: 'hintButtonTapped'},
+			{name: 'toggle', kind: ToggleButton, small: true, toggleOnLabel: 'disabled is on', toggleOffLabel: 'disabled is off', ontap: 'disabledTapped'},
+			{name: 'reload', kind: Button, small: true, content: 'Reload', ontap: 'reload'}
+		]},
+		{name: 'container', kind: Scroller, fit: true, components: [
+			{classes: 'moon-1v'},
+			{kind: Divider, content: 'Icons: '},
+			{kind: Icon, icon: 'play', small: false, ontap: 'buttonTapped', accessibilityLabel: 'play'},
+			{kind: Icon, src: '@../assets/icon-list.png', ontap: 'buttonTapped', accessibilityLabel: 'icon List'},
+			{kind: Item, classes: 'moon-hspacing', ontap: 'buttonTapped', accessibilityLabel: 'selectable icon List', components: [
+				{content: 'Selectable Item', accessibilityDisabled: true},
+				{kind: Icon, src: '@../assets/icon-list.png', ontap: 'buttonTapped'}
+			]},
+			{kind: Control, tag: 'br'},
+			{classes: 'moon-1v'},
+			{kind: Divider, content: 'Icon Buttons: '},
+			{kind: IconButton, icon: 'drawer', small: false, ontap: 'buttonTapped', accessibilityLabel: 'drawer'},
+			{kind: IconButton, src: '@../assets/icon-list.png', small: false, ontap: 'buttonTapped', accessibilityLabel: 'icon List'}
+		]},
+		{kind: Divider, content: 'Result'},
+		{kind: BodyText, name: 'console', content: 'No changes yet'}
+	],
+	buttonTapped: function (sender, event) {
+		this.$.console.setContent(sender.get('accessibilityDisabled') ? 'accessibility disabled' : sender.getAttribute('aria-label') +' tapped.');
+	},
+	labelButtonTapped: function (sender, event) {
+		this.$.header.setTitleBelow('Set all control\'s accessibilityLabel to \'Label\'');
+		var i,
+			control = Object.keys(this.$);
+		for (i = 0; i < control.length; ++i) {
+			this.$[control[i]].set('accessibilityLabel', this.labelText);
+		}
+	},
+	hintButtonTapped: function (sender, event) {
+		this.$.header.setTitleBelow('Set all control\'s accessibilityHint to \'Hint\'');
+		var i,
+			control = Object.keys(this.$);
+		for (i = 0; i < control.length; ++i) {
+			this.$[control[i]].set('accessibilityHint', this.hintText);
+		}
+	},
+	disabledTapped: function (sender, event) {
+		this.$.header.setTitleBelow('Set all control\'s accessibilityDisabled to ' + sender.value);
+		var i,
+			control = Object.keys(this.$);
+		for (i = 0; i < control.length; ++i) {
+			this.$[control[i]].set('accessibilityDisabled', sender.value ? true : false);
+		}
+	},
+	reload: function (sender, event) {
+		window.location.reload();
+	}
+});


### PR DESCRIPTION
## Issue

Almost all component samples can support accessibility feature but in some components as Icon or IconButton, we need to add accessibility api for supporting accessibility.
## Cause

By default, Accessibility feature works well when component is focused and has content in dom node. However, moonstone Icon has not spotlight focus and content, so screen reader can not read anything. In this case, If developer adds described message to Icon using accessibilityLabel or accessibilityHint API, screen reader can read it. Thus it is necessary that developers can reference accessibility sample
## Fix

add accessibilitySample to moonstone samples

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com
