### PR TITLE
[PLAT-11215] Garnet : Fix item couldn't be selected

### DIFF
--- a/garnet/src/DataListwithRadioButtonsSample.js
+++ b/garnet/src/DataListwithRadioButtonsSample.js
@@ -69,8 +69,8 @@ var RadioDataListPanel = kind({
 			name: "list",
 			kind: DataList,
 			controlsPerPage: 4,
-			groupSelection: true,
 			selection: true,
+			selectionType: "group",
 			style: "background-color: #000000;",
 			components: [
 				{kind: RadioButtonItem, ontap: "tapItem"}

--- a/garnet/src/DataListwithRadioButtonsSample.less
+++ b/garnet/src/DataListwithRadioButtonsSample.less
@@ -34,7 +34,7 @@
 		overflow: inherit;
 	}
 	.g-selection-overlay-support.selected .g-icon-button {
-		background-position: 0 0;
+		background-position: 0 -144px;
 	}
 	.g-selection-overlay-support.active .g-icon-button {
 		background-position: 0 -144px;


### PR DESCRIPTION
## Issue

: Radio button image didn't change properly when it selected in
DataListSamplewithRadioButtonsSample.
## Fix

: Fixed background position in selected class
Changed deprecated property 'groupSelection' to 'selectonType'

https://jira2.lgsvl.com/browse/PLAT-11215
Enyo-DCO-1.1-Signed-off-by: Mikyung Kim mikyung27.kim@lge.com
