### PR TITLE
ENYO-1949 - enyo2Sampler Crashes when playing audio sample

### DIFF
--- a/src/enyo-samples/lib/AudioSample/AudioSample.js
+++ b/src/enyo-samples/lib/AudioSample/AudioSample.js
@@ -42,10 +42,10 @@ module.exports = kind({
 		{kind: Popup, name: "popupStatus", floating: true, centered: true, classes: "popup"}
 	],
 	sounds: [
-		"http://www.noiseaddicts.com/samples/3828.mp3",
-		"http://www.noiseaddicts.com/samples/2514.mp3",
-		"http://www.noiseaddicts.com/samples/4353.mp3",
-		"http://www.noiseaddicts.com/samples/134.mp3"
+		"http://www.noiseaddicts.com/samples_1w72b820/3828.mp3",
+		"http://www.noiseaddicts.com/samples_1w72b820/2514.mp3",
+		"http://www.noiseaddicts.com/samples_1w72b820/4353.mp3",
+		"http://www.noiseaddicts.com/samples_1w72b820/134.mp3"
 	],
 	rendered: function() {
 		this.inherited(arguments);


### PR DESCRIPTION
Issue. 

The audio player crashes when trying to play an audio sample.

Solution. 

The audio file source locations have changed, updated the source locations.

Enyo-DCO-1.1-Signed-off-by: Derek Anderson derek.anderson@lge.com
