### PR TITLE
PLAT-11370: Garnet: Apply PanelManager instead of using garnet/Popup with "depth-transition" effect

### DIFF
--- a/garnet/src/FormSample.js
+++ b/garnet/src/FormSample.js
@@ -122,7 +122,7 @@ var Formatter = kind.singleton({
 });
 
 var SampleTimePickerPanel = kind({
-	name: 'g.sample.CurrentTimePickerPanel',
+	name: 'g.sample.TimePickerPanel',
 	kind: TimePickerPanel,
 	valueChanged: kind.inherit(function(sup) {
 		return function() {
@@ -133,6 +133,22 @@ var SampleTimePickerPanel = kind({
 					hour: this.getHourValue(),
 					minute: this.getMinuteValue(),
 					meridiem: this.getMeridiemValue()
+				});
+			}			
+		};
+	})
+});
+
+var SampleDatePickerPanel = kind({
+	name: 'g.sample.DatePickerPanel',
+	kind: DatePickerPanel,
+	valueChanged: kind.inherit(function(sup) {
+		return function() {
+			sup.apply(this, arguments);
+			if (this.fromPanel) {
+				this.fromPanel.triggerHandler('onUpdate', {
+					name: this.name,
+					value: this.value
 				});
 			}			
 		};
@@ -165,8 +181,8 @@ var
 	panels = {
 		timePickerButton:                {name: 'timePicker', kind: SampleTimePickerPanel, meridiemValue: '24'},
 		timePickerButtonWithValue:       {name: 'timePickerWithValue', kind: SampleTimePickerPanel},
-		datePickerButton:                {name: 'datePicker', kind: DatePickerPanel},
-		datePickerButtonWithValue:       {name: 'datePickerWithValue', kind: DatePickerPanel},
+		datePickerButton:                {name: 'datePicker', kind: SampleDatePickerPanel},
+		datePickerButtonWithValue:       {name: 'datePickerWithValue', kind: SampleDatePickerPanel},
 		pickerPanelButton:               {name: 'pickerPanel', kind: CollectionPickerPanel, title:true, titleContent: 'PickerTitle', ontap: 'hidePickerPanelPopup'},
 		pickerPanelButtonWithValue:      {name: 'pickerPanelWithValue', kind: CollectionPickerPanel, title:true, titleContent: 'PickerTitle',ontap: 'hidePickerPanelPopupWithValue'},
 		multiPickerPanelButton:          {name: 'multiPickerPanel', kind: CollectionMultiPickerPanel, title:true, titleContent: 'MultiPickerTitle', style: 'position: relative; display: inline-block; margin-right: 20px;', selection: true, multipleSelection: true},
@@ -308,10 +324,10 @@ var FormPanel = kind({
 			content = Formatter.TimePickerPanel({hour: inEvent.hour, meridiem: inEvent.meridiem, minute: inEvent.minute});
 			this.$.timePickerButtonWithValue.setContent(content);
 		} else if (name === 'datePicker') {
-			content = Formatter.DatePickerPanel(new Date());
+			content = Formatter.DatePickerPanel(inEvent.value);
 			this.$.datePickerButton.setContent(content);
 		} else if (name === 'datePickerWithValue') {
-			content = Formatter.DatePickerPanel(new Date('2014/1/1'));
+			content = Formatter.DatePickerPanel(inEvent.value);
 			this.$.datePickerButtonWithValue.setContent(content);
 		} else if (name === 'pickerPanel') {
 			content = Formatter.CollectionPickerPanel();

--- a/garnet/src/TimePickerPanelSample.js
+++ b/garnet/src/TimePickerPanelSample.js
@@ -8,43 +8,17 @@ var
 var TimePicker12Panel = kind({
 	name: 'g.sample.TimePicker12Panel',
 	kind: GarnetTimePickerPanel,
-	handlers: {
-		onOK: 'tapOK',
-		onCancel: 'tapCancel'
-	},
-	events: {
-		onResult: ''
-	},
 	hourValue: 12,
 	minuteValue: 30,
-	meridiemValue: 'PM',
-	tapOK: function(inSender, inEvent) {
-		this.doResult({msg: 'Time is ' + this.getHourValue() + ' : ' + this.getMinuteValue() + ' ' + this.meridiemValue});
-	},
-	tapCancel: function() {
-		this.doResult({msg: 'Cancel!'});
-	}
+	meridiemValue: 'PM'
 });
 
 var TimePicker24Panel = kind({
 	name: 'g.sample.TimePicker24Panel',
 	kind: GarnetTimePickerPanel,
-	handlers: {
-		onOK: 'onOK',
-		onCancel: 'onCancel'
-	},
-	events: {
-		onResult: ''
-	},
 	hourValue: 17,
 	minuteValue: 45,
-	meridiemValue: '24',
-	onOK: function(inSender, inEvent) {
-		this.doResult({msg: 'Time is ' + this.getHourValue() + ' : ' + this.getMinuteValue()});
-	},
-	onCancel: function() {
-		this.doResult({msg: 'Cancel!'});
-	}
+	meridiemValue: '24'
 });
 
 module.exports = kind({
@@ -75,9 +49,11 @@ module.exports = kind({
 			{name: 'result', allowHtml: true, content: 'No button pressed yet.', classes: 'g-sample-description'}
 		]}
 	],
-	result: function(inSender, inEvent) {
-		this.$.result.setContent(inEvent.msg);
-	},
+	bindings: [
+		{from: '.$.timePicker12Panel.value', to: '.$.result.content', transform: function(val) {
+			return 'Time is ' + val.hour + ':' + val.minute + ' ' + val.meridiem;
+		}}
+	],
 	goBack: function(inSender, inEvent) {
 		global.history.go(-1);
 		return false;


### PR DESCRIPTION
## Issue

: 'depth-transition' in garnet/Popup was deprecated.
So we have to use garnet/PanelManager to push TimePickerPanel, DatePickerPanel, PickerPanel, MultiPickerPanel
## Fix

: Applied garnet/PanelManager into the samples below
- FormSample
- PickerPanelSample
- MultiPickerPanelSample

Checklist :
JSHint : No error ( Using gulp )

Enyo-DCO-1.1-Signed-off-by: YB Sung yb.sung@lge.com
