### PR TITLE
ENYO-2394: Garnet sample: Fix error during 'epack garnet' due to garnet/src/package.json

### DIFF
--- a/garnet/src/WheelSliderControllerSample.js
+++ b/garnet/src/WheelSliderControllerSample.js
@@ -187,7 +187,7 @@ var WheelSliderControllerPanel = kind({
 	}
 });
 
-module.exports = kind({
+var WheelSliderControllerSample = module.exports = kind({
 	name: "g.sample.WheelSliderControllerSample",
 	classes: "enyo-unselectable garnet g-sample",
 	components: [
@@ -209,3 +209,5 @@ module.exports = kind({
 		return false;
 	}
 });
+
+WheelSliderControllerSample.WheelSliderControllerPanel = WheelSliderControllerPanel;

--- a/garnet/src/package.json
+++ b/garnet/src/package.json
@@ -1,11 +1,5 @@
 {
   "name": "enyo-strawman-garnet",
   "filename": "index.js",
-  "main": "index.js",
-  "styles": [
-    "../*.css"
-  ],
-  "assets": [
-    "../assets/*"
-  ]
+  "main": "index.js"
 }


### PR DESCRIPTION
## Issue

: Error occurs when we do "epack garnet" due to unused and misused
properties in garnet/src/package.json.
WheelSliderControllerSamplePanel is not shown in PanelSetSample.
## Fix

: Removed unused and misused properties in package.json
Fixed WheelSliderControllerSample to be shown.

https://jira2.lgsvl.com/browse/ENYO-2394
Enyo-DCO-1.1-Signed-off-by: Mikyung Kim mikyung27.kim@lge.com
