### PR TITLE
ENYO-2579: Add workaround for preventing multi-tap issue

### DIFF
--- a/sunstone/src/DataGridListSample.js
+++ b/sunstone/src/DataGridListSample.js
@@ -17,6 +17,8 @@ module.exports = kind({
 				onup: 'unpressed',
 				onleave: 'unpressed',
 				ontap: 'itemTapped',
+				ongesturechange: 'unpressed',
+				ongestureend: 'unpressed',
 				kind: GridListImageItem,
 				source: '@../assets/default-music.png',
 				bindings: [

--- a/sunstone/src/GridListSample.js
+++ b/sunstone/src/GridListSample.js
@@ -27,7 +27,7 @@ module.exports = kind({
 				onSetupItem: "setupItem",
 				count: 20,
 				components: [
-					{ondown: "pressed", onup:"unpressed", ondragfinish: "unpressed", /*onleave: "unpressed",*/ ontap: "itemTapped", name: "tile", kind: GridListImageItem, source: "@../assets/default-music.png"}
+					{ondown: "pressed", onup:"unpressed", ondragout: "unpressed", ontap: "itemTapped", name: "tile", kind: GridListImageItem, source: "@../assets/default-music.png"}
 				],
 				reorderComponents: [
 					{name: "reorderContent", classes: "enyo-fit reorderDragger", components: [
@@ -38,6 +38,7 @@ module.exports = kind({
 		]}
 	],
 	names: [],
+	isPressed: false, // For preventing remained pressed state when user taps item with two-finger
 	create: kind.inherit(function (sup) {
 		return function () {
 			sup.apply(this, arguments);
@@ -100,13 +101,17 @@ module.exports = kind({
 		return true;
 	},
 	pressed: function(inSender, inEvent) {
-		this.$.list.lockRow();
-		this.$.list.prepareRow(inEvent.index);
-		inSender.addClass('pressed');
+		if (!this.isPressed) {
+			this.$.list.lockRow();
+			this.$.list.prepareRow(inEvent.index);
+			inSender.addClass('pressed');
+			this.isPressed = true;
+		}
 	},
 	unpressed: function(inSender, inEvent) {
 		inSender.removeClass('pressed');
 		this.$.list.lockRow();
+		this.isPressed = false;
 	},
 	itemTapped: function() {
 		playFeedback();

--- a/sunstone/src/GridListSample.js
+++ b/sunstone/src/GridListSample.js
@@ -12,26 +12,26 @@ var
 	Header = require('sunstone/Header');
 
 module.exports = kind({
-	name: "enyo.sample.GridListSample",
+	name: 'enyo.sample.GridListSample',
 	kind: FittableRows,
-	classes: "enyo-unselectable enyo-fit",
+	classes: 'enyo-unselectable enyo-fit',
 	components: [
-		{kind: Header, title:"Header"},
-		{fit:true, classes:"watch-wrapper", components:[
+		{kind: Header, title: 'Header'},
+		{fit: true, classes: 'watch-wrapper', components: [
 			{
-				name: "list",
+				name: 'list',
 				kind: GridList,
 				reorderable: true,
-				onReorder: "listReorder",
-				onSetupReorderComponents: "setupReorderComponents",
-				onSetupItem: "setupItem",
+				onReorder: 'listReorder',
+				onSetupReorderComponents: 'setupReorderComponents',
+				onSetupItem: 'setupItem',
 				count: 20,
 				components: [
-					{ondown: "pressed", onup:"unpressed", ondragout: "unpressed", ontap: "itemTapped", name: "tile", kind: GridListImageItem, source: "@../assets/default-music.png"}
+					{ondown: 'pressed', onup:'unpressed', onrelease: 'unpressed', ondragout: 'unpressed', ontap: 'itemTapped', name: 'tile', kind: GridListImageItem, source: '@../assets/default-music.png'}
 				],
 				reorderComponents: [
-					{name: "reorderContent", classes: "enyo-fit reorderDragger", components: [
-						{name: "reorderTile", kind: GridListImageItem}
+					{name: 'reorderContent', classes: 'enyo-fit reorderDragger', components: [
+						{name: 'reorderTile', kind: GridListImageItem}
 					]}
 				]
 			}
@@ -45,7 +45,7 @@ module.exports = kind({
 			// make some mock data if we have none for this row
 			var i = 0;
 			for (; i < this.$.list.count; i++) {
-				this.names.push({name:"Item " + i});
+				this.names.push({name:'Item ' + i});
 			}
 		};
 	}),
@@ -89,7 +89,7 @@ module.exports = kind({
 			return;
 		}
 		var item = this.names[i];
-		this.$.reorderTile.setSource("@../assets/default-music.png");
+		this.$.reorderTile.setSource('@../assets/default-music.png');
 		this.$.reorderTile.setCaption(item.name);
 		this.$.reorderTile.setSelected(this.$.list.isSelected(i));
 	},

--- a/sunstone/src/ListSample.js
+++ b/sunstone/src/ListSample.js
@@ -29,7 +29,7 @@ module.exports = kind({
 			onReorder: 'listReorder',
 			onSetupReorderComponents: 'setupReorderComponents',
 			components: [
-				{ondown: 'pressed', onup: 'unpressed', onleave: 'unpressed', ontap: 'itemTapped', name: 'item', classes: 'list-item', components: [
+				{ondown: 'pressed', onup: 'unpressed', ondragout: 'unpressed', ontap: 'itemTapped', name: 'item', classes: 'list-item', components: [
 					{name: 'name'},
 					{name: 'checkbox', kind: Checkbox, onchange: 'checkboxChanged', ondown: 'checkboxDown'}
 				]}
@@ -43,6 +43,7 @@ module.exports = kind({
 		}
 	],
 	names: [],
+	isPressed: false, // For preventing remained pressed state when user taps item with two-finger
 	create: kind.inherit(function(sup) {
 		return function() {
 			var i;
@@ -107,11 +108,14 @@ module.exports = kind({
 		return true;
 	},
 	pressed: function (inSender, e) {
-		this.$.list.lockRow();
-		this.$.list.prepareRow(e.index);
-		inSender.addClass('pressed');
-		if (e.originator instanceof Checkbox) {
-			this.waterfallDown('ondown', e, inSender);
+		if (!this.isPressed) {
+			this.isPressed = true;
+			this.$.list.lockRow();
+			this.$.list.prepareRow(e.index);
+			inSender.addClass('pressed');
+			if (e.originator instanceof Checkbox) {
+				this.waterfallDown('ondown', e, inSender);
+			}
 		}
 	},
 	unpressed: function (inSender, e) {
@@ -119,6 +123,7 @@ module.exports = kind({
 		if (!(e.originator instanceof Checkbox)) {
 			this.$.list.lockRow();
 		}
+		this.isPressed = false;
 	},
 	itemTapped: function (inSender, e) {
 		if (!(e.originator instanceof Checkbox)) {

--- a/sunstone/src/ListSample.js
+++ b/sunstone/src/ListSample.js
@@ -29,7 +29,7 @@ module.exports = kind({
 			onReorder: 'listReorder',
 			onSetupReorderComponents: 'setupReorderComponents',
 			components: [
-				{ondown: 'pressed', onup: 'unpressed', ondragout: 'unpressed', ontap: 'itemTapped', name: 'item', classes: 'list-item', components: [
+				{ondown: 'pressed', onup: 'unpressed', onrelease: 'unpressed', ondragout: 'unpressed', ontap: 'itemTapped', name: 'item', classes: 'list-item', components: [
 					{name: 'name'},
 					{name: 'checkbox', kind: Checkbox, onchange: 'checkboxChanged', ondown: 'checkboxDown'}
 				]}


### PR DESCRIPTION
## Issue

The focus does not released when the list type components are multi-tapped
## Cause

DataList, List and GridList item has no workaroud (ongesturechange, ongestureend, onleave) for preventing remained pressed state.
## Fix

Add ongesturechange and ongestureend event to DataGridList for preventing multi-tap issue. However,In List and GridList,  this workaround(ongesturechange, ongestureend, onleave) is not fired because of flyweight pattern 's limitation, so we add ondragout to List type component instead of onleave.
In addition, we found that List item is remained press state after onhold event, so we added onrelease event for preventing it.

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com
