### PR TITLE
ENYO-2384: Update to work with tweaked LightPanels structure.

### DIFF
--- a/src/enyo-samples/lib/LightPanelsSample/LightPanelsSample.js
+++ b/src/enyo-samples/lib/LightPanelsSample/LightPanelsSample.js
@@ -92,12 +92,12 @@ module.exports = kind({
 		], {owner: this});
 	},
 	prevTapped: function (sender, ev) {
-		var panels = ev.originator.parent.parent;
+		var panels = ev.originator.isDescendantOf(this.$.lightHorizontal) ? this.$.lightHorizontal : this.$.lightVertical;
 		panels.previous();
 		return true;
 	},
 	nextTapped: function (sender, ev) {
-		var panels = ev.originator.parent.parent;
+		var panels = ev.originator.isDescendantOf(this.$.lightHorizontal) ? this.$.lightHorizontal : this.$.lightVertical;
 		if ((panels.name == 'lightHorizontal' && this.multipleHorizontal) || (panels.name == 'lightVertical' && this.multipleVertical)) {
 			this.pushMultiplePanels(panels);
 		} else {


### PR DESCRIPTION
### Issue

The structure of `LightPanels` has been tweaked such that there is a container element for the set of panels.
### Fix

We need to make a small tweak to this sample to both make it more robust, and to be compatible with this structure change. This is purely a sample-specific scenario.

This change is dependent on https://github.com/enyojs/enyo/pull/1260.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
