### PR TITLE
ENYO-2215: Garnet sample: Fix the garnet sample warnings more

### DIFF
--- a/garnet/src/ArcSample.js
+++ b/garnet/src/ArcSample.js
@@ -8,7 +8,7 @@ var
 	Arc = require('garnet/Arc'),
 	Panel = require('garnet/Panel');
 
-kind({
+var ArcPanel = kind({
 	name: "g.sample.ArcPanel",
 	kind: Panel,
 	style: "position: relative; border-radius: 50%; background-color: #000000;",
@@ -45,7 +45,7 @@ module.exports = kind({
 		{content: "< Arc Sample", classes: "g-sample-header", ontap: "goBack"},
 
 		{content: "Arc", classes: "g-sample-subheader"},
-		{kind: "g.sample.ArcPanel"}
+		{kind: ArcPanel}
 	],
 	goBack: function(inSender, inEvent) {
 		global.history.go(-1);

--- a/garnet/src/ButtonSample.js
+++ b/garnet/src/ButtonSample.js
@@ -9,7 +9,7 @@ var
 	Button = require('garnet/Button'),
 	Panel = require('garnet/Panel');
 
-kind({
+var ButtonPanel = kind({
 	name: "g.sample.ButtonPanel",
 	kind: Panel,
 	events: {
@@ -44,7 +44,7 @@ module.exports = kind({
 		{content: "< Button Sample", classes: "g-sample-header", ontap: "goBack"},
 
 		{content: "Buttons", classes: "g-sample-subheader"},
-		{kind: "g.sample.ButtonPanel", style: "position: relative;", onResult: "result"},
+		{kind: ButtonPanel, style: "position: relative;", onResult: "result"},
 
 		{src: "@../assets/btn_command_next.svg", classes: "g-sample-result", components: [
 			{content: "Result", classes: "g-sample-subheader"},

--- a/garnet/src/CheckboxSample.js
+++ b/garnet/src/CheckboxSample.js
@@ -10,7 +10,7 @@ var
 	Checkbox = require('garnet/Checkbox'),
 	Panel = require('garnet/Panel');
 
-kind({
+var CheckboxPanel = kind({
 	name: "g.sample.CheckboxPanel",
 	kind: Panel,
 	events: {
@@ -53,7 +53,7 @@ module.exports = kind({
 		{content: "< Checkbox Sample", classes: "g-sample-header", ontap: "goBack"},
 
 		{content: "Checkboxes", classes: "g-sample-subheader"},
-		{kind: "g.sample.CheckboxPanel", style: "position: relative;", onResult: "result"},
+		{kind: CheckboxPanel, style: "position: relative;", onResult: "result"},
 
 		{src: "@../assets/btn_command_next.svg", classes: "g-sample-result", components: [
 			{content: "Result", classes: "g-sample-subheader"},

--- a/garnet/src/CommandBarSample.js
+++ b/garnet/src/CommandBarSample.js
@@ -11,7 +11,7 @@ var
 	Panel = require('garnet/Panel'),
 	Scroller = require('garnet/Scroller');
 
-kind({
+var DefaultCommandBarPanel = kind({
 	name: "g.sample.DefaultCommandBarPanel",
 	kind: Panel,
 	events: {
@@ -40,7 +40,7 @@ kind({
 });
 
 // single commandBar sample
-kind({
+var SingleCommandBarPanel = kind({
 	name: "g.sample.SingleCommandBarPanel",
 	kind: Panel,
 	events: {
@@ -68,7 +68,7 @@ kind({
 });
 
 // custom commandBar sample
-kind({
+var CustomCommandBarPanel = kind({
 	name: "g.sample.CustomCommandBarPanel",
 	kind: Panel,
 	events: {
@@ -113,17 +113,17 @@ module.exports = kind({
 		{style: "position: relative; height: 100%;", components: [
 			{
 				name: "commandBar1",
-				kind: "g.sample.DefaultCommandBarPanel",
+				kind: DefaultCommandBarPanel,
 				style: "background-color: #000000; position: relative; display: inline-block; overflow: hidden;"
 			},
 			{
 				name: "commandBar2",
-				kind: "g.sample.SingleCommandBarPanel",
+				kind: SingleCommandBarPanel,
 				style: "background-color: #000000; position: relative; display: inline-block; margin-left: " + ri.scale(10) + "px; overflow: hidden;"
 			},
 			{
 				name: "commandBar3",
-				kind: "g.sample.CustomCommandBarPanel",
+				kind: CustomCommandBarPanel,
 				style: "background-color: #000000; position: relative; display: inline-block; margin-left: " + ri.scale(10) + "px; overflow: hidden;"
 			}
 		]},

--- a/garnet/src/ConfirmPopupSample.js
+++ b/garnet/src/ConfirmPopupSample.js
@@ -13,7 +13,7 @@ var
 	PopupScroller = require('garnet/PopupScroller'),
 	Panel = require('garnet/Panel');
 
-kind({
+var ConfirmPopupPanel = kind({
 	name: "g.sample.ConfirmPopupPanel",
 	kind: Panel,
 	events: {
@@ -149,7 +149,7 @@ module.exports = kind({
 		{content: "< Confirm Popup Sample", classes: "g-sample-header", ontap: "goBack"},
 
 		{content: "Confirm with only Text/Scroll + Text /Icon+Title+Text/ Scorll + Icon + Title+ Text ", classes: "g-sample-subheader"},
-		{kind: "g.sample.ConfirmPopupPanel", style: "position: relative;", onResult: "result"},
+		{kind: ConfirmPopupPanel, style: "position: relative;", onResult: "result"},
 
 		{style: "position: fixed; width: 100%; min-height: +" + ri.scale(160) + "px; bottom: 0; z-index: 9999; background-color: #EDEDED; opacity: 0.8;", classes: "g-sample-result", components: [
 			{content: "Result", classes: "g-sample-subheader"},

--- a/garnet/src/DataGridListSample.js
+++ b/garnet/src/DataGridListSample.js
@@ -14,8 +14,8 @@ var
 	Panel = require('garnet/Panel'),
 	SelectionOverlaySupport = require('garnet/SelectionOverlaySupport');
 
-var DataGridListSampleImageItem = kind({
-	name: "g.DataGridListSampleImageItem",
+var DataGridListImageItem = kind({
+	name: "g.DataGridListImageItem",
 	classes: "g-sample-gridlist-imageitem",
 	components: [{
 		name: "image",
@@ -54,9 +54,9 @@ var DataGridListSampleImageItem = kind({
 	}
 });
 
-kind({
-	name: "g.sample.DataGridListSampleItem",
-	kind: DataGridListSampleImageItem,
+var DataGridListItem = kind({
+	name: "g.sample.DataGridListItem",
+	kind: DataGridListImageItem,
 	mixins: [SelectionOverlaySupport],
 	selectionScrimIcon: {
 		"w320": "garnet/images/320/frame_check.png",
@@ -73,15 +73,15 @@ kind({
 	}]
 });
 
-var DataGridListSampleCircleImageItem = kind({
-	name: "DataGridListSampleCircleImageItem",
-	kind: DataGridListSampleImageItem,
+var DataGridListCircleImageItem = kind({
+	name: "DataGridListCircleImageItem",
+	kind: DataGridListImageItem,
 	classes: "g-sample-gridlist-circle-imageitem"
 });
 
-kind({
-	name: "g.sample.DataGridListSampleCircleItem",
-	kind: DataGridListSampleCircleImageItem,
+var DataGridListCircleItem = kind({
+	name: "g.sample.DataGridListCircleItem",
+	kind: DataGridListCircleImageItem,
 	mixins: [SelectionOverlaySupport],
 	selectionScrimIcon: {
 		"w320": "garnet/images/320/frame_check.png",
@@ -115,7 +115,7 @@ var DataGridListPanel = kind({
 		spacing: 0,
 		style: "width: " + ri.scale(232) + "px; height: " + ri.scale(320) + "px; margin: auto; background-color: #000000;",
 		components: [{
-			kind: "g.sample.DataGridListSampleItem"
+			kind: DataGridListItem
 		}]
 	}],
 	bindings: [{
@@ -131,7 +131,7 @@ var DataGridListPanel = kind({
 	})
 });
 
-kind({
+var DataGridListCirclePanel = kind({
 	name: "g.sample.DataGridListCirclePanel",
 	kind: DataGridListPanel,
 	components: [{
@@ -142,12 +142,12 @@ kind({
 		minHeight: 106,
 		style: "width: " + ri.scale(230) + "px; height: " + ri.scale(320) + "px; margin: auto; background-color: #000000;",
 		components: [{
-			kind: "g.sample.DataGridListSampleCircleItem"
+			kind: DataGridListCircleItem
 		}]
 	}]
 });
 
-module.exports = kind({
+var DataGridListSample = module.exports = kind({
 	name: "g.sample.DataGridListSample",
 	classes: "enyo-unselectable garnet g-sample",
 	components: [
@@ -159,7 +159,7 @@ module.exports = kind({
 			content: "Data Grid List", classes: "g-sample-subheader"
 		}, {
 			name: "gridListCircle",
-			kind: "g.sample.DataGridListCirclePanel",
+			kind: DataGridListCirclePanel,
 			style: "position: relative; display: inline-block; margin-right: " + ri.scale(20) + "px;",
 			selection: true,
 			multipleSelection: true
@@ -171,7 +171,7 @@ module.exports = kind({
 			multipleSelection: true
 		}, {
 			name: "gridListSingleCircle",
-			kind: "g.sample.DataGridListCirclePanel",
+			kind: DataGridListCirclePanel,
 			style: "position: relative; display: inline-block; margin-right: " + ri.scale(20) + "px;",
 			selection: true
 		}, {
@@ -215,3 +215,5 @@ module.exports = kind({
 		return false;
 	}
 });
+
+DataGridListSample.DataGridListPanel = DataGridListPanel;

--- a/garnet/src/DataGridListSample.js
+++ b/garnet/src/DataGridListSample.js
@@ -15,7 +15,7 @@ var
 	SelectionOverlaySupport = require('garnet/SelectionOverlaySupport');
 
 var DataGridListImageItem = kind({
-	name: "g.DataGridListImageItem",
+	name: "g.sample.DataGridListImageItem",
 	classes: "g-sample-gridlist-imageitem",
 	components: [{
 		name: "image",
@@ -74,7 +74,7 @@ var DataGridListItem = kind({
 });
 
 var DataGridListCircleImageItem = kind({
-	name: "DataGridListCircleImageItem",
+	name: "g.sample.DataGridListCircleImageItem",
 	kind: DataGridListImageItem,
 	classes: "g-sample-gridlist-circle-imageitem"
 });

--- a/garnet/src/DataGridListwithCardsSample.js
+++ b/garnet/src/DataGridListwithCardsSample.js
@@ -12,8 +12,8 @@ var
 	Panel = require('garnet/Panel'),
 	SelectionOverlaySupport = require('garnet/SelectionOverlaySupport');
 
-var DataGridListCardsSampleImageItem = kind({
-	name: "DataGridListCardsSampleImageItem",
+var DataGridListCardsImageItem = kind({
+	name: "DataGridListCardsImageItem",
 	classes: "g-sample-gridlistcards-imageitem",
 	components: [
 		{name: "image", kind: Image},
@@ -42,9 +42,9 @@ var DataGridListCardsSampleImageItem = kind({
 	}
 });
 
-kind({
-	name: "g.sample.DataGridListCardsSampleItem",
-	kind: DataGridListCardsSampleImageItem,
+var DataGridListCardsItem = kind({
+	name: "g.sample.DataGridListCardsItem",
+	kind: DataGridListCardsImageItem,
 	mixins: [SelectionOverlaySupport],
 	selectionScrimIcon: {
 		"w320": "garnet/images/320/badge_check.png",
@@ -57,15 +57,15 @@ kind({
 	]
 });
 
-var DataGridListCardsSampleCircleImageItem = kind({
-	name: "DataGridListCardsSampleCircleImageItem",
-	kind: DataGridListCardsSampleImageItem,
+var DataGridListCardsCircleImageItem = kind({
+	name: "DataGridListCardsCircleImageItem",
+	kind: DataGridListCardsImageItem,
 	classes: "g-sample-gridlistcards-circle-imageitem"
 });
 
-kind({
-	name: "g.sample.DataGridListCardsSampleCircleItem",
-	kind: DataGridListCardsSampleCircleImageItem,
+var DataGridListCardsCircleItem = kind({
+	name: "g.sample.DataGridListCardsCircleItem",
+	kind: DataGridListCardsCircleImageItem,
 	mixins: [SelectionOverlaySupport],
 	selectionScrimIcon: {
 		"w320": "garnet/images/320/badge_check.png",
@@ -79,8 +79,8 @@ kind({
 	]
 });
 
-kind({
-	name: "g.sample.DataGridListCardsSamplePanel",
+var DataGridListCardsPanel = kind({
+	name: "g.sample.DataGridListCardsPanel",
 	kind: Panel,
 	title: true,
 	titleContent: "Title",
@@ -100,7 +100,7 @@ kind({
 			scrollerOptions: {maxHeight: ri.scale(370) + "px"},
 			style: "width: " + ri.scale(212) + "px; height: " + ri.scale(320) + "px; padding-top: " + ri.scale(6) + "px; margin: auto; background-color: #000000;",
 			components: [
-				{ kind: "g.sample.DataGridListCardsSampleItem" }
+				{kind: DataGridListCardsItem}
 			]
 		}
 	],
@@ -109,8 +109,8 @@ kind({
 	]
 });
 
-kind({
-	name: "g.sample.DataGridListCardsCircleSamplePanel",
+var DataGridListCardsCirclePanel = kind({
+	name: "g.sample.DataGridListCardsCirclePanel",
 	kind: Panel,
 	title: true,
 	titleContent: "Title",
@@ -130,7 +130,7 @@ kind({
 			scrollerOptions: {maxHeight: ri.scale(370) + "px"},
 			style: "width: " + ri.scale(212) + "px; height: " + ri.scale(320) + "px; padding-top: " + ri.scale(6) + "px; margin: auto; background-color: #000000;",
 			components: [
-				{ kind: "g.sample.DataGridListCardsSampleCircleItem" }
+				{kind: DataGridListCardsCircleItem}
 			]
 		}
 	],
@@ -146,8 +146,8 @@ module.exports = kind({
 		{content: "< Data Grid List with Cards Sample", classes: "g-sample-header", ontap: "goBack"},
 
 		{content: "Data Grid List with Cards", classes: "g-sample-subheader"},
-		{name: "gridList", kind: "g.sample.DataGridListCardsSamplePanel", style: "position: relative; display: inline-block; margin-right: " + ri.scale(10) + "px"},
-		{name: "gridListCircle", kind: "g.sample.DataGridListCardsCircleSamplePanel", style: "position: relative; display: inline-block;"}
+		{name: "gridList", kind: DataGridListCardsPanel, style: "position: relative; display: inline-block; margin-right: " + ri.scale(10) + "px"},
+		{name: "gridListCircle", kind: DataGridListCardsCirclePanel, style: "position: relative; display: inline-block;"}
 	],
 	bindings: [
 		{from: ".collection", to: ".$.gridList.collection"},

--- a/garnet/src/DataGridListwithCardsSample.js
+++ b/garnet/src/DataGridListwithCardsSample.js
@@ -13,7 +13,7 @@ var
 	SelectionOverlaySupport = require('garnet/SelectionOverlaySupport');
 
 var DataGridListCardsImageItem = kind({
-	name: "DataGridListCardsImageItem",
+	name: "g.sample.DataGridListCardsImageItem",
 	classes: "g-sample-gridlistcards-imageitem",
 	components: [
 		{name: "image", kind: Image},
@@ -58,7 +58,7 @@ var DataGridListCardsItem = kind({
 });
 
 var DataGridListCardsCircleImageItem = kind({
-	name: "DataGridListCardsCircleImageItem",
+	name: "g.sample.DataGridListCardsCircleImageItem",
 	kind: DataGridListCardsImageItem,
 	classes: "g-sample-gridlistcards-circle-imageitem"
 });

--- a/garnet/src/DataIndexListSample.js
+++ b/garnet/src/DataIndexListSample.js
@@ -15,7 +15,7 @@ var
 	Panel = require('garnet/Panel');
 
 var DataIndexListItem = kind({
-	name: "DataIndexListItem",
+	name: "g.sample.DataIndexListItem",
 	kind: Item,
 	classes: "g-sample-indexlist-item",
 	published: {

--- a/garnet/src/DataIndexListSample.js
+++ b/garnet/src/DataIndexListSample.js
@@ -14,8 +14,8 @@ var
 	DataList = require('garnet/DataList'),
 	Panel = require('garnet/Panel');
 
-kind({
-	name: "DataIndexListSampleItem",
+var DataIndexListItem = kind({
+	name: "DataIndexListItem",
 	kind: Item,
 	classes: "g-sample-indexlist-item",
 	published: {
@@ -44,7 +44,7 @@ kind({
 	}
 });
 
-kind({
+var DataIndexListPanel = kind({
 	name: "g.sample.DataIndexListPanel",
 	kind: Panel,
 	title: true,
@@ -64,7 +64,7 @@ kind({
 				]}
 			],
 			components: [
-				{kind: "DataIndexListSampleItem"}
+				{kind: DataIndexListItem}
 			],
 			footerComponents: [
 				{style: "width: 100%; height: " + ri.scale(93) + "px;", ontap: "preventSound"}
@@ -86,7 +86,7 @@ module.exports = kind({
 		{content: "< Data Index List Sample", classes: "g-sample-header", ontap: "goBack"},
 
 		{content: "Data Index List", classes: "g-sample-subheader"},
-		{name: "list", kind: "g.sample.DataIndexListPanel", pagesPerRound: 10, style: "position: relative;"}
+		{name: "list", kind: DataIndexListPanel, pagesPerRound: 10, style: "position: relative;"}
 	],
 	bindings: [
 		{from: ".collection", to: ".$.list.collection"}

--- a/garnet/src/DataListSample.js
+++ b/garnet/src/DataListSample.js
@@ -18,7 +18,7 @@ var
 	Panel = require('garnet/Panel');
 
 var DataListItem = kind({
-	name: "g.DataListItem",
+	name: "g.sample.DataListItem",
 	kind: Item,
 	classes: "g-sample-datalist-item",
 	handlers: {

--- a/garnet/src/DataListSample.js
+++ b/garnet/src/DataListSample.js
@@ -17,8 +17,8 @@ var
 	IconMenuPopup = require('garnet/IconMenuPopup'),
 	Panel = require('garnet/Panel');
 
-kind({
-	name: "g.DataListSampleItem",
+var DataListItem = kind({
+	name: "g.DataListItem",
 	kind: Item,
 	classes: "g-sample-datalist-item",
 	handlers: {
@@ -55,7 +55,7 @@ kind({
 	}
 });
 
-kind({
+var DataListPanel = kind({
 	name: "g.sample.DataListPanel",
 	kind: Panel,
 	title: true,
@@ -75,7 +75,7 @@ kind({
 				]}
 			],
 			components: [
-				{kind: "g.DataListSampleItem", onlongpress: "showPopup"}
+				{kind: DataListItem, onlongpress: "showPopup"}
 			],
 			footerComponents: [
 				{kind: Button, content: "Text", style: "width: " + ri.scale(122) + "px; height: " + ri.scale(52) + "px; margin: " + ri.scale(21) + "px " + ri.scale(99) +"px " + ri.scale(21) +"px;"}
@@ -119,14 +119,14 @@ kind({
 	]
 });
 
-module.exports = kind({
+var DataListSample = module.exports = kind({
 	name: "g.sample.DataListSample",
 	classes: "enyo-unselectable garnet g-sample",
 	components: [
 		{content: "< Data List Sample", classes: "g-sample-header", ontap: "goBack"},
 
 		{content: "Data List", classes: "g-sample-subheader"},
-		{name: "listPanel", kind: "g.sample.DataListPanel", style: "position: relative;"}
+		{name: "listPanel", kind: DataListPanel, style: "position: relative;"}
 	],
 	bindings: [
 		{from: ".collection", to: ".$.listPanel.collection"}
@@ -244,3 +244,5 @@ module.exports = kind({
 		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"}
 	]
 });
+
+DataListSample.DataListPanel = DataListPanel;

--- a/garnet/src/DataListwithCardsSample.js
+++ b/garnet/src/DataListwithCardsSample.js
@@ -10,7 +10,7 @@ var
 	DataList = require('garnet/DataList'),
 	Panel = require('garnet/Panel');
 
-kind({
+var DataListCardsPanel = kind({
 	name: "g.sample.DataListCardsPanel",
 	kind: Panel,
 	knob: true,
@@ -38,7 +38,7 @@ kind({
 	]
 });
 
-kind({
+var DataListSmallCardsPanel = kind({
 	name: "g.sample.DataListSmallCardsPanel",
 	kind: Panel,
 	knob: true,
@@ -81,8 +81,8 @@ module.exports = kind({
 		{content: "< Data List with Cards Sample", classes: "g-sample-header", ontap: "goBack"},
 
 		{content: "Data List with Cards", classes: "g-sample-subheader"},
-		{name: "listPanel", kind: "g.sample.DataListCardsPanel", style: "position: relative; display: inline-block;"},
-		{name: "listPanel2", kind: "g.sample.DataListSmallCardsPanel", style: "border-radius: 100%; position: relative; display: inline-block; margin-left: " + ri.scale(10) + "px;"}
+		{name: "listPanel", kind: DataListCardsPanel, style: "position: relative; display: inline-block;"},
+		{name: "listPanel2", kind: DataListSmallCardsPanel, style: "border-radius: 100%; position: relative; display: inline-block; margin-left: " + ri.scale(10) + "px;"}
 	],
 	bindings: [
 		{from: ".collection", to: ".$.listPanel.collection"},

--- a/garnet/src/DataListwithCheckboxesSample.js
+++ b/garnet/src/DataListwithCheckboxesSample.js
@@ -14,8 +14,8 @@ var
 	Panel = require('garnet/Panel')
 	SelectionOverlaySupport = require('garnet/SelectionOverlaySupport');
 
-var CheckboxItem = kind({
-	name: "g.CheckboxItem",
+var CheckboxItemBase = kind({
+	name: "g.sample.CheckboxItemBase",
 	kind: Item,
 	classes: "g-sample-datalistcheckbox-checkbox-item",
 	published: {
@@ -44,9 +44,9 @@ var CheckboxItem = kind({
 	}
 });
 
-kind({
+var CheckboxItem = kind({
 	name: "g.sample.CheckboxItem",
-	kind: CheckboxItem,
+	kind: CheckboxItemBase,
 	mixins: [SelectionOverlaySupport],
 	selectionOverlayVerticalOffset: 53,
 	selectionOverlayHorizontalOffset: 20,
@@ -55,7 +55,7 @@ kind({
 	]
 });
 
-kind({
+var CheckableDataListPanel = kind({
 	name: "g.sample.CheckableDataListPanel",
 	kind: Panel,
 	events: {
@@ -72,7 +72,7 @@ kind({
 			multipleSelection: true,
 			style: "background-color: #000000;",
 			components: [
-				{kind: "g.sample.CheckboxItem", ontap: "tapItem"}
+				{kind: CheckboxItem, ontap: "tapItem"}
 			],
 			footerComponents: [
 				{style: "height: " + ri.scale(116) + "px;"}
@@ -129,7 +129,7 @@ module.exports = kind({
 		{content: "< Data List with Checkboxes Sample", classes: "g-sample-header", ontap: "goBack"},
 
 		{content: "Data List with Checkboxes", classes: "g-sample-subheader"},
-		{name: "checkableListPanel", kind: "g.sample.CheckableDataListPanel", style: "position: relative;", onResult: "result"},
+		{name: "checkableListPanel", kind: CheckableDataListPanel, style: "position: relative;", onResult: "result"},
 
 		{src: "@../assets/btn_command_next.svg", classes: "g-sample-result", components: [
 			{content: "Result", classes: "g-sample-subheader"},

--- a/garnet/src/DataListwithIconBadgeSample.js
+++ b/garnet/src/DataListwithIconBadgeSample.js
@@ -14,7 +14,7 @@ var
 	Panel = require('garnet/Panel');
 
 var IconBadgeItem = kind({
-	name: "IconBadgeItem",
+	name: "g.sample.IconBadgeItem",
 	kind: Item,
 	classes: "g-datalist-icon-badge-item",
 	published: {

--- a/garnet/src/DataListwithRadioButtonsSample.js
+++ b/garnet/src/DataListwithRadioButtonsSample.js
@@ -13,8 +13,8 @@ var
 	Panel = require('garnet/Panel'),
 	SelectionOverlaySupport = require('garnet/SelectionOverlaySupport');
 
-var RadioButtonItem = kind({
-	name: "RadioButtonItem",
+var RadioButtonItemBase = kind({
+	name: "g.sample.RadioButtonItemBase",
 	kind: Item,
 	classes: "g-datalist-radiobutton-item",
 	published: {
@@ -43,9 +43,9 @@ var RadioButtonItem = kind({
 	}
 });
 
-kind({
+var RadioButtonItem = kind({
 	name: "g.sample.RadioButtonItem",
-	kind: RadioButtonItem,
+	kind: RadioButtonItemBase,
 	mixins: [SelectionOverlaySupport],
 	selectionScrimIcon: {
 		"w320": "garnet/images/320/btn_radio.svg",
@@ -58,7 +58,7 @@ kind({
 	]
 });
 
-kind({
+var RadioDataListPanel = kind({
 	name: "g.sample.RadioDataListPanel",
 	kind: Panel,
 	noDefer: true,
@@ -76,7 +76,7 @@ kind({
 			selection: true,
 			style: "background-color: #000000;",
 			components: [
-				{kind: "g.sample.RadioButtonItem", ontap: "tapItem"}
+				{kind: RadioButtonItem, ontap: "tapItem"}
 			],
 			footerComponents: [
 				{style: "height: " + ri.scale(116) + "px;"}
@@ -119,7 +119,7 @@ module.exports = kind({
 		{content: "< DataList with Radio Buttons Sample", classes: "g-sample-header", ontap: "goBack"},
 
 		{content: "DataList with Radio Buttons", classes: "g-sample-subheader"},
-		{name: "radioDataListPanel", kind: "g.sample.RadioDataListPanel", style: "position: relative;", onResult: "result"},
+		{name: "radioDataListPanel", kind: RadioDataListPanel, style: "position: relative;", onResult: "result"},
 
 		{src: "@../assets/btn_command_next.svg", classes: "g-sample-result", components: [
 			{content: "Result", classes: "g-sample-subheader"},

--- a/garnet/src/DatePickerPanelSample.js
+++ b/garnet/src/DatePickerPanelSample.js
@@ -4,11 +4,11 @@ var
 	utils = require('enyo/utils'),
 
 	g = require('garnet'),
-	DatePickerPanel = require('garnet/DatePickerPanel');
+	GarnetDatePickerPanel = require('garnet/DatePickerPanel');
 
-kind({
+var SampleDatePickerPanel = kind({
 	name: "g.sample.DatePickerPanel",
-	kind: DatePickerPanel,
+	kind: GarnetDatePickerPanel,
 	handlers: {
 		onOK: "tapOK",
 		onCancel: "tapCancel"
@@ -34,7 +34,7 @@ module.exports = kind({
 		{content: "< Date Picker Panel Sample", classes: "g-sample-header", ontap: "goBack"},
 
 		{content: "Date Picker Panel", classes: "g-sample-subheader"},
-		{kind: "g.sample.DatePickerPanel", style: "position: relative;", onResult: "result"},
+		{kind: SampleDatePickerPanel, style: "position: relative;", onResult: "result"},
 
 		{style: "position: fixed; width: 100%; min-height: 160px; bottom: 0; z-index: 9999; background-color: #EDEDED; opacity: 0.8;", classes: "g-sample-result", components: [
 			{content: "Result", classes: "g-sample-subheader"},

--- a/garnet/src/FormSample.js
+++ b/garnet/src/FormSample.js
@@ -25,7 +25,7 @@ var
 	Scroller = require('garnet/Scroller'),
 	TimePickerPanel = require('garnet/TimePickerPanel');
 
-kind({
+var FormPanel = kind({
 	name: "g.sample.FormPanel",
 	kind: Panel,
 	events: {
@@ -494,7 +494,7 @@ module.exports = kind({
 		{content: "< Form Sample", classes: "g-sample-header", ontap: "goBack"},
 
 		{content: "Form Picker Buttons / Form Buttons / Form Inputs", classes: "g-sample-subheader"},
-		{kind: "g.sample.FormPanel", style: "position: relative;", onResult: "result"},
+		{kind: FormPanel, style: "position: relative;", onResult: "result"},
 
 		{src: "@../assets/btn_command_next.svg", classes: "g-sample-result", components: [
 			{content: "Result", classes: "g-sample-subheader"},

--- a/garnet/src/IconButtonSample.js
+++ b/garnet/src/IconButtonSample.js
@@ -12,7 +12,7 @@ var
 	Button = require('garnet/Button'),
 	Panel = require('garnet/Panel');
 
-kind({
+var IconButtonPanel = kind({
 	name: "g.sample.IconButtonPanel",
 	kind: Panel,
 	events: {
@@ -53,7 +53,7 @@ module.exports = kind({
 		{content: "< Icon Button Sample", classes: "g-sample-header", ontap: "goBack"},
 
 		{content: "Icon Buttons", classes: "g-sample-subheader"},
-		{kind: "g.sample.IconButtonPanel", style: "position: relative;", onResult: "result"},
+		{kind: IconButtonPanel, style: "position: relative;", onResult: "result"},
 
 		{src: "@../assets/btn_command_next.svg", classes: "g-sample-result", components: [
 			{content: "Result", classes: "g-sample-subheader"},

--- a/garnet/src/IconMenuPopupSample.js
+++ b/garnet/src/IconMenuPopupSample.js
@@ -11,7 +11,7 @@ var
 	Button = require('garnet/Button'),
 	Panel = require('garnet/Panel');
 
-kind({
+var IconMenuPopupPanel = kind({
 	name: "g.sample.IconMenuPopupPanel",
 	kind: Panel,
 	events: {
@@ -104,7 +104,7 @@ module.exports = kind({
 		{content: "< IconMenu Popup Sample", classes: "g-sample-header", ontap: "goBack"},
 
 		{content: "IconMenu with 1 button / 2 buttons / 3 buttons", classes: "g-sample-subheader"},
-		{kind: "g.sample.IconMenuPopupPanel", style: "position: relative;", onResult: "result"},
+		{kind: IconMenuPopupPanel, style: "position: relative;", onResult: "result"},
 
 		{src: "@../assets/btn_command_next.svg", classes: "g-sample-result", components: [
 			{content: "Result", classes: "g-sample-subheader"},

--- a/garnet/src/IconSample.js
+++ b/garnet/src/IconSample.js
@@ -10,7 +10,7 @@ var
 	Icon = require('garnet/Icon'),
 	Panel = require('garnet/Panel');
 
-kind({
+var IconPanel = kind({
 	name: "g.sample.IconPanel",
 	kind: Panel,
 	classes: "g-layout-absolute-wrapper",
@@ -36,7 +36,7 @@ module.exports = kind({
 		{content: "< Icon Sample", classes: "g-sample-header", ontap: "goBack"},
 
 		{content: "Icons", classes: "g-sample-subheader"},
-		{kind: "g.sample.IconPanel", style: "position: relative;"}
+		{kind: IconPanel, style: "position: relative;"}
 	],
 	goBack: function(inSender, inEvent) {
 		global.history.go(-1);

--- a/garnet/src/MenuScrollerSample.js
+++ b/garnet/src/MenuScrollerSample.js
@@ -14,7 +14,7 @@ var
 	Panel = require('garnet/Panel'),
 	Popup = require('garnet/Popup');
 
-kind({
+var MenuScrollerPanel = kind({
 	name: "g.sample.MenuScrollerPanel",
 	kind: Panel,
 	handlers: {
@@ -63,7 +63,7 @@ module.exports = kind({
 		{content: "< Menu Scroller Sample", classes: "g-sample-header", ontap: "goBack"},
 
 		{content: "Menu Scroller", classes: "g-sample-subheader"},
-		{kind: "g.sample.MenuScrollerPanel", style: "position: relative;", onResult: "result"},
+		{kind: MenuScrollerPanel, style: "position: relative;", onResult: "result"},
 
 		{src: "@../assets/btn_command_next.svg", classes: "g-sample-result", components: [
 			{content: "Result", classes: "g-sample-subheader"},

--- a/garnet/src/MultiPickerPanelSample.js
+++ b/garnet/src/MultiPickerPanelSample.js
@@ -8,11 +8,11 @@ var
 
 	g = require('garnet'),
 	FormPickerButton = require('garnet/FormPickerButton'),
-	MultiPickerPanel = require('garnet/MultiPickerPanel'),
+	GarnetMultiPickerPanel = require('garnet/MultiPickerPanel'),
 	Panel = require('garnet/Panel'),
 	Popup = require('garnet/Popup');
 
-kind({
+var SampleMultiPickerPanel = kind({
 	name: "g.sample.MultiPickerPanel",
 	kind: Panel,
 	handlers: {
@@ -27,7 +27,7 @@ kind({
 		{name: "pickerPopup", kind: Popup, effect: "depth-transition", components: [
 			{
 				name: "multipicker",
-				kind: MultiPickerPanel,
+				kind: GarnetMultiPickerPanel,
 				title: true,
 				titleContent: "MultiPickerTitle"
 			}
@@ -103,7 +103,7 @@ module.exports = kind({
 		{content: "< MultiPickerPanel Sample", classes: "g-sample-header", ontap: "goBack"},
 
 		{content: "MultiPickerPanel", classes: "g-sample-subheader"},
-		{kind: "g.sample.MultiPickerPanel", style: "position: relative;", onResult: "result"},
+		{kind: SampleMultiPickerPanel, style: "position: relative;", onResult: "result"},
 
 		{src: "@../assets/btn_command_next.svg", classes: "g-sample-result", components: [
 			{content: "Result", classes: "g-sample-subheader"},

--- a/garnet/src/PanelSetDepthInMoveSample.js
+++ b/garnet/src/PanelSetDepthInMoveSample.js
@@ -10,7 +10,9 @@ var
 	g_ri = require('garnet/resolution'),
 	Scroller = require('garnet/Scroller'),
 	Panel = require('garnet/Panel'),
-	PanelSet = require('garnet/PanelSet');
+	PanelSet = require('garnet/PanelSet'),
+
+	SampleDataListPanel = require('./DataListSample').DataListPanel;
 
 module.exports = kind({
 	name: "g.sample.PanelSetDepthInMoveSample",
@@ -31,43 +33,43 @@ module.exports = kind({
 					pageIndicator: true,
 					components: [
 						{kind: PanelSet, components: [
-							{name: "panelA1-1", kind: "g.sample.DataListPanel", title: true, titleContent: "1-1", commandBarComponents: [
+							{name: "panelA1-1", kind: SampleDataListPanel, title: true, titleContent: "1-1", commandBarComponents: [
 								{name: "previousA1-1", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 								{name: "nextA1-1", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 							]},
-							{name: "panelA1-2", kind: "g.sample.DataListPanel", title: true, titleContent: "1-2", commandBarComponents: [
+							{name: "panelA1-2", kind: SampleDataListPanel, title: true, titleContent: "1-2", commandBarComponents: [
 								{name: "previousA1-2", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 								{name: "nextA1-2", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 							]},
-							{name: "panelA1-3", kind: "g.sample.DataListPanel", title: true, titleContent: "1-3", commandBarComponents: [
+							{name: "panelA1-3", kind: SampleDataListPanel, title: true, titleContent: "1-3", commandBarComponents: [
 								{name: "previousA1-3", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 								{name: "nextA1-3", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 							]}
 						]},
 						{kind: PanelSet, components: [
-							{name: "panelA2-1", kind: "g.sample.DataListPanel", title: true, titleContent: "2-1", commandBarComponents: [
+							{name: "panelA2-1", kind: SampleDataListPanel, title: true, titleContent: "2-1", commandBarComponents: [
 								{name: "previousA2-1", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 								{name: "nextA2-1", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 							]},
-							{name: "panelA2-2", kind: "g.sample.DataListPanel", title: true, titleContent: "2-2", commandBarComponents: [
+							{name: "panelA2-2", kind: SampleDataListPanel, title: true, titleContent: "2-2", commandBarComponents: [
 								{name: "previousA2-2", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 								{name: "nextA2-2", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 							]},
-							{name: "panelA2-3", kind: "g.sample.DataListPanel", title: true, titleContent: "2-3", commandBarComponents: [
+							{name: "panelA2-3", kind: SampleDataListPanel, title: true, titleContent: "2-3", commandBarComponents: [
 								{name: "previousA2-3", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 								{name: "nextA2-3", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 							]}
 						]},
 						{kind: PanelSet, components: [
-							{name: "panelA3-1", kind: "g.sample.DataListPanel", title: true, titleContent: "3-1", commandBarComponents: [
+							{name: "panelA3-1", kind: SampleDataListPanel, title: true, titleContent: "3-1", commandBarComponents: [
 								{name: "previousA3-1", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 								{name: "nextA3-1", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 							]},
-							{name: "panelA3-2", kind: "g.sample.DataListPanel", title: true, titleContent: "3-2", commandBarComponents: [
+							{name: "panelA3-2", kind: SampleDataListPanel, title: true, titleContent: "3-2", commandBarComponents: [
 								{name: "previousA3-2", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 								{name: "nextA3-2", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 							]},
-							{name: "panelA3-3", kind: "g.sample.DataListPanel", title: true, titleContent: "3-3", commandBarComponents: [
+							{name: "panelA3-3", kind: SampleDataListPanel, title: true, titleContent: "3-3", commandBarComponents: [
 								{name: "previousA3-3", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 								{name: "nextA3-3", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 							]}
@@ -87,15 +89,15 @@ module.exports = kind({
 					components: [
 						{kind: Panel, pageIndicatorFadeOut: false, components: [
 							{kind: PanelSet, components: [
-								{name: "panelB1-1", kind: "g.sample.DataListPanel", title: true, titleContent: "1-1", commandBarComponents: [
+								{name: "panelB1-1", kind: SampleDataListPanel, title: true, titleContent: "1-1", commandBarComponents: [
 									{name: "previousB1-1", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 									{name: "nextB1-1", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelB1-2", kind: "g.sample.DataListPanel", title: true, titleContent: "1-2", commandBarComponents: [
+								{name: "panelB1-2", kind: SampleDataListPanel, title: true, titleContent: "1-2", commandBarComponents: [
 									{name: "previousB1-2", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 									{name: "nextB1-2", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelB1-3", kind: "g.sample.DataListPanel", title: true, titleContent: "1-3", commandBarComponents: [
+								{name: "panelB1-3", kind: SampleDataListPanel, title: true, titleContent: "1-3", commandBarComponents: [
 									{name: "previousB1-3", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 									{name: "nextB1-3", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]}
@@ -103,15 +105,15 @@ module.exports = kind({
 						]},
 						{king: Panel, pageIndicatorFadeOut: false, components: [
 							{kind: PanelSet, components: [
-								{name: "panelB2-1", kind: "g.sample.DataListPanel", title: true, titleContent: "2-1", commandBarComponents: [
+								{name: "panelB2-1", kind: SampleDataListPanel, title: true, titleContent: "2-1", commandBarComponents: [
 									{name: "previousB2-1", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextB2-1", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelB2-2", kind: "g.sample.DataListPanel", title: true, titleContent: "2-2", commandBarComponents: [
+								{name: "panelB2-2", kind: SampleDataListPanel, title: true, titleContent: "2-2", commandBarComponents: [
 									{name: "previousB2-2", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextB2-2", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelB2-3", kind: "g.sample.DataListPanel", title: true, titleContent: "2-3", commandBarComponents: [
+								{name: "panelB2-3", kind: SampleDataListPanel, title: true, titleContent: "2-3", commandBarComponents: [
 									{name: "previousB2-3", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextB2-3", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]}
@@ -119,15 +121,15 @@ module.exports = kind({
 						]},
 						{king: Panel, pageIndicatorFadeOut: false, components: [
 							{kind: PanelSet, components: [
-								{name: "panelB3-1", kind: "g.sample.DataListPanel", title: true, titleContent: "3-1", commandBarComponents: [
+								{name: "panelB3-1", kind: SampleDataListPanel, title: true, titleContent: "3-1", commandBarComponents: [
 									{name: "previousB3-1", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextB3-1", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 								]},
-								{name: "panelB3-2", kind: "g.sample.DataListPanel", title: true, titleContent: "3-2", commandBarComponents: [
+								{name: "panelB3-2", kind: SampleDataListPanel, title: true, titleContent: "3-2", commandBarComponents: [
 									{name: "previousB3-2", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextB3-2", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 								]},
-								{name: "panelB3-3", kind: "g.sample.DataListPanel", title: true, titleContent: "3-3", commandBarComponents: [
+								{name: "panelB3-3", kind: SampleDataListPanel, title: true, titleContent: "3-3", commandBarComponents: [
 									{name: "previousB3-3", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextB3-3", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 								]}
@@ -145,43 +147,43 @@ module.exports = kind({
 					components: [
 						{name: "panelSetC", kind: PanelSet, pageIndicator: true, effect: "move-transition", components: [
 							{kind: PanelSet, components: [
-								{name: "panelC1-1", kind: "g.sample.DataListPanel", title: true, titleContent: "1-1", commandBarComponents: [
+								{name: "panelC1-1", kind: SampleDataListPanel, title: true, titleContent: "1-1", commandBarComponents: [
 									{name: "previousC1-1", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 									{name: "nextC1-1", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelC1-2", kind: "g.sample.DataListPanel", title: true, titleContent: "1-2", commandBarComponents: [
+								{name: "panelC1-2", kind: SampleDataListPanel, title: true, titleContent: "1-2", commandBarComponents: [
 									{name: "previousC1-2", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 									{name: "nextC1-2", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelC1-3", kind: "g.sample.DataListPanel", title: true, titleContent: "1-3", commandBarComponents: [
+								{name: "panelC1-3", kind: SampleDataListPanel, title: true, titleContent: "1-3", commandBarComponents: [
 									{name: "previousC1-3", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 									{name: "nextC1-3", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]}
 							]},
 							{kind: PanelSet, components: [
-								{name: "panelC2-1", kind: "g.sample.DataListPanel", title: true, titleContent: "2-1", commandBarComponents: [
+								{name: "panelC2-1", kind: SampleDataListPanel, title: true, titleContent: "2-1", commandBarComponents: [
 									{name: "previousC2-1", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextC2-1", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelC2-2", kind: "g.sample.DataListPanel", title: true, titleContent: "2-2", commandBarComponents: [
+								{name: "panelC2-2", kind: SampleDataListPanel, title: true, titleContent: "2-2", commandBarComponents: [
 									{name: "previousC2-2", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextC2-2", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelC2-3", kind: "g.sample.DataListPanel", title: true, titleContent: "2-3", commandBarComponents: [
+								{name: "panelC2-3", kind: SampleDataListPanel, title: true, titleContent: "2-3", commandBarComponents: [
 									{name: "previousC2-3", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextC2-3", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]}
 							]},
 							{kind: PanelSet, components: [
-								{name: "panelC3-1", kind: "g.sample.DataListPanel", title: true, titleContent: "3-1", commandBarComponents: [
+								{name: "panelC3-1", kind: SampleDataListPanel, title: true, titleContent: "3-1", commandBarComponents: [
 									{name: "previousC3-1", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextC3-1", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 								]},
-								{name: "panelC3-2", kind: "g.sample.DataListPanel", title: true, titleContent: "3-2", commandBarComponents: [
+								{name: "panelC3-2", kind: SampleDataListPanel, title: true, titleContent: "3-2", commandBarComponents: [
 									{name: "previousC3-2", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextC3-2", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 								]},
-								{name: "panelC3-3", kind: "g.sample.DataListPanel", title: true, titleContent: "3-3", commandBarComponents: [
+								{name: "panelC3-3", kind: SampleDataListPanel, title: true, titleContent: "3-3", commandBarComponents: [
 									{name: "previousC3-3", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextC3-3", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 								]}
@@ -253,128 +255,26 @@ module.exports = kind({
 	create: kind.inherit(function(sup) {
 		return function() {
 			sup.apply(this, arguments);
-			this.collection = new Collection(this.data);
-			this.set("collection2", new Collection(this.generateRecords()));
+			this.set("collection", new Collection(this.generateRecords()));
 		};
 	}),
 	generateRecords: function () {
 		var records = [],
-			idx     = this.index || 0;
+			idx = 0,
+			title = ["Alejandra", "Marquez", "Barr", "Everett", "Crane", "Raymond", "Petersen", "Kristina", "Barbra", "Tracey"],
+			genre = ["Rock", "Pop", "Hiphop", "Rock", "Ballad"];
+
 		for (; records.length < 500; ++idx) {
-			var title = (idx % 8 === 0) ? " with long title" : "";
 			records.push({
-				text: "Item " + idx + title,
-				url: "@../assets/photo.png"
+				iconUrl: "@../assets/ic_dialog_alert.svg",
+				albumTitle: title[idx % title.length] + ((idx % 8 === 0) ? " with long title" : ""),
+				albumGenre: genre[idx % genre.length]
 			});
 		}
-		// update our internal index so it will always generate unique values
-		this.index = idx;
 		return records;
 	},
 	goBack: function(inSender, inEvent) {
 		global.history.go(-1);
 		return false;
-	},
-	data: [
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock.collection"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop.collection"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop.collection"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock.collection"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad.collection"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"}
-	]
+	}
 });

--- a/garnet/src/PanelSetDepthtInDepthSample.js
+++ b/garnet/src/PanelSetDepthtInDepthSample.js
@@ -10,7 +10,9 @@ var
 	g_ri = require('garnet/resolution'),
 	Scroller = require('garnet/Scroller'),
 	Panel = require('garnet/Panel'),
-	PanelSet = require('garnet/PanelSet');
+	PanelSet = require('garnet/PanelSet'),
+
+	SampleDataListPanel = require('./DataListSample').DataListPanel;
 
 module.exports = kind({
 	name: "g.sample.PanelSetDepthtInDepthSample",
@@ -29,43 +31,43 @@ module.exports = kind({
 					kind: PanelSet,
 					components: [
 						{kind: PanelSet, components: [
-							{name: "panelA1-1", kind: "g.sample.DataListPanel", title: true, titleContent: "1-1", commandBarComponents: [
+							{name: "panelA1-1", kind: SampleDataListPanel, title: true, titleContent: "1-1", commandBarComponents: [
 								{name: "previousA1-1", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 								{name: "nextA1-1", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 							]},
-							{name: "panelA1-2", kind: "g.sample.DataListPanel", title: true, titleContent: "1-2", commandBarComponents: [
+							{name: "panelA1-2", kind: SampleDataListPanel, title: true, titleContent: "1-2", commandBarComponents: [
 								{name: "previousA1-2", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 								{name: "nextA1-2", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 							]},
-							{name: "panelA1-3", kind: "g.sample.DataListPanel", title: true, titleContent: "1-3", commandBarComponents: [
+							{name: "panelA1-3", kind: SampleDataListPanel, title: true, titleContent: "1-3", commandBarComponents: [
 								{name: "previousA1-3", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 								{name: "nextA1-3", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 							]}
 						]},
 						{kind: PanelSet, components: [
-							{name: "panelA2-1", kind: "g.sample.DataListPanel", title: true, titleContent: "2-1", commandBarComponents: [
+							{name: "panelA2-1", kind: SampleDataListPanel, title: true, titleContent: "2-1", commandBarComponents: [
 								{name: "previousA2-1", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 								{name: "nextA2-1", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 							]},
-							{name: "panelA2-2", kind: "g.sample.DataListPanel", title: true, titleContent: "2-2", commandBarComponents: [
+							{name: "panelA2-2", kind: SampleDataListPanel, title: true, titleContent: "2-2", commandBarComponents: [
 								{name: "previousA2-2", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 								{name: "nextA2-2", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 							]},
-							{name: "panelA2-3", kind: "g.sample.DataListPanel", title: true, titleContent: "2-3", commandBarComponents: [
+							{name: "panelA2-3", kind: SampleDataListPanel, title: true, titleContent: "2-3", commandBarComponents: [
 								{name: "previousA2-3", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 								{name: "nextA2-3", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 							]}
 						]},
 						{kind: PanelSet, components: [
-							{name: "panelA3-1", kind: "g.sample.DataListPanel", title: true, titleContent: "3-1", commandBarComponents: [
+							{name: "panelA3-1", kind: SampleDataListPanel, title: true, titleContent: "3-1", commandBarComponents: [
 								{name: "previousA3-1", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 								{name: "nextA3-1", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 							]},
-							{name: "panelA3-2", kind: "g.sample.DataListPanel", title: true, titleContent: "3-2", commandBarComponents: [
+							{name: "panelA3-2", kind: SampleDataListPanel, title: true, titleContent: "3-2", commandBarComponents: [
 								{name: "previousA3-2", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 								{name: "nextA3-2", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 							]},
-							{name: "panelA3-3", kind: "g.sample.DataListPanel", title: true, titleContent: "3-3", commandBarComponents: [
+							{name: "panelA3-3", kind: SampleDataListPanel, title: true, titleContent: "3-3", commandBarComponents: [
 								{name: "previousA3-3", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 								{name: "nextA3-3", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 							]}
@@ -83,15 +85,15 @@ module.exports = kind({
 					components: [
 						{kind: Panel, components: [
 							{kind: PanelSet, components: [
-								{name: "panelB1-1", kind: "g.sample.DataListPanel", title: true, titleContent: "1-1", commandBarComponents: [
+								{name: "panelB1-1", kind: SampleDataListPanel, title: true, titleContent: "1-1", commandBarComponents: [
 									{name: "previousB1-1", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 									{name: "nextB1-1", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelB1-2", kind: "g.sample.DataListPanel", title: true, titleContent: "1-2", commandBarComponents: [
+								{name: "panelB1-2", kind: SampleDataListPanel, title: true, titleContent: "1-2", commandBarComponents: [
 									{name: "previousB1-2", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 									{name: "nextB1-2", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelB1-3", kind: "g.sample.DataListPanel", title: true, titleContent: "1-3", commandBarComponents: [
+								{name: "panelB1-3", kind: SampleDataListPanel, title: true, titleContent: "1-3", commandBarComponents: [
 									{name: "previousB1-3", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 									{name: "nextB1-3", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]}
@@ -99,15 +101,15 @@ module.exports = kind({
 						]},
 						{king: Panel, components: [
 							{kind: PanelSet, components: [
-								{name: "panelB2-1", kind: "g.sample.DataListPanel", title: true, titleContent: "2-1", commandBarComponents: [
+								{name: "panelB2-1", kind: SampleDataListPanel, title: true, titleContent: "2-1", commandBarComponents: [
 									{name: "previousB2-1", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextB2-1", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelB2-2", kind: "g.sample.DataListPanel", title: true, titleContent: "2-2", commandBarComponents: [
+								{name: "panelB2-2", kind: SampleDataListPanel, title: true, titleContent: "2-2", commandBarComponents: [
 									{name: "previousB2-2", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextB2-2", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelB2-3", kind: "g.sample.DataListPanel", title: true, titleContent: "2-3", commandBarComponents: [
+								{name: "panelB2-3", kind: SampleDataListPanel, title: true, titleContent: "2-3", commandBarComponents: [
 									{name: "previousB2-3", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextB2-3", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]}
@@ -115,15 +117,15 @@ module.exports = kind({
 						]},
 						{king: Panel, components: [
 							{kind: PanelSet, components: [
-								{name: "panelB3-1", kind: "g.sample.DataListPanel", title: true, titleContent: "3-1", commandBarComponents: [
+								{name: "panelB3-1", kind: SampleDataListPanel, title: true, titleContent: "3-1", commandBarComponents: [
 									{name: "previousB3-1", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextB3-1", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 								]},
-								{name: "panelB3-2", kind: "g.sample.DataListPanel", title: true, titleContent: "3-2", commandBarComponents: [
+								{name: "panelB3-2", kind: SampleDataListPanel, title: true, titleContent: "3-2", commandBarComponents: [
 									{name: "previousB3-2", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextB3-2", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 								]},
-								{name: "panelB3-3", kind: "g.sample.DataListPanel", title: true, titleContent: "3-3", commandBarComponents: [
+								{name: "panelB3-3", kind: SampleDataListPanel, title: true, titleContent: "3-3", commandBarComponents: [
 									{name: "previousB3-3", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextB3-3", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 								]}
@@ -141,43 +143,43 @@ module.exports = kind({
 					components: [
 						{name: "panelSetC", kind: PanelSet, components: [
 							{kind: PanelSet, components: [
-								{name: "panelC1-1", kind: "g.sample.DataListPanel", title: true, titleContent: "1-1", commandBarComponents: [
+								{name: "panelC1-1", kind: SampleDataListPanel, title: true, titleContent: "1-1", commandBarComponents: [
 									{name: "previousC1-1", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 									{name: "nextC1-1", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelC1-2", kind: "g.sample.DataListPanel", title: true, titleContent: "1-2", commandBarComponents: [
+								{name: "panelC1-2", kind: SampleDataListPanel, title: true, titleContent: "1-2", commandBarComponents: [
 									{name: "previousC1-2", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 									{name: "nextC1-2", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelC1-3", kind: "g.sample.DataListPanel", title: true, titleContent: "1-3", commandBarComponents: [
+								{name: "panelC1-3", kind: SampleDataListPanel, title: true, titleContent: "1-3", commandBarComponents: [
 									{name: "previousC1-3", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 									{name: "nextC1-3", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]}
 							]},
 							{kind: PanelSet, components: [
-								{name: "panelC2-1", kind: "g.sample.DataListPanel", title: true, titleContent: "2-1", commandBarComponents: [
+								{name: "panelC2-1", kind: SampleDataListPanel, title: true, titleContent: "2-1", commandBarComponents: [
 									{name: "previousC2-1", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextC2-1", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelC2-2", kind: "g.sample.DataListPanel", title: true, titleContent: "2-2", commandBarComponents: [
+								{name: "panelC2-2", kind: SampleDataListPanel, title: true, titleContent: "2-2", commandBarComponents: [
 									{name: "previousC2-2", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextC2-2", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelC2-3", kind: "g.sample.DataListPanel", title: true, titleContent: "2-3", commandBarComponents: [
+								{name: "panelC2-3", kind: SampleDataListPanel, title: true, titleContent: "2-3", commandBarComponents: [
 									{name: "previousC2-3", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextC2-3", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]}
 							]},
 							{kind: PanelSet, components: [
-								{name: "panelC3-1", kind: "g.sample.DataListPanel", title: true, titleContent: "3-1", commandBarComponents: [
+								{name: "panelC3-1", kind: SampleDataListPanel, title: true, titleContent: "3-1", commandBarComponents: [
 									{name: "previousC3-1", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextC3-1", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 								]},
-								{name: "panelC3-2", kind: "g.sample.DataListPanel", title: true, titleContent: "3-2", commandBarComponents: [
+								{name: "panelC3-2", kind: SampleDataListPanel, title: true, titleContent: "3-2", commandBarComponents: [
 									{name: "previousC3-2", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextC3-2", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 								]},
-								{name: "panelC3-3", kind: "g.sample.DataListPanel", title: true, titleContent: "3-3", commandBarComponents: [
+								{name: "panelC3-3", kind: SampleDataListPanel, title: true, titleContent: "3-3", commandBarComponents: [
 									{name: "previousC3-3", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextC3-3", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 								]}
@@ -249,128 +251,26 @@ module.exports = kind({
 	create: kind.inherit(function(sup) {
 		return function() {
 			sup.apply(this, arguments);
-			this.collection = new Collection(this.data);
-			this.set("collection2", new Collection(this.generateRecords()));
+			this.set("collection", new Collection(this.generateRecords()));
 		};
 	}),
 	generateRecords: function () {
 		var records = [],
-			idx     = this.index || 0;
+			idx = 0,
+			title = ["Alejandra", "Marquez", "Barr", "Everett", "Crane", "Raymond", "Petersen", "Kristina", "Barbra", "Tracey"],
+			genre = ["Rock", "Pop", "Hiphop", "Rock", "Ballad"];
+
 		for (; records.length < 500; ++idx) {
-			var title = (idx % 8 === 0) ? " with long title" : "";
 			records.push({
-				text: "Item " + idx + title,
-				url: "@../assets/photo.png"
+				iconUrl: "@../assets/ic_dialog_alert.svg",
+				albumTitle: title[idx % title.length] + ((idx % 8 === 0) ? " with long title" : ""),
+				albumGenre: genre[idx % genre.length]
 			});
 		}
-		// update our internal index so it will always generate unique values
-		this.index = idx;
 		return records;
 	},
 	goBack: function(inSender, inEvent) {
 		global.history.go(-1);
 		return false;
-	},
-	data: [
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock.collection"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop.collection"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop.collection"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock.collection"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad.collection"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"}
-	]
+	}
 });

--- a/garnet/src/PanelSetMoveInDepthSample.js
+++ b/garnet/src/PanelSetMoveInDepthSample.js
@@ -10,7 +10,9 @@ var
 	g_ri = require('garnet/resolution'),
 	Scroller = require('garnet/Scroller'),
 	Panel = require('garnet/Panel'),
-	PanelSet = require('garnet/PanelSet');
+	PanelSet = require('garnet/PanelSet'),
+
+	SampleDataListPanel = require('./DataListSample').DataListPanel;
 
 module.exports = kind({
 	name: "g.sample.PanelSetMoveInDepthSample",
@@ -29,43 +31,43 @@ module.exports = kind({
 					kind: PanelSet,
 					components: [
 						{kind: PanelSet, pageIndicator: true, effect: "move-transition", components: [
-							{name: "panelA1-1", kind: "g.sample.DataListPanel", title: true, titleContent: "1-1", commandBarComponents: [
+							{name: "panelA1-1", kind: SampleDataListPanel, title: true, titleContent: "1-1", commandBarComponents: [
 								{name: "previousA1-1", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 								{name: "nextA1-1", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 							]},
-							{name: "panelA1-2", kind: "g.sample.DataListPanel", title: true, titleContent: "1-2", commandBarComponents: [
+							{name: "panelA1-2", kind: SampleDataListPanel, title: true, titleContent: "1-2", commandBarComponents: [
 								{name: "previousA1-2", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 								{name: "nextA1-2", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 							]},
-							{name: "panelA1-3", kind: "g.sample.DataListPanel", title: true, titleContent: "1-3", commandBarComponents: [
+							{name: "panelA1-3", kind: SampleDataListPanel, title: true, titleContent: "1-3", commandBarComponents: [
 								{name: "previousA1-3", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 								{name: "nextA1-3", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 							]}
 						]},
 						{kind: PanelSet, pageIndicator: true, effect: "move-transition", components: [
-							{name: "panelA2-1", kind: "g.sample.DataListPanel", title: true, titleContent: "2-1", commandBarComponents: [
+							{name: "panelA2-1", kind: SampleDataListPanel, title: true, titleContent: "2-1", commandBarComponents: [
 								{name: "previousA2-1", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 								{name: "nextA2-1", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 							]},
-							{name: "panelA2-2", kind: "g.sample.DataListPanel", title: true, titleContent: "2-2", commandBarComponents: [
+							{name: "panelA2-2", kind: SampleDataListPanel, title: true, titleContent: "2-2", commandBarComponents: [
 								{name: "previousA2-2", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 								{name: "nextA2-2", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 							]},
-							{name: "panelA2-3", kind: "g.sample.DataListPanel", title: true, titleContent: "2-3", commandBarComponents: [
+							{name: "panelA2-3", kind: SampleDataListPanel, title: true, titleContent: "2-3", commandBarComponents: [
 								{name: "previousA2-3", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 								{name: "nextA2-3", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 							]}
 						]},
 						{kind: PanelSet, pageIndicator: true, effect: "move-transition", components: [
-							{name: "panelA3-1", kind: "g.sample.DataListPanel", title: true, titleContent: "3-1", commandBarComponents: [
+							{name: "panelA3-1", kind: SampleDataListPanel, title: true, titleContent: "3-1", commandBarComponents: [
 								{name: "previousA3-1", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 								{name: "nextA3-1", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 							]},
-							{name: "panelA3-2", kind: "g.sample.DataListPanel", title: true, titleContent: "3-2", commandBarComponents: [
+							{name: "panelA3-2", kind: SampleDataListPanel, title: true, titleContent: "3-2", commandBarComponents: [
 								{name: "previousA3-2", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 								{name: "nextA3-2", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 							]},
-							{name: "panelA3-3", kind: "g.sample.DataListPanel", title: true, titleContent: "3-3", commandBarComponents: [
+							{name: "panelA3-3", kind: SampleDataListPanel, title: true, titleContent: "3-3", commandBarComponents: [
 								{name: "previousA3-3", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 								{name: "nextA3-3", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 							]}
@@ -83,15 +85,15 @@ module.exports = kind({
 					components: [
 						{kind: Panel, components: [
 							{kind: PanelSet, pageIndicator: true, effect: "move-transition", components: [
-								{name: "panelB1-1", kind: "g.sample.DataListPanel", title: true, titleContent: "1-1", commandBarComponents: [
+								{name: "panelB1-1", kind: SampleDataListPanel, title: true, titleContent: "1-1", commandBarComponents: [
 									{name: "previousB1-1", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 									{name: "nextB1-1", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelB1-2", kind: "g.sample.DataListPanel", title: true, titleContent: "1-2", commandBarComponents: [
+								{name: "panelB1-2", kind: SampleDataListPanel, title: true, titleContent: "1-2", commandBarComponents: [
 									{name: "previousB1-2", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 									{name: "nextB1-2", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelB1-3", kind: "g.sample.DataListPanel", title: true, titleContent: "1-3", commandBarComponents: [
+								{name: "panelB1-3", kind: SampleDataListPanel, title: true, titleContent: "1-3", commandBarComponents: [
 									{name: "previousB1-3", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 									{name: "nextB1-3", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]}
@@ -99,15 +101,15 @@ module.exports = kind({
 						]},
 						{king: Panel, components: [
 							{kind: PanelSet, pageIndicator: true, effect: "move-transition", components: [
-								{name: "panelB2-1", kind: "g.sample.DataListPanel", title: true, titleContent: "2-1", commandBarComponents: [
+								{name: "panelB2-1", kind: SampleDataListPanel, title: true, titleContent: "2-1", commandBarComponents: [
 									{name: "previousB2-1", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextB2-1", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelB2-2", kind: "g.sample.DataListPanel", title: true, titleContent: "2-2", commandBarComponents: [
+								{name: "panelB2-2", kind: SampleDataListPanel, title: true, titleContent: "2-2", commandBarComponents: [
 									{name: "previousB2-2", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextB2-2", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelB2-3", kind: "g.sample.DataListPanel", title: true, titleContent: "2-3", commandBarComponents: [
+								{name: "panelB2-3", kind: SampleDataListPanel, title: true, titleContent: "2-3", commandBarComponents: [
 									{name: "previousB2-3", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextB2-3", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]}
@@ -115,15 +117,15 @@ module.exports = kind({
 						]},
 						{king: Panel, components: [
 							{kind: PanelSet, pageIndicator: true, effect: "move-transition", components: [
-								{name: "panelB3-1", kind: "g.sample.DataListPanel", title: true, titleContent: "3-1", commandBarComponents: [
+								{name: "panelB3-1", kind: SampleDataListPanel, title: true, titleContent: "3-1", commandBarComponents: [
 									{name: "previousB3-1", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextB3-1", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 								]},
-								{name: "panelB3-2", kind: "g.sample.DataListPanel", title: true, titleContent: "3-2", commandBarComponents: [
+								{name: "panelB3-2", kind: SampleDataListPanel, title: true, titleContent: "3-2", commandBarComponents: [
 									{name: "previousB3-2", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextB3-2", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 								]},
-								{name: "panelB3-3", kind: "g.sample.DataListPanel", title: true, titleContent: "3-3", commandBarComponents: [
+								{name: "panelB3-3", kind: SampleDataListPanel, title: true, titleContent: "3-3", commandBarComponents: [
 									{name: "previousB3-3", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextB3-3", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 								]}
@@ -141,43 +143,43 @@ module.exports = kind({
 					components: [
 						{name: "panelSetC", kind: PanelSet, components: [
 							{kind: PanelSet, pageIndicator: true, effect: "move-transition", components: [
-								{name: "panelC1-1", kind: "g.sample.DataListPanel", title: true, titleContent: "1-1", commandBarComponents: [
+								{name: "panelC1-1", kind: SampleDataListPanel, title: true, titleContent: "1-1", commandBarComponents: [
 									{name: "previousC1-1", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 									{name: "nextC1-1", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelC1-2", kind: "g.sample.DataListPanel", title: true, titleContent: "1-2", commandBarComponents: [
+								{name: "panelC1-2", kind: SampleDataListPanel, title: true, titleContent: "1-2", commandBarComponents: [
 									{name: "previousC1-2", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 									{name: "nextC1-2", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelC1-3", kind: "g.sample.DataListPanel", title: true, titleContent: "1-3", commandBarComponents: [
+								{name: "panelC1-3", kind: SampleDataListPanel, title: true, titleContent: "1-3", commandBarComponents: [
 									{name: "previousC1-3", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 									{name: "nextC1-3", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]}
 							]},
 							{kind: PanelSet, pageIndicator: true, effect: "move-transition", components: [
-								{name: "panelC2-1", kind: "g.sample.DataListPanel", title: true, titleContent: "2-1", commandBarComponents: [
+								{name: "panelC2-1", kind: SampleDataListPanel, title: true, titleContent: "2-1", commandBarComponents: [
 									{name: "previousC2-1", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextC2-1", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelC2-2", kind: "g.sample.DataListPanel", title: true, titleContent: "2-2", commandBarComponents: [
+								{name: "panelC2-2", kind: SampleDataListPanel, title: true, titleContent: "2-2", commandBarComponents: [
 									{name: "previousC2-2", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextC2-2", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelC2-3", kind: "g.sample.DataListPanel", title: true, titleContent: "2-3", commandBarComponents: [
+								{name: "panelC2-3", kind: SampleDataListPanel, title: true, titleContent: "2-3", commandBarComponents: [
 									{name: "previousC2-3", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextC2-3", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]}
 							]},
 							{kind: PanelSet, pageIndicator: true, effect: "move-transition", components: [
-								{name: "panelC3-1", kind: "g.sample.DataListPanel", title: true, titleContent: "3-1", commandBarComponents: [
+								{name: "panelC3-1", kind: SampleDataListPanel, title: true, titleContent: "3-1", commandBarComponents: [
 									{name: "previousC3-1", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextC3-1", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 								]},
-								{name: "panelC3-2", kind: "g.sample.DataListPanel", title: true, titleContent: "3-2", commandBarComponents: [
+								{name: "panelC3-2", kind: SampleDataListPanel, title: true, titleContent: "3-2", commandBarComponents: [
 									{name: "previousC3-2", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextC3-2", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 								]},
-								{name: "panelC3-3", kind: "g.sample.DataListPanel", title: true, titleContent: "3-3", commandBarComponents: [
+								{name: "panelC3-3", kind: SampleDataListPanel, title: true, titleContent: "3-3", commandBarComponents: [
 									{name: "previousC3-3", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextC3-3", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 								]}
@@ -249,128 +251,26 @@ module.exports = kind({
 	create: kind.inherit(function(sup) {
 		return function() {
 			sup.apply(this, arguments);
-			this.collection = new Collection(this.data);
-			this.set("collection2", new Collection(this.generateRecords()));
+			this.set("collection", new Collection(this.generateRecords()));
 		};
 	}),
 	generateRecords: function () {
 		var records = [],
-			idx     = this.index || 0;
+			idx = 0,
+			title = ["Alejandra", "Marquez", "Barr", "Everett", "Crane", "Raymond", "Petersen", "Kristina", "Barbra", "Tracey"],
+			genre = ["Rock", "Pop", "Hiphop", "Rock", "Ballad"];
+
 		for (; records.length < 500; ++idx) {
-			var title = (idx % 8 === 0) ? " with long title" : "";
 			records.push({
-				text: "Item " + idx + title,
-				url: "@../assets/photo.png"
+				iconUrl: "@../assets/ic_dialog_alert.svg",
+				albumTitle: title[idx % title.length] + ((idx % 8 === 0) ? " with long title" : ""),
+				albumGenre: genre[idx % genre.length]
 			});
 		}
-		// update our internal index so it will always generate unique values
-		this.index = idx;
 		return records;
 	},
 	goBack: function(inSender, inEvent) {
 		global.history.go(-1);
 		return false;
-	},
-	data: [
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock.collection"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop.collection"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop.collection"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock.collection"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad.collection"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"}
-	]
+	}
 });

--- a/garnet/src/PanelSetMoveInMoveSample.js
+++ b/garnet/src/PanelSetMoveInMoveSample.js
@@ -10,7 +10,9 @@ var
 	g_ri = require('garnet/resolution'),
 	Scroller = require('garnet/Scroller'),
 	Panel = require('garnet/Panel'),
-	PanelSet = require('garnet/PanelSet');
+	PanelSet = require('garnet/PanelSet'),
+
+	SampleDataListPanel = require('./DataListSample').DataListPanel;
 
 module.exports = kind({
 	name: "g.sample.PanelSetMoveInMoveSample",
@@ -31,43 +33,43 @@ module.exports = kind({
 					pageIndicator: true,
 					components: [
 						{kind: PanelSet, pageIndicator: true, effect: "move-transition", components: [
-							{name: "panelA1-1", kind: "g.sample.DataListPanel", title: true, titleContent: "1-1", commandBarComponents: [
+							{name: "panelA1-1", kind: SampleDataListPanel, title: true, titleContent: "1-1", commandBarComponents: [
 								{name: "previousA1-1", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 								{name: "nextA1-1", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 							]},
-							{name: "panelA1-2", kind: "g.sample.DataListPanel", title: true, titleContent: "1-2", commandBarComponents: [
+							{name: "panelA1-2", kind: SampleDataListPanel, title: true, titleContent: "1-2", commandBarComponents: [
 								{name: "previousA1-2", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 								{name: "nextA1-2", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 							]},
-							{name: "panelA1-3", kind: "g.sample.DataListPanel", title: true, titleContent: "1-3", commandBarComponents: [
+							{name: "panelA1-3", kind: SampleDataListPanel, title: true, titleContent: "1-3", commandBarComponents: [
 								{name: "previousA1-3", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 								{name: "nextA1-3", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 							]}
 						]},
 						{kind: PanelSet, pageIndicator: true, effect: "move-transition", components: [
-							{name: "panelA2-1", kind: "g.sample.DataListPanel", title: true, titleContent: "2-1", commandBarComponents: [
+							{name: "panelA2-1", kind: SampleDataListPanel, title: true, titleContent: "2-1", commandBarComponents: [
 								{name: "previousA2-1", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 								{name: "nextA2-1", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 							]},
-							{name: "panelA2-2", kind: "g.sample.DataListPanel", title: true, titleContent: "2-2", commandBarComponents: [
+							{name: "panelA2-2", kind: SampleDataListPanel, title: true, titleContent: "2-2", commandBarComponents: [
 								{name: "previousA2-2", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 								{name: "nextA2-2", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 							]},
-							{name: "panelA2-3", kind: "g.sample.DataListPanel", title: true, titleContent: "2-3", commandBarComponents: [
+							{name: "panelA2-3", kind: SampleDataListPanel, title: true, titleContent: "2-3", commandBarComponents: [
 								{name: "previousA2-3", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 								{name: "nextA2-3", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 							]}
 						]},
 						{kind: PanelSet, pageIndicator: true, effect: "move-transition", components: [
-							{name: "panelA3-1", kind: "g.sample.DataListPanel", title: true, titleContent: "3-1", commandBarComponents: [
+							{name: "panelA3-1", kind: SampleDataListPanel, title: true, titleContent: "3-1", commandBarComponents: [
 								{name: "previousA3-1", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 								{name: "nextA3-1", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 							]},
-							{name: "panelA3-2", kind: "g.sample.DataListPanel", title: true, titleContent: "3-2", commandBarComponents: [
+							{name: "panelA3-2", kind: SampleDataListPanel, title: true, titleContent: "3-2", commandBarComponents: [
 								{name: "previousA3-2", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 								{name: "nextA3-2", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 							]},
-							{name: "panelA3-3", kind: "g.sample.DataListPanel", title: true, titleContent: "3-3", commandBarComponents: [
+							{name: "panelA3-3", kind: SampleDataListPanel, title: true, titleContent: "3-3", commandBarComponents: [
 								{name: "previousA3-3", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 								{name: "nextA3-3", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 							]}
@@ -87,15 +89,15 @@ module.exports = kind({
 					components: [
 						{kind: Panel, pageIndicatorFadeOut: false, components: [
 							{kind: PanelSet, pageIndicator: true, effect: "move-transition", components: [
-								{name: "panelB1-1", kind: "g.sample.DataListPanel", title: true, titleContent: "1-1", commandBarComponents: [
+								{name: "panelB1-1", kind: SampleDataListPanel, title: true, titleContent: "1-1", commandBarComponents: [
 									{name: "previousB1-1", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 									{name: "nextB1-1", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelB1-2", kind: "g.sample.DataListPanel", title: true, titleContent: "1-2", commandBarComponents: [
+								{name: "panelB1-2", kind: SampleDataListPanel, title: true, titleContent: "1-2", commandBarComponents: [
 									{name: "previousB1-2", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 									{name: "nextB1-2", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelB1-3", kind: "g.sample.DataListPanel", title: true, titleContent: "1-3", commandBarComponents: [
+								{name: "panelB1-3", kind: SampleDataListPanel, title: true, titleContent: "1-3", commandBarComponents: [
 									{name: "previousB1-3", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 									{name: "nextB1-3", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]}
@@ -103,15 +105,15 @@ module.exports = kind({
 						]},
 						{king: Panel, pageIndicatorFadeOut: false, components: [
 							{kind: PanelSet, pageIndicator: true, effect: "move-transition", components: [
-								{name: "panelB2-1", kind: "g.sample.DataListPanel", title: true, titleContent: "2-1", commandBarComponents: [
+								{name: "panelB2-1", kind: SampleDataListPanel, title: true, titleContent: "2-1", commandBarComponents: [
 									{name: "previousB2-1", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextB2-1", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelB2-2", kind: "g.sample.DataListPanel", title: true, titleContent: "2-2", commandBarComponents: [
+								{name: "panelB2-2", kind: SampleDataListPanel, title: true, titleContent: "2-2", commandBarComponents: [
 									{name: "previousB2-2", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextB2-2", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelB2-3", kind: "g.sample.DataListPanel", title: true, titleContent: "2-3", commandBarComponents: [
+								{name: "panelB2-3", kind: SampleDataListPanel, title: true, titleContent: "2-3", commandBarComponents: [
 									{name: "previousB2-3", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextB2-3", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]}
@@ -119,15 +121,15 @@ module.exports = kind({
 						]},
 						{king: Panel, pageIndicatorFadeOut: false, components: [
 							{kind: PanelSet, pageIndicator: true, effect: "move-transition", components: [
-								{name: "panelB3-1", kind: "g.sample.DataListPanel", title: true, titleContent: "3-1", commandBarComponents: [
+								{name: "panelB3-1", kind: SampleDataListPanel, title: true, titleContent: "3-1", commandBarComponents: [
 									{name: "previousB3-1", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextB3-1", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 								]},
-								{name: "panelB3-2", kind: "g.sample.DataListPanel", title: true, titleContent: "3-2", commandBarComponents: [
+								{name: "panelB3-2", kind: SampleDataListPanel, title: true, titleContent: "3-2", commandBarComponents: [
 									{name: "previousB3-2", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextB3-2", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 								]},
-								{name: "panelB3-3", kind: "g.sample.DataListPanel", title: true, titleContent: "3-3", commandBarComponents: [
+								{name: "panelB3-3", kind: SampleDataListPanel, title: true, titleContent: "3-3", commandBarComponents: [
 									{name: "previousB3-3", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextB3-3", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 								]}
@@ -145,43 +147,43 @@ module.exports = kind({
 					components: [
 						{name: "panelSetC", kind: PanelSet, effect: "move-transition", pageIndicator: true, components: [
 							{kind: PanelSet, pageIndicator: true, effect: "move-transition", components: [
-								{name: "panelC1-1", kind: "g.sample.DataListPanel", title: true, titleContent: "1-1", commandBarComponents: [
+								{name: "panelC1-1", kind: SampleDataListPanel, title: true, titleContent: "1-1", commandBarComponents: [
 									{name: "previousC1-1", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 									{name: "nextC1-1", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelC1-2", kind: "g.sample.DataListPanel", title: true, titleContent: "1-2", commandBarComponents: [
+								{name: "panelC1-2", kind: SampleDataListPanel, title: true, titleContent: "1-2", commandBarComponents: [
 									{name: "previousC1-2", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 									{name: "nextC1-2", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelC1-3", kind: "g.sample.DataListPanel", title: true, titleContent: "1-3", commandBarComponents: [
+								{name: "panelC1-3", kind: SampleDataListPanel, title: true, titleContent: "1-3", commandBarComponents: [
 									{name: "previousC1-3", src: "@../assets/btn_command_previous.svg", disabled: true, ontap: "previousTap"},
 									{name: "nextC1-3", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]}
 							]},
 							{kind: PanelSet, pageIndicator: true, effect: "move-transition", components: [
-								{name: "panelC2-1", kind: "g.sample.DataListPanel", title: true, titleContent: "2-1", commandBarComponents: [
+								{name: "panelC2-1", kind: SampleDataListPanel, title: true, titleContent: "2-1", commandBarComponents: [
 									{name: "previousC2-1", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextC2-1", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelC2-2", kind: "g.sample.DataListPanel", title: true, titleContent: "2-2", commandBarComponents: [
+								{name: "panelC2-2", kind: SampleDataListPanel, title: true, titleContent: "2-2", commandBarComponents: [
 									{name: "previousC2-2", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextC2-2", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]},
-								{name: "panelC2-3", kind: "g.sample.DataListPanel", title: true, titleContent: "2-3", commandBarComponents: [
+								{name: "panelC2-3", kind: SampleDataListPanel, title: true, titleContent: "2-3", commandBarComponents: [
 									{name: "previousC2-3", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextC2-3", src: "@../assets/btn_command_next.svg", ontap: "nextTap"}
 								]}
 							]},
 							{kind: PanelSet, pageIndicator: true, effect: "move-transition", components: [
-								{name: "panelC3-1", kind: "g.sample.DataListPanel", title: true, titleContent: "3-1", commandBarComponents: [
+								{name: "panelC3-1", kind: SampleDataListPanel, title: true, titleContent: "3-1", commandBarComponents: [
 									{name: "previousC3-1", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextC3-1", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 								]},
-								{name: "panelC3-2", kind: "g.sample.DataListPanel", title: true, titleContent: "3-2", commandBarComponents: [
+								{name: "panelC3-2", kind: SampleDataListPanel, title: true, titleContent: "3-2", commandBarComponents: [
 									{name: "previousC3-2", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextC3-2", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 								]},
-								{name: "panelC3-3", kind: "g.sample.DataListPanel", title: true, titleContent: "3-3", commandBarComponents: [
+								{name: "panelC3-3", kind: SampleDataListPanel, title: true, titleContent: "3-3", commandBarComponents: [
 									{name: "previousC3-3", src: "@../assets/btn_command_previous.svg", ontap: "previousTap"},
 									{name: "nextC3-3", src: "@../assets/btn_command_next.svg", disabled: true, ontap: "nextTap"}
 								]}
@@ -253,128 +255,26 @@ module.exports = kind({
 	create: kind.inherit(function(sup) {
 		return function() {
 			sup.apply(this, arguments);
-			this.collection = new Collection(this.data);
-			this.set("collection2", new Collection(this.generateRecords()));
+			this.set("collection", new Collection(this.generateRecords()));
 		};
 	}),
 	generateRecords: function () {
 		var records = [],
-			idx     = this.index || 0;
+			idx = 0,
+			title = ["Alejandra", "Marquez", "Barr", "Everett", "Crane", "Raymond", "Petersen", "Kristina", "Barbra", "Tracey"],
+			genre = ["Rock", "Pop", "Hiphop", "Rock", "Ballad"];
+
 		for (; records.length < 500; ++idx) {
-			var title = (idx % 8 === 0) ? " with long title" : "";
 			records.push({
-				text: "Item " + idx + title,
-				url: "@../assets/photo.png"
+				iconUrl: "@../assets/ic_dialog_alert.svg",
+				albumTitle: title[idx % title.length] + ((idx % 8 === 0) ? " with long title" : ""),
+				albumGenre: genre[idx % genre.length]
 			});
 		}
-		// update our internal index so it will always generate unique values
-		this.index = idx;
 		return records;
 	},
 	goBack: function(inSender, inEvent) {
 		global.history.go(-1);
 		return false;
-	},
-	data: [
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock.collection"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop.collection"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop.collection"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock.collection"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad.collection"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"}
-	]
+	}
 });

--- a/garnet/src/PanelSetPanelSample.js
+++ b/garnet/src/PanelSetPanelSample.js
@@ -9,7 +9,9 @@ var
 	g = require('garnet'),
 	Scroller = require('garnet/Scroller'),
 	Panel = require('garnet/Panel'),
-	PanelSet = require('garnet/PanelSet');
+	PanelSet = require('garnet/PanelSet'),
+
+	SampleDataListPanel = require('./DataListSample').DataListPanel;
 
 module.exports = kind({
 	name: "g.sample.PanelSetPanelSample",
@@ -27,10 +29,10 @@ module.exports = kind({
 					kind: PanelSet,
 					components: [
 						{kind: Panel, name: "p3", components: [
-							{name: "panelA1-1", kind: "g.sample.DataListPanel", title: true, titleContent: "1-1"}
+							{name: "panelA1-1", kind: SampleDataListPanel, title: true, titleContent: "1-1"}
 						]},
-						{name: "panelA2", kind: "g.sample.DataListPanel", title: true, titleContent: "2"},
-						{name: "panelA3", kind: "g.sample.DataListPanel", title: true, titleContent: "3"}
+						{name: "panelA2", kind: SampleDataListPanel, title: true, titleContent: "2"},
+						{name: "panelA3", kind: SampleDataListPanel, title: true, titleContent: "3"}
 					]
 				}
 			]
@@ -42,9 +44,9 @@ module.exports = kind({
 					kind: Panel,
 					components: [
 						{kind: PanelSet, components: [
-							{name: "panelB1-1", kind: "g.sample.DataListPanel", title: true, titleContent: "1-1"},
-							{name: "panelB1-2", kind: "g.sample.DataListPanel", title: true, titleContent: "1-2"},
-							{name: "panelB1-3", kind: "g.sample.DataListPanel", title: true, titleContent: "1-3"}
+							{name: "panelB1-1", kind: SampleDataListPanel, title: true, titleContent: "1-1"},
+							{name: "panelB1-2", kind: SampleDataListPanel, title: true, titleContent: "1-2"},
+							{name: "panelB1-3", kind: SampleDataListPanel, title: true, titleContent: "1-3"}
 						]}
 					]
 				}
@@ -58,9 +60,9 @@ module.exports = kind({
 					components: [
 						{kind: Panel, components: [
 							{kind: PanelSet, components: [
-								{name: "panelC1-1", kind: "g.sample.DataListPanel", title: true, titleContent: "1-1"},
-								{name: "panelC1-2", kind: "g.sample.DataListPanel", title: true, titleContent: "1-2"},
-								{name: "panelC1-3", kind: "g.sample.DataListPanel", title: true, titleContent: "1-3"}
+								{name: "panelC1-1", kind: SampleDataListPanel, title: true, titleContent: "1-1"},
+								{name: "panelC1-2", kind: SampleDataListPanel, title: true, titleContent: "1-2"},
+								{name: "panelC1-3", kind: SampleDataListPanel, title: true, titleContent: "1-3"}
 							]}
 						]}
 					]
@@ -79,10 +81,10 @@ module.exports = kind({
 					pageIndicator: true,
 					components: [
 						{kind: Panel, pageIndicatorFadeOut: false, name: "p3", components: [
-							{name: "panelD1-1", kind: "g.sample.DataListPanel", title: true, titleContent: "1-1"}
+							{name: "panelD1-1", kind: SampleDataListPanel, title: true, titleContent: "1-1"}
 						]},
-						{name: "panelD2", kind: "g.sample.DataListPanel", title: true, titleContent: "2"},
-						{name: "panelD3", kind: "g.sample.DataListPanel", title: true, titleContent: "3"}
+						{name: "panelD2", kind: SampleDataListPanel, title: true, titleContent: "2"},
+						{name: "panelD3", kind: SampleDataListPanel, title: true, titleContent: "3"}
 					]
 				}
 			]
@@ -94,9 +96,9 @@ module.exports = kind({
 					kind: Panel,
 					components: [
 						{kind: PanelSet, effect: "move-transition", pageIndicator: true, components: [
-							{name: "panelE1-1", kind: "g.sample.DataListPanel", title: true, titleContent: "1-1"},
-							{name: "panelE1-2", kind: "g.sample.DataListPanel", title: true, titleContent: "1-2"},
-							{name: "panelE1-3", kind: "g.sample.DataListPanel", title: true, titleContent: "1-3"}
+							{name: "panelE1-1", kind: SampleDataListPanel, title: true, titleContent: "1-1"},
+							{name: "panelE1-2", kind: SampleDataListPanel, title: true, titleContent: "1-2"},
+							{name: "panelE1-3", kind: SampleDataListPanel, title: true, titleContent: "1-3"}
 						]}
 					]
 				}
@@ -110,9 +112,9 @@ module.exports = kind({
 					components: [
 						{kind: Panel, components: [
 							{kind: PanelSet, effect: "move-transition", pageIndicator: true, components: [
-								{name: "panelF1-1", kind: "g.sample.DataListPanel", title: true, titleContent: "1-1"},
-								{name: "panelF1-2", kind: "g.sample.DataListPanel", title: true, titleContent: "1-2"},
-								{name: "panelF1-3", kind: "g.sample.DataListPanel", title: true, titleContent: "1-3"}
+								{name: "panelF1-1", kind: SampleDataListPanel, title: true, titleContent: "1-1"},
+								{name: "panelF1-2", kind: SampleDataListPanel, title: true, titleContent: "1-2"},
+								{name: "panelF1-3", kind: SampleDataListPanel, title: true, titleContent: "1-3"}
 							]}
 						]}
 					]
@@ -172,128 +174,26 @@ module.exports = kind({
 	create: kind.inherit(function(sup) {
 		return function() {
 			sup.apply(this, arguments);
-			this.collection = new Collection(this.data);
-			this.set("collection2", new Collection(this.generateRecords()));
+			this.set("collection", new Collection(this.generateRecords()));
 		};
 	}),
 	generateRecords: function () {
 		var records = [],
-			idx     = this.index || 0;
+			idx = 0,
+			title = ["Alejandra", "Marquez", "Barr", "Everett", "Crane", "Raymond", "Petersen", "Kristina", "Barbra", "Tracey"],
+			genre = ["Rock", "Pop", "Hiphop", "Rock", "Ballad"];
+
 		for (; records.length < 500; ++idx) {
-			var title = (idx % 8 === 0) ? " with long title" : "";
 			records.push({
-				text: "Item " + idx + title,
-				url: "@../assets/photo.png"
+				iconUrl: "@../assets/ic_dialog_alert.svg",
+				albumTitle: title[idx % title.length] + ((idx % 8 === 0) ? " with long title" : ""),
+				albumGenre: genre[idx % genre.length]
 			});
 		}
-		// update our internal index so it will always generate unique values
-		this.index = idx;
 		return records;
 	},
 	goBack: function(inSender, inEvent) {
 		global.history.go(-1);
 		return false;
-	},
-	data: [
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock.collection"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop.collection"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop.collection"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock.collection"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad.collection"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"}
-	]
+	}
 });

--- a/garnet/src/PanelSetPanelSample.js
+++ b/garnet/src/PanelSetPanelSample.js
@@ -28,7 +28,7 @@ module.exports = kind({
 				{
 					kind: PanelSet,
 					components: [
-						{kind: Panel, name: "p3", components: [
+						{kind: Panel, components: [
 							{name: "panelA1-1", kind: SampleDataListPanel, title: true, titleContent: "1-1"}
 						]},
 						{name: "panelA2", kind: SampleDataListPanel, title: true, titleContent: "2"},
@@ -80,7 +80,7 @@ module.exports = kind({
 					effect: "move-transition",
 					pageIndicator: true,
 					components: [
-						{kind: Panel, pageIndicatorFadeOut: false, name: "p3", components: [
+						{kind: Panel, pageIndicatorFadeOut: false, components: [
 							{name: "panelD1-1", kind: SampleDataListPanel, title: true, titleContent: "1-1"}
 						]},
 						{name: "panelD2", kind: SampleDataListPanel, title: true, titleContent: "2"},

--- a/garnet/src/PanelSetSample.js
+++ b/garnet/src/PanelSetSample.js
@@ -10,7 +10,11 @@ var
 	Panel = require('garnet/Panel'),
 	TimePickerPanel = require('garnet/TimePickerPanel'),
 	DatePickerPanel = require('garnet/DatePickerPanel'),
-	PanelSet = require('garnet/PanelSet');
+	PanelSet = require('garnet/PanelSet'),
+
+	SampleDataListPanel = require('./DataListSample').DataListPanel,
+	SampleDataGridListPanel = require('./DataGridListSample').DataGridListPanel,
+	SampleWheelSliderController = require('./WheelSliderControllerSample').WheelSliderControllerPanel;
 
 module.exports = kind({
 	name: "g.sample.PanelSetSample",
@@ -36,11 +40,11 @@ module.exports = kind({
 							{content: "Text 4", style: "text-align: center;"},
 							{content: "Text 5", style: "text-align: center;"}
 						]},
-						{name: "panel2", kind: "g.sample.DataListPanel", style: "background-color: #000000;"},
-						{name: "panel3", kind: "g.sample.DataGridListPanel", style: "background-color: #000000;"},
+						{name: "panel2", kind: SampleDataListPanel, style: "background-color: #000000;"},
+						{name: "panel3", kind: SampleDataGridListPanel, style: "background-color: #000000;"},
 						{name: "panel4", kind: TimePickerPanel},
 						{name: "panel5", kind : DatePickerPanel},
-						{kind: "g.sample.WheelSliderController"}
+						{kind: SampleWheelSliderController}
 					]
 				}
 			]
@@ -65,11 +69,11 @@ module.exports = kind({
 						{content: "Text 4", style: "text-align: center;"},
 						{content: "Text 5", style: "text-align: center;"}
 					]},
-					{name: "listPanel1", kind: "g.sample.DataListPanel", style: "background-color: #000000;"},
-					{name: "listPanel2", kind: "g.sample.DataGridListPanel", style: "background-color: #000000;"},
+					{name: "listPanel1", kind: SampleDataListPanel, style: "background-color: #000000;"},
+					{name: "listPanel2", kind: SampleDataGridListPanel, style: "background-color: #000000;"},
 					{name: "timePickerPanel1", kind: TimePickerPanel, pageIndicatorDisable: true},
 					{name: "DatePickerPanel1", kind : DatePickerPanel, pageIndicatorDisable: true},
-					{kind: "g.sample.WheelSliderController", pageIndicatorDisable: true}
+					{kind: SampleWheelSliderController, pageIndicatorDisable: true}
 				]
 			}
 		]},
@@ -84,13 +88,28 @@ module.exports = kind({
 	create: kind.inherit(function(sup) {
 		return function() {
 			sup.apply(this, arguments);
-			this.collection = new Collection(this.data);
-			this.set("collection2", new Collection(this.generateRecords()));
+			this.set("collection", new Collection(this.generateRecords()));
+			this.set("collection2", new Collection(this.generateRecords2()));
 		};
 	}),
 	generateRecords: function () {
 		var records = [],
-			idx     = this.index || 0;
+			idx = 0,
+			title = ["Alejandra", "Marquez", "Barr", "Everett", "Crane", "Raymond", "Petersen", "Kristina", "Barbra", "Tracey"],
+			genre = ["Rock", "Pop", "Hiphop", "Rock", "Ballad"];
+
+		for (; records.length < 500; ++idx) {
+			records.push({
+				iconUrl: "@../assets/ic_dialog_alert.svg",
+				albumTitle: title[idx % title.length] + ((idx % 8 === 0) ? " with long title" : ""),
+				albumGenre: genre[idx % genre.length]
+			});
+		}
+		return records;
+	},
+	generateRecords2: function () {
+		var records = [],
+			idx = 0;
 		for (; records.length < 500; ++idx) {
 			var title = (idx % 8 === 0) ? " with long title" : "";
 			records.push({
@@ -98,114 +117,10 @@ module.exports = kind({
 				url: "@../assets/photo.png"
 			});
 		}
-		// update our internal index so it will always generate unique values
-		this.index = idx;
 		return records;
 	},
 	goBack: function(inSender, inEvent) {
 		global.history.go(-1);
 		return false;
-	},
-	data: [
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Alejandra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Marquez", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barr", albumGenre: "Hiphop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Everett", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Crane", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Raymond", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Petersen", albumGenre: "Pop"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Kristina", albumGenre: "Ballad"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Barbra", albumGenre: "Rock"},
-		{iconUrl: "@../assets/ic_dialog_alert.svg", albumTitle: "Tracey", albumGenre: "Hiphop"}
-	]
+	}
 });

--- a/garnet/src/PickerPanelSample.js
+++ b/garnet/src/PickerPanelSample.js
@@ -9,10 +9,10 @@ var
 	g = require('garnet'),
 	FormPickerButton = require('garnet/FormPickerButton'),
 	Panel = require('garnet/Panel'),
-	PickerPanel = require('garnet/PickerPanel'),
+	GarnetPickerPanel = require('garnet/PickerPanel'),
 	Popup = require('garnet/Popup');
 
-kind({
+var SamplePickerPanel = kind({
 	name: "g.sample.PickerPanel",
 	kind: Panel,
 	events: {
@@ -23,7 +23,7 @@ kind({
 			{name: "pickerButton", kind: FormPickerButton, style: "top: " + ri.scale(134) + "px;", ontap: "showPopup", content: "Click here!"},
 			{name: "pickerPopup", kind: Popup, effect: "depth-transition", components: [
 				{style: "background-color: #000000;position: relative;", classes: "g-common-width-height-fit g-layout-absolute-wrapper", components: [
-					{name: "pickerPanel", kind: PickerPanel, title: true, titleContent: "PickerTitle", ontap: "tapItem"}
+					{name: "pickerPanel", kind: GarnetPickerPanel, title: true, titleContent: "PickerTitle", ontap: "tapItem"}
 				]}
 			]}
 		]}
@@ -80,7 +80,7 @@ module.exports = kind({
 		{content: "< PickerPanel Sample", classes: "g-sample-header", ontap: "goBack"},
 
 		{content: "PickerPanel", classes: "g-sample-subheader"},
-		{kind: "g.sample.PickerPanel", style: "position: relative;", onResult: "result"},
+		{kind: SamplePickerPanel, style: "position: relative;", onResult: "result"},
 
 		{src: "@../assets/btn_command_next.svg", classes: "g-sample-result", components: [
 			{content: "Result", classes: "g-sample-subheader"},

--- a/garnet/src/PopupSample.js
+++ b/garnet/src/PopupSample.js
@@ -13,7 +13,7 @@ var
 	Popup = require('garnet/Popup'),
 	Scroller = require('garnet/Scroller');
 
-kind({
+var PopupPanel = kind({
 	name: "g.sample.PopupPanel",
 	kind: Panel,
 	events: {
@@ -83,7 +83,7 @@ module.exports = kind({
 		{content: "< Popup Sample", classes: "g-sample-header", ontap: "goBack"},
 
 		{content: "Popup with contents", classes: "g-sample-subheader"},
-		{kind: "g.sample.PopupPanel", style: "position: relative;", onResult: "result"},
+		{kind: PopupPanel, style: "position: relative;", onResult: "result"},
 
 		{src: "@../assets/btn_command_next.svg", classes: "g-sample-result", components: [
 			{content: "Result", classes: "g-sample-subheader"},

--- a/garnet/src/ProgressBarSample.js
+++ b/garnet/src/ProgressBarSample.js
@@ -16,7 +16,7 @@ var
 	Panel = require('garnet/Panel'),
 	ProgressBar = require('garnet/ProgressBar');
 
-kind({
+var ProgressBarPanel = kind({
 	name: "g.sample.ProgressBarPanel",
 	kind: Panel,
 	handlers: {
@@ -100,7 +100,7 @@ module.exports = kind({
 		{content: "< Progress Bar Sample", classes: "g-sample-header", ontap: "goBack"},
 
 		{content: "ProgressBars", classes: "g-sample-subheader"},
-		{kind: "g.sample.ProgressBarPanel", style: "position: relative;"}
+		{kind: ProgressBarPanel, style: "position: relative;"}
 	],
 	goBack: function(inSender, inEvent) {
 		global.history.go(-1);

--- a/garnet/src/SpinnerSample.js
+++ b/garnet/src/SpinnerSample.js
@@ -9,7 +9,7 @@ var
 	Spinner = require('garnet/Spinner'),
 	Panel = require('garnet/Panel');
 
-kind({
+var SpinnerPanel = kind({
 	name: "g.sample.SpinnerPanel",
 	kind: Panel,
 	style: "border-radius: 50%; background-color: #000000;",
@@ -20,7 +20,7 @@ kind({
 	]
 });
 
-kind({
+var TextSpinnerPanel = kind({
 	name: "g.sample.TextSpinnerPanel",
 	kind: Panel,
 	style: "border-radius: 50%; background-color: #000000;",
@@ -39,12 +39,12 @@ module.exports = kind({
 		{style: "position: relative; height: 100%", components: [
 			{
 				name: "spinnerPanel",
-				kind: "g.sample.SpinnerPanel",
+				kind: SpinnerPanel,
 				style: "background-color: #000000; position: relative; display: inline-block; overflow: hidden;"
 			},
 			{
 				name: "textSpinnerPanel",
-				kind: "g.sample.TextSpinnerPanel",
+				kind: TextSpinnerPanel,
 				style: "background-color: #000000; position: relative; display: inline-block; overflow: hidden;"
 			}
 		]}

--- a/garnet/src/TimePickerPanelSample.js
+++ b/garnet/src/TimePickerPanelSample.js
@@ -6,12 +6,12 @@ var
 	ri = require('enyo/resolution'),
 
 	g = require('garnet'),
-	TimePickerPanel = require('garnet/TimePickerPanel'),
+	GarnetTimePickerPanel = require('garnet/TimePickerPanel'),
 	Panel = require('garnet/Panel');
 
 var TimePicker12Panel = kind({
 	name: "g.sample.TimePicker12Panel",
-	kind: TimePickerPanel,
+	kind: GarnetTimePickerPanel,
 	handlers: {
 		onOK: "tapOK",
 		onCancel: "tapCancel"
@@ -32,7 +32,7 @@ var TimePicker12Panel = kind({
 
 var TimePicker24Panel = kind({
 	name: "g.sample.TimePicker24Panel",
-	kind: TimePickerPanel,
+	kind: GarnetTimePickerPanel,
 	handlers: {
 		onOK: "onOK",
 		onCancel: "onCancel"

--- a/garnet/src/TitleSample.js
+++ b/garnet/src/TitleSample.js
@@ -10,7 +10,7 @@ var
 	Scroller = require('garnet/Scroller'),
 	Panel = require('garnet/Panel');
 
-kind({
+var TitlePanel = kind({
 	name: "g.sample.TitlePanel",
 	kind: Panel,
 	handlers: {
@@ -52,7 +52,7 @@ module.exports = kind({
 		{content: "< Title ( + BodyText ) Sample", classes: "g-sample-header", ontap: "goBack"},
 
 		{content: "Title with a scrollable content area", classes: "g-sample-subheader"},
-		{kind: "g.sample.TitlePanel", style: "position: relative;", onResult: "result"},
+		{kind: TitlePanel, style: "position: relative;", onResult: "result"},
 
 		{src: "@../assets/btn_command_next.svg", classes: "g-sample-result", components: [
 			{content: "Result", classes: "g-sample-subheader"},

--- a/garnet/src/ToastSample.js
+++ b/garnet/src/ToastSample.js
@@ -10,7 +10,7 @@ var
 	Toast = require('garnet/Toast'),
 	Panel = require('garnet/Panel');
 
-kind({
+var ToastPanel = kind({
 	name: "g.sample.ToastPanel",
 	kind: Panel,
 	classes: "g-layout-absolute-wrapper", // for button
@@ -36,7 +36,7 @@ module.exports = kind({
 		{content: "< Toast Sample", classes: "g-sample-header", ontap: "goBack"},
 
 		{content: "Toast", classes: "g-sample-subheader"},
-		{kind: "g.sample.ToastPanel", style: "position: relative;"}
+		{kind: ToastPanel, style: "position: relative;"}
 	],
 	goBack: function(inSender, inEvent) {
 		global.history.go(-1);

--- a/garnet/src/ToggleButtonSample.js
+++ b/garnet/src/ToggleButtonSample.js
@@ -10,7 +10,7 @@ var
 	ToggleButton = require('garnet/ToggleButton'),
 	Panel = require('garnet/Panel');
 
-kind({
+var ToggleButtonPanel = kind({
 	name: "g.sample.ToggleButtonPanel",
 	kind: Panel,
 	events: {
@@ -44,7 +44,7 @@ module.exports = kind({
 		{content: "< Toggle Button Sample", classes: "g-sample-header", ontap: "goBack"},
 
 		{content: "Toggle Buttons", classes: "g-sample-subheader"},
-		{kind: "g.sample.ToggleButtonPanel", style: "position: relative;", onResult: "result"},
+		{kind: ToggleButtonPanel, style: "position: relative;", onResult: "result"},
 
 		{style: "position: fixed; width: 100%; min-height: +" + ri.scale(160) + "px; bottom: 0; z-index: 9999; background-color: #EDEDED; opacity: 0.8;", classes: "g-sample-result", components: [
 			{content: "Result", classes: "g-sample-subheader"},

--- a/garnet/src/ToggleIconButtonSample.js
+++ b/garnet/src/ToggleIconButtonSample.js
@@ -11,7 +11,7 @@ var
 	ToggleIconButton = require('garnet/ToggleIconButton'),
 	Panel = require('garnet/Panel');
 
-kind({
+var ToggleIconButtonPanel = kind({
 	name: "g.sample.ToggleIconButtonPanel",
 	kind: Panel,
 	handlers: {
@@ -69,7 +69,7 @@ module.exports = kind({
 		{content: "< Toggle Icon Button Sample", classes: "g-sample-header", ontap: "goBack"},
 
 		{content: "Toggle Icon Buttons", classes: "g-sample-subheader"},
-		{kind: "g.sample.ToggleIconButtonPanel", style: "position: relative;", onResult: "result"},
+		{kind: ToggleIconButtonPanel, style: "position: relative;", onResult: "result"},
 
 		{src: "@../assets/btn_command_next.svg", classes: "g-sample-result", components: [
 			{content: "Result", classes: "g-sample-subheader"},

--- a/garnet/src/WheelSliderControllerSample.js
+++ b/garnet/src/WheelSliderControllerSample.js
@@ -11,7 +11,7 @@ var
 	Popup = require('garnet/Popup'),
 	WheelSliderController = require('garnet/WheelSliderController');
 
-kind({
+var WheelSliderControllerPopup = kind({
 	name: "g.sample.WheelSliderControllerPopup",
 	kind: Panel,
 	events: {
@@ -43,7 +43,7 @@ kind({
 	}
 });
 
-kind({
+var WheelSliderControllerPanel = kind({
 	name: "g.sample.WheelSliderController",
 	kind: Panel,
 	events: {
@@ -86,7 +86,7 @@ kind({
 				onChanging: "showPopup"
 			},
 			components: [
-				{kind: "g.sample.WheelSliderControllerPopup"}
+				{kind: WheelSliderControllerPopup}
 			],
 			popupAnimationFinished: function() {
 				if (this.showing) {
@@ -194,7 +194,7 @@ module.exports = kind({
 		{content: "< Wheel Slider Controller Sample", classes: "g-sample-header", ontap: "goBack"},
 
 		{content: "Wheel Slider Panel", classes: "g-sample-subheader"},
-		{kind: "g.sample.WheelSliderController", onResult: "result"},
+		{kind: WheelSliderControllerPanel, onResult: "result"},
 
 		{src: "@../assets/btn_command_next.svg", classes: "g-sample-result", components: [
 			{content: "Result", classes: "g-sample-subheader"},


### PR DESCRIPTION
## Issue

: I found more warnings when running garnet samples with enyo-strawman repo.
## Fix
- I used kind instances instead of using kind string names to remove the warnings.
- I omitted "Sample" strings in kind names if the kind names already had "g.sample"

``` javascript
/* AS-IS : */ name: "g.sample.DataGridListCardsSampleItem"
/* TO-BE : */ name: "g.sample.DataGridListCardsItem"
```
- I renamed the kind names if their prefix were not "g.sample.".

``` javascript
/* AS-IS : */ name: "g.DataGridListImageItem"
/* TO-BE : */ name: "g.sample.DataGridListImageItem"
```
- I generated data in several panels samples to reduce sample code.

https://jira2.lgsvl.com/browse/ENYO-2215
Enyo-DCO-1.1-Signed-off-by: YB Sung yb.sung@lge.com
