### PR TITLE
ENYO-2541: Clean-up LightPanels samples.

### DIFF
--- a/src/enyo-samples/lib/LightPanelsSample/LightPanelsSample.js
+++ b/src/enyo-samples/lib/LightPanelsSample/LightPanelsSample.js
@@ -51,8 +51,8 @@ module.exports = kind({
 			this.$.lightHorizontal.createComponent(infoHorizontal, {owner: this});
 			this.$.lightVertical.createComponent(infoVertical, {owner: this});
 
-			this.$.lightHorizontal.set('index', 0);
-			this.$.lightVertical.set('index', 0);
+			this.$.lightHorizontal.set('index', startIndex);
+			this.$.lightVertical.set('index', startIndex);
 		};
 	}),
 	generatePanelInfo: function (id) {

--- a/src/enyo-samples/lib/LightPanelsSample/LightPanelsSample.js
+++ b/src/enyo-samples/lib/LightPanelsSample/LightPanelsSample.js
@@ -40,56 +40,44 @@ module.exports = kind({
 	],
 	rendered: kind.inherit(function (sup) {
 		return function () {
+			var startIndex = 0,
+				infoHorizontal, infoVertical;
+
 			sup.apply(this, arguments);
-			this.pushSinglePanel(this.$.lightHorizontal);
-			this.pushSinglePanel(this.$.lightVertical);
+
+			infoHorizontal = this.generatePanelInfo(startIndex);
+			infoVertical = this.generatePanelInfo(startIndex);
+
+			this.$.lightHorizontal.createComponent(infoHorizontal, {owner: this});
+			this.$.lightVertical.createComponent(infoVertical, {owner: this});
+
+			this.$.lightHorizontal.set('index', 0);
+			this.$.lightVertical.set('index', 0);
 		};
 	}),
-	pushSinglePanel: function (panels) {
-		panels.pushPanel({
+	generatePanelInfo: function (id) {
+		return {
 			classes: 'light-panel',
-			panelId: 'panel-' + panels.getPanels().length,
+			panelId: 'panel-' + id,
 			style: 'background-color: ' + this.bgcolors[Math.floor(Math.random() * this.bgcolors.length)],
 			components: [
-				{content: panels.getPanels().length, classes: 'label'},
+				{content: id, classes: 'label'},
 				{content: 'Prev', kind: Button, classes: 'previous', ontap: 'prevTapped'},
 				{content: 'Next', kind: Button, classes: 'next', ontap: 'nextTapped'}
 			]
-		}, {owner: this});
+		};
+	},
+	pushSinglePanel: function (panels) {
+		var info = this.generatePanelInfo(panels.getPanels().length);
+		panels.pushPanel(info, {owner: this});
 	},
 	pushMultiplePanels: function (panels) {
-		panels.pushPanels([
-			{
-				classes: 'light-panel',
-				panelId: 'panel-' + panels.getPanels().length,
-				style: 'background-color: ' + this.bgcolors[Math.floor(Math.random() * this.bgcolors.length)],
-				components: [
-					{content: panels.getPanels().length, classes: 'label'},
-					{content: 'Prev', kind: Button, classes: 'previous', ontap: 'prevTapped'},
-					{content: 'Next', kind: Button, classes: 'next', ontap: 'nextTapped'}
-				]
-			},
-			{
-				classes: 'light-panel',
-				panelId: 'panel-' + (panels.getPanels().length + 1),
-				style: 'background-color: ' + this.bgcolors[Math.floor(Math.random() * this.bgcolors.length)],
-				components: [
-					{content: panels.getPanels().length + 1, classes: 'label'},
-					{content: 'Prev', kind: Button, classes: 'previous', ontap: 'prevTapped'},
-					{content: 'Next', kind: Button, classes: 'next', ontap: 'nextTapped'}
-				]
-			},
-			{
-				classes: 'light-panel',
-				panelId: 'panel-' + (panels.getPanels().length + 2),
-				style: 'background-color: ' + this.bgcolors[Math.floor(Math.random() * this.bgcolors.length)],
-				components: [
-					{content: panels.getPanels().length + 2, classes: 'label'},
-					{content: 'Prev', kind: Button, classes: 'previous', ontap: 'prevTapped'},
-					{content: 'Next', kind: Button, classes: 'next', ontap: 'nextTapped'}
-				]
-			}
-		], {owner: this});
+		var panelLength = panels.getPanels().length,
+			info1 = this.generatePanelInfo(panelLength),
+			info2 = this.generatePanelInfo(panelLength + 1),
+			info3 = this.generatePanelInfo(panelLength + 2);
+
+		panels.pushPanels([info1, info2, info3], {owner: this});
 	},
 	prevTapped: function (sender, ev) {
 		var panels = ev.originator.isDescendantOf(this.$.lightHorizontal) ? this.$.lightHorizontal : this.$.lightVertical;

--- a/src/moonstone-samples/lib/LightPanelsSample.js
+++ b/src/moonstone-samples/lib/LightPanelsSample.js
@@ -65,17 +65,20 @@ module.exports = kind({
 	components: [
 		{kind: LightPanels, name: 'panels'}
 	],
-	rendered: kind.inherit(function (sup) {
+	create: kind.inherit(function (sup) {
 		return function () {
+			var startIndex = 0,
+				info;
+
 			sup.apply(this, arguments);
-			this.pushSinglePanel(true);
+
+			info = this.generatePanelInfo(startIndex);
+			this.$.panels.createComponent(info, {owner: this});
+			this.$.panels.set('index', startIndex);
 		};
 	}),
-	pushSinglePanel: function (direct) {
-		var panels = this.$.panels,
-			id = panels.getPanels().length;
-
-		panels.pushPanel({
+	generatePanelInfo: function (id) {
+		return {
 			classes: 'light-panel',
 			panelId: 'panel-' + id,
 			title: 'This is the extended and long title of panel ' + id,
@@ -111,7 +114,14 @@ module.exports = kind({
 					{kind: Item, content: 'Item Twenty', ontap: 'nextTapped'}
 				]}
 			]
-		}, {owner: this}, {direct: direct});
+		};
+	},
+	pushSinglePanel: function (direct) {
+		var panels = this.$.panels,
+			id = panels.getPanels().length,
+			info = this.generatePanelInfo(id);
+
+		this.$.panels.pushPanel(info, {owner: this}, {direct: direct});
 	},
 	prevTapped: function (sender, ev) {
 		this.$.panels.previous();


### PR DESCRIPTION
### Issue

While auditing the use of `popOnForward` and investigating another issue, I noticed we are essentially calling `pushPanel`/`pushPanels` from `rendered`, which now ultimately results in a call to `render`.
### Fix

We have rejiggered things a bit and use `createComponent` in `create`, instead. This will also help to test the additional use case of utilizing `createComponent`, while maintaining coverage of `pushPanel`/`pushPanels` usage.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
