### PR TITLE
GARNET: Updated package.json for assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,3 @@ node_modules
 /lib
 dist
 .enyocache
-appinfo.json
-icon.png
-largeIcon.png

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ dist/
 node_modules
 /lib
 dist
+.enyocache
+appinfo.json
+icon.png
+largeIcon.png

--- a/garnet/package.json
+++ b/garnet/package.json
@@ -36,6 +36,7 @@
   "assets": [
     "../appinfo.json",
     "../icon.png",
-    "../largeIcon.png"
+    "../largeIcon.png",
+    "assets/**/*.*"
   ]
 }


### PR DESCRIPTION
## Issue

1) "320", "360" folders in "\enyo-strawman\garnet\assets" weren't copied into "\enyo-strawman\dist\garnet\assets" when using "epack garnet".
2) For the code below, I copied appinfo.json, icon.png and largeIcon.png from "\enyo-strawman\webos-meta" to "\enyo-strawman". For convenience, could we ignore these files and ".enyocache" defined in ".gitignore" file?

``` json
  "assets": [
    "../appinfo.json",
    "../icon.png",
    "../largeIcon.png"
  ]
```
## Fix

1) I updated package.json in "\enyo-strawman\garnet"
2) I added ".enyocache, "appinfo.json", "icon.png" and "largeIcon.png" in .gitignore".
    If it's too wearable specific issue to deploy apps, I could skip issue 2).

 Enyo-DCO-1.1-Signed-off-by: YB Sung yb.sung@lge.com
