### PR TITLE
ENYO-2040: Use kind.inherit for tap handler.

### DIFF
--- a/src/strawman/LinkSupport.js
+++ b/src/strawman/LinkSupport.js
@@ -4,13 +4,20 @@
  * Add automatic on-tap support for controls with a href attribute
  */
 
+require('enyo');
+
+var
+	kind = require('enyo/kind');
+
 module.exports = {
 	name: 'LinkSupport',
-	tap: function (sender, ev) {
-		this.inherited(arguments);
-		var link = this.get('href') || ev.originator.get('href') || ev.originator.parent.get('href');
-		if (link) {
-			window.location.href = link;
-		}
-	}
+	tap: kind.inherit(function (sup) {
+		return function (sender, ev) {
+			sup.apply(this, arguments);
+			var link = this.get('href') || ev.originator.get('href') || ev.originator.parent.get('href');
+			if (link) {
+				window.location.href = link;
+			}
+		};
+	})
 };


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
