### PR TITLE
ENYO-2069: Enable accessibility option for moonstone-extra builds.

### DIFF
--- a/moonstone-extra/index.js
+++ b/moonstone-extra/index.js
@@ -1,3 +1,5 @@
+require('enyo/options').accessibility = true;
+
 var
 	ready = require('enyo/ready');
 


### PR DESCRIPTION
### Issue

We were only enabling the accessibility option for standard `strawman` builds, and not builds with `moonstone-extra`.
### Fix

We have added the setting of the option for `moonstone-extra` in `strawman`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
