### PR TITLE
ENYO-2422: Garnet sample: Use "src" value for "moduleDir" property

### DIFF
--- a/garnet/package.json
+++ b/garnet/package.json
@@ -17,7 +17,7 @@
     "src/*.less"
   ],
   "main": "index.js",
-  "moduleDir": "lib",
+  "moduleDir": "src",
   "filename": "index.js",
   "version": "0.0.1",
   "description": "Collection of Enyo lib samples for Quality Assurance with Garnet",


### PR DESCRIPTION
## Issue

When using enyo-dev 0.5.1, there were so many errors when running "epack garnet" because "moduleDir": "lib" in package.json didn't work. So we decided to use "src" directory in garnet library instead of using "lib" folder name because sometime we had to do it.
## Fix

Used "src" value for "moduleDir" property in "enyo-strawman\garnet\package.json"

https://jira2.lgsvl.com/browse/ENYO-2422
Enyo-DCO-1.1-Signed-off-by: YB Sung yb.sung@lge.com
