### PR TITLE
Enyo-2197 Give fixed childSize to prevent wrong controlsPerPage calcu…

### DIFF
--- a/src/moonstone-samples/lib/All/All.js
+++ b/src/moonstone-samples/lib/All/All.js
@@ -159,7 +159,7 @@ module.exports = kind({
 					{kind: Button, content: 'Back', small: true, href: './', mixins: [LinkSupport]}
 				],
 				components: [
-					{name: 'list', kind: DataList, components: [
+					{name: 'list', kind: DataList, fixedChildSize: 63, components: [
 						{kind: SampleListItem, bindings: [
 							{from: 'model.new', to: 'new'},
 							{from: 'model.label', to: 'content'},


### PR DESCRIPTION
…lation
## Issue

moonstone sample shows blank page when we back to list from any sample with following conditions
1. page1 has higher top. It means page1 is under the page2
2. page1 has a few children like 2
3. page2 has a full children

When we back to list, dataList will generate pages again.
But childSize() will make huge list.childSize because page1 has just 2 children.
It causes wrong controlsPerPage, so pages will have small height.
Due to this process, we can see blank space
## Cause

In this scenario, childSize() should use page2 instead of page1 because page2 has full children.
## Fix

We can update childSize() but to make a least changes on DataList, I used `fixedChildSize` to avoid calculation of list.childSize

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
