### PR TITLE
ENYO-2465: Update LightPanelsSample.

### DIFF
--- a/src/moonstone-samples/lib/LightPanelsSample.css
+++ b/src/moonstone-samples/lib/LightPanelsSample.css
@@ -1,0 +1,14 @@
+.moon-light-panels-sample .control-container > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.moon-light-panels-sample .control-panel {
+	position: static;
+	height: 60px;
+	width: 400px;
+}
+
+.moon-light-panels-sample .panel-scroller {
+	height: 750px;
+}

--- a/src/moonstone-samples/lib/LightPanelsSample.js
+++ b/src/moonstone-samples/lib/LightPanelsSample.js
@@ -4,9 +4,32 @@ var
 
 var
 	Button = require('moonstone/Button'),
+	IconButton = require('moonstone/IconButton'),
 	Item = require('moonstone/Item'),
 	LightPanels = require('moonstone/LightPanels'),
 	Scroller = require('moonstone/Scroller');
+
+var controls = [
+	{kind: Item, content: 'Control Item 1'},
+	{kind: Item, content: 'Control Item 2'},
+	{kind: Item, content: 'Control Item 3'},
+	{kind: Item, content: 'Control Item 4'},
+	{kind: Item, content: 'Control Item 5'},
+	{kind: Item, content: 'Control Item 6'},
+	{kind: Item, content: 'Control Item 7'},
+	{kind: Item, content: 'Control Item 8'},
+	{kind: Item, content: 'Control Item 9'}
+];
+
+var ControlPanel = kind({
+	kind: LightPanels,
+	cacheViews: false,
+	popOnBack: false,
+	wrap: true,
+	orientation: LightPanels.Orientation.VERTICAL,
+	direction: LightPanels.Direction.BACKWARDS,
+	components: controls
+});
 
 module.exports = kind({
 	name: 'moon.sample.LightPanelsSample',
@@ -28,7 +51,7 @@ module.exports = kind({
 		panels.pushPanel({
 			classes: 'light-panel',
 			panelId: 'panel-' + id,
-			title: 'Panel ' + id,
+			title: 'This is the extended and long title of panel ' + id,
 			headerComponents: [
 				{
 					kind: Button,
@@ -38,7 +61,14 @@ module.exports = kind({
 				}
 			],
 			clientComponents: [
-				{kind: Scroller, style: 'height:800px', components: [
+				{kind: Control, classes: 'control-container', components: [
+					{kind: Control, components: [
+						{kind: IconButton, icon: 'arrowlargedown', ontap: 'prevIconTapped'},
+						{kind: IconButton, icon: 'arrowlargeup', ontap: 'nextIconTapped'}
+					]},
+					{kind: ControlPanel, classes: 'control-panel', index: id < controls.length ? id : controls.length - 1}
+				]},
+				{kind: Scroller, classes: 'panel-scroller', components: [
 					{kind: Item, content: 'Item One', ontap: 'nextTapped'},
 					{kind: Item, content: 'Item Two', ontap: 'nextTapped'},
 					{kind: Item, content: 'Item Three', ontap: 'nextTapped'},
@@ -68,6 +98,14 @@ module.exports = kind({
 	},
 	nextTapped: function (sender, ev) {
 		this.pushSinglePanel();
+		return true;
+	},
+	prevIconTapped: function (sender, ev) {
+		this.$.lightPanels.previous();
+		return true;
+	},
+	nextIconTapped: function (sender, ev) {
+		this.$.lightPanels.next();
 		return true;
 	}
 });

--- a/src/moonstone-samples/lib/LightPanelsSample.js
+++ b/src/moonstone-samples/lib/LightPanelsSample.js
@@ -31,6 +31,33 @@ var ControlPanel = kind({
 	components: controls
 });
 
+var ControlContainer = kind({
+	kind: Control,
+	classes: 'control-container',
+	panelId: 0,
+	components: [
+		{kind: Control, components: [
+			{kind: IconButton, icon: 'arrowlargedown', ontap: 'prevIconTapped'},
+			{kind: IconButton, icon: 'arrowlargeup', ontap: 'nextIconTapped'}
+		]},
+		{kind: ControlPanel, name: 'controlPanel', classes: 'control-panel'}
+	],
+	bindings: [
+		{from: 'panelId', to: '$.controlPanel.index', transform: function (id) {
+			// clamping id such that we have a valid value
+			return id < controls.length ? id : controls.length - 1;
+		}}
+	],
+	prevIconTapped: function (sender, ev) {
+		this.$.controlPanel.previous();
+		return true;
+	},
+	nextIconTapped: function (sender, ev) {
+		this.$.controlPanel.next();
+		return true;
+	}
+});
+
 module.exports = kind({
 	name: 'moon.sample.LightPanelsSample',
 	classes: 'moon enyo-fit enyo-unselectable moon-light-panels-sample',
@@ -61,13 +88,7 @@ module.exports = kind({
 				}
 			],
 			clientComponents: [
-				{kind: Control, classes: 'control-container', components: [
-					{kind: Control, components: [
-						{kind: IconButton, icon: 'arrowlargedown', ontap: 'prevIconTapped'},
-						{kind: IconButton, icon: 'arrowlargeup', ontap: 'nextIconTapped'}
-					]},
-					{kind: ControlPanel, classes: 'control-panel', index: id < controls.length ? id : controls.length - 1}
-				]},
+				{kind: ControlContainer, panelId: id},
 				{kind: Scroller, classes: 'panel-scroller', components: [
 					{kind: Item, content: 'Item One', ontap: 'nextTapped'},
 					{kind: Item, content: 'Item Two', ontap: 'nextTapped'},
@@ -98,14 +119,6 @@ module.exports = kind({
 	},
 	nextTapped: function (sender, ev) {
 		this.pushSinglePanel();
-		return true;
-	},
-	prevIconTapped: function (sender, ev) {
-		this.$.lightPanels.previous();
-		return true;
-	},
-	nextIconTapped: function (sender, ev) {
-		this.$.lightPanels.next();
 		return true;
 	}
 });


### PR DESCRIPTION
### Issue

With some alternative use cases to consider, the `LightPanelsSample` needed some updating to provide additional test coverage.
### Fix

Made a few tweaks to the `LightPanelsSample` to test a static components block with a predefined starting index. This also tests the vertical orientation, backwards direction, and wrap functionality. Lastly, the titles of the panels have been extended such that they marquee.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
