### PR TITLE
ENYO-2122: Update ActivityPanelsSample

### DIFF
--- a/moonstone-extra/src/ActivityPanelsSample.js
+++ b/moonstone-extra/src/ActivityPanelsSample.js
@@ -85,7 +85,7 @@ module.exports = kind({
 	// custom next handler for each panel to avoid switching from one active panel
 	// to another with no visible change for demo
 	next1: function(inSender, inEvent) {
-		this.$.panels.setIndex(2);
+		this.$.panels.setIndex(1);
 		return true;
 	},
 	next2: function(inSender, inEvent) {
@@ -93,19 +93,19 @@ module.exports = kind({
 		return true;
 	},
 	next3: function(inSender, inEvent) {
-		this.$.panels.setIndex(5);
+		this.$.panels.setIndex(3);
 		return true;
 	},
 	next4: function(inSender, inEvent) {
-		this.$.panels.setIndex(5);
+		this.$.panels.setIndex(4);
 		return true;
 	},
 	next5: function(inSender, inEvent) {
-		this.$.panels.setIndex(7);
+		this.$.panels.setIndex(5);
 		return true;
 	},
 	next6: function(inSender, inEvent) {
-		this.$.panels.setIndex(7);
+		this.$.panels.setIndex(6);
 		return true;
 	},
 	inputChanged: function(inSender, inEvent) {

--- a/moonstone-extra/src/ActivityPanelsWithVideoSample.js
+++ b/moonstone-extra/src/ActivityPanelsWithVideoSample.js
@@ -114,7 +114,7 @@ module.exports = kind({
 	// custom next handler for each panel to avoid switching from one active panel
 	// to another with no visible change for demo
 	next1: function(inSender, inEvent) {
-		this.$.panels.setIndex(2);
+		this.$.panels.setIndex(1);
 		return true;
 	},
 	next2: function(inSender, inEvent) {
@@ -122,19 +122,19 @@ module.exports = kind({
 		return true;
 	},
 	next3: function(inSender, inEvent) {
-		this.$.panels.setIndex(5);
+		this.$.panels.setIndex(3);
 		return true;
 	},
 	next4: function(inSender, inEvent) {
-		this.$.panels.setIndex(5);
+		this.$.panels.setIndex(4);
 		return true;
 	},
 	next5: function(inSender, inEvent) {
-		this.$.panels.setIndex(7);
+		this.$.panels.setIndex(5);
 		return true;
 	},
 	next6: function(inSender, inEvent) {
-		this.$.panels.setIndex(7);
+		this.$.panels.setIndex(6);
 		return true;
 	},
 	handleShowingChanged: function(inSender, inEvent) {


### PR DESCRIPTION
This sample was originally set up for the old Moonstone panels
implementation, in which multiple panels could appear side-by-side.
As a result, tap handlers were set up to skip some panels. We now
show only one panel at a time, so tapping any panel should simply
move to the next.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
