### PR TITLE
Enyo-2367 Bind selection property of view with model

### DIFF
--- a/src/moonstone-samples/lib/DataGridListSample.js
+++ b/src/moonstone-samples/lib/DataGridListSample.js
@@ -209,6 +209,7 @@ module.exports = kind({
 					horizontal: 'hidden',
 					spotlightPagingControls: true
 				},
+				selectionProperty: 'selected',
 				components: [
 					{kind: GridSampleItem, overlayTransparent: this.transparency}
 				]


### PR DESCRIPTION
## Issue

Selection property changing in view level does not affect on model.
## Cause

`selectionProperty` is not defined when we instanciate DataGridList 
## Fix

Add `selectionProperty: 'selected'` 

Signed-off-by: David Joonho Um david.um@lge.com
