### PR TITLE
Fixes ENYO-2037

### DIFF
--- a/src/moonstone-samples/lib/OverlaySample.css
+++ b/src/moonstone-samples/lib/OverlaySample.css
@@ -1,7 +1,7 @@
 .samples-moon-overlay {
 	.moon-gridlist-imageitem {
-		height: 400px;
-		width: 300px;
+		height: 408px;
+		width: 312px;
 		margin: 10px;
 		position: relative;
 


### PR DESCRIPTION
## Issue

Regression from ENYO-1886 which correctly added box-sizing: border-box to enyo/GridListImageItem but the fixed dimensions in this sample didn't account for that CSS rule.
## Fix

Adjust the dimensions of the GridListImageItems

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
