### PR TITLE
Fix for: ENYO-1859

### DIFF
--- a/src/moonstone-samples/lib/All/All.js
+++ b/src/moonstone-samples/lib/All/All.js
@@ -230,7 +230,7 @@ module.exports = kind({
 			this.$.localePopup.hide();
 		}
 		this.locales.find(function(elem) { return elem.get('locale') == newLocale; }).set('selected', true);
-		i18n.updateLocale(newLocale);
+		i18n.updateLocale(newLocale == 'local' ? null : newLocale);
 		this.$.router.trigger({location: this.get('location'), change: true});
 	},
 	sampleChanged: function (was, is) {

--- a/src/moonstone-samples/lib/CalendarSample.js
+++ b/src/moonstone-samples/lib/CalendarSample.js
@@ -4,6 +4,9 @@ var
 	updateLocale = i18n.updateLocale;
 
 var
+	Locale = require('enyo-ilib/Locale');
+
+var
 	FittableColumns = require('layout/FittableColumns'),
 	FittableRows = require('layout/FittableRows');
 
@@ -110,11 +113,13 @@ module.exports = kind({
 	},
 
 	setLocale: function(inSender, inEvent){
-		var locale = inEvent.selected.content,
-			val = (locale == 'Use Default Locale') ? null : locale;
-		updateLocale(val);
-		this.$.calendar.setLocale(val);
-		this.$.picker.setLocale(val);
+		var locale = inEvent.selected.content;
+		locale = locale == 'Use Default Locale' ? null : locale;
+		// auto-triggers update to correctly configured/written widgets
+		updateLocale(locale);
+		// egregious misuse of now-deprecated widget/api to avoid needing to rewrite the entire
+		// widget at this time
+		this.$.calendar.set('locale', new Locale());
 
 		this.df = new DateFmt({
 			type: 'datetime',

--- a/src/moonstone-samples/lib/ClockSample.js
+++ b/src/moonstone-samples/lib/ClockSample.js
@@ -66,10 +66,9 @@ module.exports = kind({
 		}
 	},
 	setLocale: function(inSender, inEvent){
-		var locale = inEvent.selected.content,
-			val = (locale == 'Use Default Locale') ? null : locale;
+		var locale = inEvent.selected.content;
+		locale = locale == 'Use Default Locale' ? null : locale;
 		updateLocale(locale);
-		this.$.clock.setLocale(val);
 		return true;
 	},
 	setTime: function() {

--- a/src/moonstone-samples/lib/DatePickerSample.js
+++ b/src/moonstone-samples/lib/DatePickerSample.js
@@ -79,14 +79,10 @@ module.exports = kind({
 		}
 	},
 	setLocale: function(sender, event){
-		if (ilib) {
-			var locale = event.selected.content,
-				val = (locale == 'Use Default Locale') ? null : locale;
-			i18n.updateLocale(val);
-			this.$.picker.setLocale(val);
-			this.$.disabledPicker.setLocale(val);
-			this.$.result.setContent(event.originator.name + ' changed to ' + val);
-		}
+		var locale = event.selected.content;
+		locale = locale == 'Use Default Locale' ? null : locale;
+		i18n.updateLocale(locale);
+		this.$.result.setContent(event.originator.name + ' changed to ' + ilib.getLocale());
 		return true;
 	},
 	setDate: function() {


### PR DESCRIPTION
## Issue

Incorrect assignment of locales and inconsistent application of locale information was causing bad handling for Clock, DatePicker and Calendar (_now deprecated_!).
## Fix

Update to not attempt to set a fake locale of _local_ and avoid directly setting locale values on widgets since they will automatically adjust to locale changes.

The exception is the now deprecated Calendar widget.

Tied to these other PR's:

https://github.com/enyojs/moonstone/pull/2531 
https://github.com/enyojs/enyo-ilib/pull/146

Enyo-DCO-1.1-Signed-Off-By: Cole Davis (cole.davis@lge.com)
