### PR TITLE
ENYO-2040: Added a back button to the Moonstone lists for easier TV-navigation

### DIFF
--- a/src/moonstone-samples/lib/All.js
+++ b/src/moonstone-samples/lib/All.js
@@ -140,6 +140,9 @@ module.exports = kind({
 	listTools: [
 		{kind: Panels, pattern: 'activity', classes: 'enyo-fit', components: [
 			{kind: Panel, name: 'listpanel', headerType: 'small',
+				headerComponents: [
+					{kind: Button, content: 'Back', small: true, href: './', ontap: 'handleLink'}
+				],
 				components: [
 					{name: 'list', kind: DataList, components: [
 						{kind: Anchor, classes: 'moon-sample-list-item enyo-border-box', bindings: [
@@ -247,6 +250,12 @@ module.exports = kind({
 	},
 	reload: function () {
 		window.location.reload();
+	},
+	handleLink: function (sender, ev) {
+		var link = ev.originator.get('href') || ev.originator.parent.get('href');
+		if (link) {
+			window.location.href = link;
+		}
 	},
 	chooseSample: function (sender, ev) {
 		this.set('sample', ev.model.get('name'));


### PR DESCRIPTION
Added a method to handle `href` properties as a click-handler.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
