### PR TITLE
GARNET: Used history.go instead of location.href

### DIFF
--- a/garnet/src/ArcSample.js
+++ b/garnet/src/ArcSample.js
@@ -48,7 +48,7 @@ module.exports = kind({
 		{kind: "g.sample.ArcPanel"}
 	],
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	}
 });

--- a/garnet/src/ButtonSample.js
+++ b/garnet/src/ButtonSample.js
@@ -55,7 +55,7 @@ module.exports = kind({
 		this.$.result.setContent(inEvent.msg);
 	},
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	}
 });

--- a/garnet/src/CheckboxSample.js
+++ b/garnet/src/CheckboxSample.js
@@ -64,7 +64,7 @@ module.exports = kind({
 		this.$.result.setContent(inEvent.msg);
 	},
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	}
 });

--- a/garnet/src/CommandBarSample.js
+++ b/garnet/src/CommandBarSample.js
@@ -137,7 +137,7 @@ module.exports = kind({
 		this.$.result.setContent(inEvent.msg);
 	},
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	}
 });

--- a/garnet/src/ConfirmPopupSample.js
+++ b/garnet/src/ConfirmPopupSample.js
@@ -160,7 +160,7 @@ module.exports = kind({
 		this.$.result.setContent(inEvent.msg);
 	},
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	}
 });

--- a/garnet/src/DataGridListSample.js
+++ b/garnet/src/DataGridListSample.js
@@ -211,7 +211,7 @@ module.exports = kind({
 		return records;
 	},
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	}
 });

--- a/garnet/src/DataGridListwithCardsSample.js
+++ b/garnet/src/DataGridListwithCardsSample.js
@@ -177,7 +177,7 @@ module.exports = kind({
 		return records;
 	},
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	}
 });

--- a/garnet/src/DataIndexListSample.js
+++ b/garnet/src/DataIndexListSample.js
@@ -98,7 +98,7 @@ module.exports = kind({
 		};
 	}),
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	},
 	data: [

--- a/garnet/src/DataListSample.js
+++ b/garnet/src/DataListSample.js
@@ -138,7 +138,7 @@ module.exports = kind({
 		};
 	}),
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	},
 	data: [

--- a/garnet/src/DataListwithCardsSample.js
+++ b/garnet/src/DataListwithCardsSample.js
@@ -95,7 +95,7 @@ module.exports = kind({
 		};
 	}),
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	},
 	data: [

--- a/garnet/src/DataListwithCheckboxesSample.js
+++ b/garnet/src/DataListwithCheckboxesSample.js
@@ -149,7 +149,7 @@ module.exports = kind({
 		this.$.result.setContent(inEvent.msg);
 	},
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	},
 	data: [

--- a/garnet/src/DataListwithIconBadgeSample.js
+++ b/garnet/src/DataListwithIconBadgeSample.js
@@ -102,7 +102,7 @@ module.exports = kind({
 		};
 	}),
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	},
 	data: [

--- a/garnet/src/DataListwithRadioButtonsSample.js
+++ b/garnet/src/DataListwithRadioButtonsSample.js
@@ -139,7 +139,7 @@ module.exports = kind({
 		this.$.result.setContent(inEvent.msg);
 	},
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	},
 	data: [

--- a/garnet/src/DatePickerPanelSample.js
+++ b/garnet/src/DatePickerPanelSample.js
@@ -45,7 +45,7 @@ module.exports = kind({
 		this.$.result.setContent(inEvent.msg);
 	},
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	}
 });

--- a/garnet/src/FormSample.js
+++ b/garnet/src/FormSample.js
@@ -505,7 +505,7 @@ module.exports = kind({
 		this.$.result.setContent(inEvent.msg);
 	},
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	}
 });

--- a/garnet/src/IconButtonSample.js
+++ b/garnet/src/IconButtonSample.js
@@ -64,7 +64,7 @@ module.exports = kind({
 		this.$.result.setContent(inEvent.msg);
 	},
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	}
 });

--- a/garnet/src/IconMenuPopupSample.js
+++ b/garnet/src/IconMenuPopupSample.js
@@ -115,7 +115,7 @@ module.exports = kind({
 		this.$.result.setContent(inEvent.msg);
 	},
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	}
 });

--- a/garnet/src/IconSample.js
+++ b/garnet/src/IconSample.js
@@ -39,7 +39,7 @@ module.exports = kind({
 		{kind: "g.sample.IconPanel", style: "position: relative;"}
 	],
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	}
 });

--- a/garnet/src/MenuScrollerSample.js
+++ b/garnet/src/MenuScrollerSample.js
@@ -74,7 +74,7 @@ module.exports = kind({
 		this.$.result.setContent(inEvent.msg);
 	},
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	}
 });

--- a/garnet/src/MultiPickerPanelSample.js
+++ b/garnet/src/MultiPickerPanelSample.js
@@ -114,7 +114,7 @@ module.exports = kind({
 		this.$.result.setContent(inEvent.msg);
 	},
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	}
 });

--- a/garnet/src/PageIndicatorSample.js
+++ b/garnet/src/PageIndicatorSample.js
@@ -76,7 +76,7 @@ module.exports = kind({
 		{content: ": Drag a panel to the left or to the right.", classes: "g-sample-description"}
 	],
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	}
 });

--- a/garnet/src/PanelSetDepthInMoveSample.js
+++ b/garnet/src/PanelSetDepthInMoveSample.js
@@ -272,7 +272,7 @@ module.exports = kind({
 		return records;
 	},
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	},
 	data: [

--- a/garnet/src/PanelSetDepthtInDepthSample.js
+++ b/garnet/src/PanelSetDepthtInDepthSample.js
@@ -268,7 +268,7 @@ module.exports = kind({
 		return records;
 	},
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	},
 	data: [

--- a/garnet/src/PanelSetMoveInDepthSample.js
+++ b/garnet/src/PanelSetMoveInDepthSample.js
@@ -268,7 +268,7 @@ module.exports = kind({
 		return records;
 	},
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	},
 	data: [

--- a/garnet/src/PanelSetMoveInMoveSample.js
+++ b/garnet/src/PanelSetMoveInMoveSample.js
@@ -272,7 +272,7 @@ module.exports = kind({
 		return records;
 	},
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	},
 	data: [

--- a/garnet/src/PanelSetPanelSample.js
+++ b/garnet/src/PanelSetPanelSample.js
@@ -191,7 +191,7 @@ module.exports = kind({
 		return records;
 	},
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	},
 	data: [

--- a/garnet/src/PanelSetSample.js
+++ b/garnet/src/PanelSetSample.js
@@ -103,7 +103,7 @@ module.exports = kind({
 		return records;
 	},
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	},
 	data: [

--- a/garnet/src/PickerPanelSample.js
+++ b/garnet/src/PickerPanelSample.js
@@ -91,7 +91,7 @@ module.exports = kind({
 		this.$.result.setContent(inEvent.msg);
 	},
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	}
 });

--- a/garnet/src/PopupSample.js
+++ b/garnet/src/PopupSample.js
@@ -94,7 +94,7 @@ module.exports = kind({
 		this.$.result.setContent(inEvent.msg);
 	},
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	}
 });

--- a/garnet/src/PreventTapOnDragSample.js
+++ b/garnet/src/PreventTapOnDragSample.js
@@ -25,7 +25,7 @@ module.exports = kind({
 		this.$.result.setContent(this.$.result.getContent() + "<br>tapped !!");
 	},
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	}
 });

--- a/garnet/src/ProgressBarSample.js
+++ b/garnet/src/ProgressBarSample.js
@@ -88,7 +88,7 @@ kind({
 		}
 	},
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	}
 });
@@ -103,7 +103,7 @@ module.exports = kind({
 		{kind: "g.sample.ProgressBarPanel", style: "position: relative;"}
 	],
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	}
 });

--- a/garnet/src/SpinnerSample.js
+++ b/garnet/src/SpinnerSample.js
@@ -50,7 +50,7 @@ module.exports = kind({
 		]}
 	],
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	}
 });

--- a/garnet/src/TimePickerPanelSample.js
+++ b/garnet/src/TimePickerPanelSample.js
@@ -83,7 +83,7 @@ module.exports = kind({
 		this.$.result.setContent(inEvent.msg);
 	},
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	}
 });

--- a/garnet/src/TitleSample.js
+++ b/garnet/src/TitleSample.js
@@ -64,7 +64,7 @@ module.exports = kind({
 		this.$.result.setContent(inEvent.msg);
 	},
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	}
 });

--- a/garnet/src/ToastSample.js
+++ b/garnet/src/ToastSample.js
@@ -39,7 +39,7 @@ module.exports = kind({
 		{kind: "g.sample.ToastPanel", style: "position: relative;"}
 	],
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	}
 });

--- a/garnet/src/ToggleButtonSample.js
+++ b/garnet/src/ToggleButtonSample.js
@@ -55,7 +55,7 @@ module.exports = kind({
 		this.$.result.setContent(inEvent.msg);
 	},
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	}
 });

--- a/garnet/src/ToggleIconButtonSample.js
+++ b/garnet/src/ToggleIconButtonSample.js
@@ -80,7 +80,7 @@ module.exports = kind({
 		this.$.result.setContent(inEvent.msg);
 	},
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	}
 });

--- a/garnet/src/WheelSliderControllerSample.js
+++ b/garnet/src/WheelSliderControllerSample.js
@@ -205,7 +205,7 @@ module.exports = kind({
 		this.$.result.setContent(inEvent.msg);
 	},
 	goBack: function(inSender, inEvent) {
-		global.location.href = "./index.html?Garnet"; // global.history.go(-1);
+		global.history.go(-1);
 		return false;
 	}
 });


### PR DESCRIPTION
## Issue

: "history.go" didn't work well with garnet samples in a watch. So I used temporary "location.href" instead of it. After Blake updated enyo-strawman environment for garnet samples, "history.go" works well with garnet samples.
## Fix

: Used history.go instead of location.href

Enyo-DCO-1.1-Signed-off-by: YB Sung yb.sung@lge.com
