### PR TITLE
ENYO-2556: Set locale before sample is loaded.

### DIFF
--- a/src/moonstone-samples/lib/All/All.js
+++ b/src/moonstone-samples/lib/All/All.js
@@ -215,11 +215,12 @@ module.exports = kind({
 		var locale = ev.model.get('locale');
 		if (locale) {
 			this.set('locale', locale);
+			this.$.router.trigger({location: this.get('location'), change: true});
 		}
 	},
 	handleRoute: function (sender, ev) {
-		this.set('sample', ev.sampleName);
 		this.set('locale', ev.locale);
+		this.set('sample', ev.sampleName);
 	},
 	updateTitle: function (title) {
 		document.title = (title ? title + ' - ' : '') + this.get('title');
@@ -231,7 +232,6 @@ module.exports = kind({
 		}
 		this.locales.find(function(elem) { return elem.get('locale') == newLocale; }).set('selected', true);
 		i18n.updateLocale(newLocale == 'local' ? null : newLocale);
-		this.$.router.trigger({location: this.get('location'), change: true});
 	},
 	sampleChanged: function (was, is) {
 		if (was) {


### PR DESCRIPTION
### Issue

When loading a sample that has a locale specified, properties such as `rtl` are not updated when the sample is loaded.
### Fix

We now set the locale before loading the sample. We can assume that the locale will not change when the control is rendered, and that it will have already been set before the control is created, in terms of how Enyo is used on the devices.
### Notes

This change came about when creating https://github.com/enyojs/enyo/pull/1293.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
