### PR TITLE
PLAT-11357: Garnet: style cleanup

### DIFF
--- a/garnet/src/ArcSample.js
+++ b/garnet/src/ArcSample.js
@@ -8,7 +8,6 @@ var
 var ArcPanel = kind({
 	name: 'g.sample.ArcPanel',
 	kind: Panel,
-	style: 'position: relative; border-radius: 50%; background-color: #000000;',
 	components: [
 		{name: 'arc1', kind: Arc, color: '#FF3300', width: 10, diameter: 30},
 		{name: 'arc2', kind: Arc, color: '#FF6600', width: 11, diameter: 70},
@@ -42,7 +41,7 @@ module.exports = kind({
 		{content: '< Arc Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'Arc', classes: 'g-sample-subheader'},
-		{kind: ArcPanel}
+		{kind: ArcPanel, classes: 'g-sample-circle-panel'}
 	],
 	goBack: function(inSender, inEvent) {
 		global.history.go(-1);

--- a/garnet/src/ArcSample.less
+++ b/garnet/src/ArcSample.less
@@ -2,7 +2,8 @@
 
 .g-sample-circle-panel {
 	background-color: #000000;
+
 	position: relative;
-	overflow: hidden;
 	border-radius: 50%;
+	overflow: hidden;
 }

--- a/garnet/src/ArcSample.less
+++ b/garnet/src/ArcSample.less
@@ -1,5 +1,7 @@
 /* ArcSample */
 
+// Common classes
+
 .g-sample-circle-panel {
 	background-color: #000000;
 

--- a/garnet/src/ArcSample.less
+++ b/garnet/src/ArcSample.less
@@ -1,1 +1,8 @@
 /* ArcSample */
+
+.g-sample-circle-panel {
+	background-color: #000000;
+	position: relative;
+	overflow: hidden;
+	border-radius: 50%;
+}

--- a/garnet/src/ButtonSample.js
+++ b/garnet/src/ButtonSample.js
@@ -2,7 +2,6 @@ require('garnet');
 
 var
 	kind = require('enyo/kind'),
-	ri = require('enyo/resolution'),
 	Group = require('enyo/Group'),
 	Button = require('garnet/Button'),
 	Panel = require('garnet/Panel');
@@ -15,7 +14,7 @@ var ButtonPanel = kind({
 	},
 	classes: 'g-layout-absolute-wrapper',
 	components: [
-		{classes: 'g-layout-absolute-center', classes: 'g-sample-button-container', components: [
+		{classes: 'g-sample-button-container g-layout-absolute-center', components: [
 			{name: 'B Button', kind: Button, content: 'B', ontap: 'tapButton'},
 			{name: 'Button', kind: Button, content: 'Btn A', ontap: 'tapButton'},
 			{name: 'B Button Disabled', kind: Button, content: 'Disabled', classes: 'g-sample-button-disable', disabled: true, ontap: 'tapButton'},

--- a/garnet/src/ButtonSample.js
+++ b/garnet/src/ButtonSample.js
@@ -19,9 +19,9 @@ var ButtonPanel = kind({
 			{name: 'B Button', kind: Button, content: 'B', ontap: 'tapButton'},
 			{name: 'Button', kind: Button, content: 'Btn A', ontap: 'tapButton'},
 			{name: 'B Button Disabled', kind: Button, content: 'Disabled', classes: 'g-sample-button-disable', disabled: true, ontap: 'tapButton'},
-			{content: 'Fixed Button : ', classes: 'g-sample-button-fixed'},
-			{name: 'Fixed Button', kind: Button, content: 'Fixed Button', classes: 'g-sample-button-fixed2', ontap: 'tapButton'},
-			{content: 'Grouped Buttons : ', classes: 'g-sample-button-group-text'},
+			{content: 'Fixed Button : ', classes: 'g-sample-text'},
+			{name: 'Fixed Button', kind: Button, content: 'Fixed Button', classes: 'g-sample-button-fixed', ontap: 'tapButton'},
+			{content: 'Grouped Buttons : ', classes: 'g-sample-text'},
 			{kind: Group, components: [
 				{name: 'Apple Button', kind: Button, active: true, content: 'AA', ontap: 'tapButton'},
 				{name: 'Banana Button', kind: Button, content: 'BB', ontap: 'tapButton'},

--- a/garnet/src/ButtonSample.js
+++ b/garnet/src/ButtonSample.js
@@ -14,15 +14,14 @@ var ButtonPanel = kind({
 		onResult: ''
 	},
 	classes: 'g-layout-absolute-wrapper',
-	style: 'border-radius: 50%; background-color: #000000;',
 	components: [
-		{classes: 'g-layout-absolute-center', style: 'width: ' + ri.scale(280) + 'px; height: ' + ri.scale(230) + 'px;', components: [
+		{classes: 'g-layout-absolute-center', classes: 'g-sample-button-container', components: [
 			{name: 'B Button', kind: Button, content: 'B', ontap: 'tapButton'},
 			{name: 'Button', kind: Button, content: 'Btn A', ontap: 'tapButton'},
-			{name: 'B Button Disabled', kind: Button, content: 'Disabled', style: 'width: ' + ri.scale(100) + 'px', disabled: true, ontap: 'tapButton'},
-			{content: 'Fixed Button : ', style: 'font-size: ' + ri.scale(20) + 'px; display: inline-block; margin-right: ' + ri.scale(10) + 'px; color: #FFFFFF;'},
-			{name: 'Fixed Button', kind: Button, content: 'Fixed Button', style: 'width: ' + ri.scale(280) + 'px;', ontap: 'tapButton'},
-			{content: 'Grouped Buttons : ', style: 'font-size: ' + ri.scale(20) + 'px; display: inline-block; margin-right: ' + ri.scale(10) + 'px; color: #FFFFFF;'},
+			{name: 'B Button Disabled', kind: Button, content: 'Disabled', classes: 'g-sample-button-disable', disabled: true, ontap: 'tapButton'},
+			{content: 'Fixed Button : ', classes: 'g-sample-button-fixed'},
+			{name: 'Fixed Button', kind: Button, content: 'Fixed Button', classes: 'g-sample-button-fixed2', ontap: 'tapButton'},
+			{content: 'Grouped Buttons : ', classes: 'g-sample-button-group-text'},
 			{kind: Group, components: [
 				{name: 'Apple Button', kind: Button, active: true, content: 'AA', ontap: 'tapButton'},
 				{name: 'Banana Button', kind: Button, content: 'BB', ontap: 'tapButton'},
@@ -42,7 +41,7 @@ module.exports = kind({
 		{content: '< Button Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'Buttons', classes: 'g-sample-subheader'},
-		{kind: ButtonPanel, style: 'position: relative;', onResult: 'result'},
+		{kind: ButtonPanel, classes: 'g-sample-circle-panel', onResult: 'result'},
 
 		{src: '@../assets/btn_command_next.svg', classes: 'g-sample-result', components: [
 			{content: 'Result', classes: 'g-sample-subheader'},

--- a/garnet/src/ButtonSample.less
+++ b/garnet/src/ButtonSample.less
@@ -1,6 +1,7 @@
 /* ButtonSample */
 
-// common
+// Common classes
+
 .g-sample-circle-panel {
 	background-color: #000000;
 
@@ -24,6 +25,8 @@
 	font-size: 20px;
 	color: #FFFFFF;
 }
+
+// sample specific classes
 
 .g-sample-button-container {
 	width: 280px;

--- a/garnet/src/ButtonSample.less
+++ b/garnet/src/ButtonSample.less
@@ -16,6 +16,11 @@
 	z-index: 9999;
 	opacity: 0.8;
 }
+.g-sample-text {
+	display: inline-block;
+	font-size: 20px;
+	color: #FFFFFF;
+}
 
 .g-sample-button-container {
 	width: 280px; height: 230px;
@@ -24,11 +29,5 @@
 	width: 100px;
 }
 .g-sample-button-fixed {
-	font-size: 20px; display: inline-block; margin-right: 10px; color: #FFFFFF;
-}
-.g-sample-button-fixed2 {
 	width: 280px;
-}
-.g-sample-button-group-text {
-	font-size: 20px; display: inline-block; margin-right: 10px; color: #FFFFFF;
 }

--- a/garnet/src/ButtonSample.less
+++ b/garnet/src/ButtonSample.less
@@ -26,7 +26,7 @@
 	color: #FFFFFF;
 }
 
-// sample specific classes
+// Sample specific classes
 
 .g-sample-button-container {
 	width: 280px;

--- a/garnet/src/ButtonSample.less
+++ b/garnet/src/ButtonSample.less
@@ -1,1 +1,34 @@
 /* ButtonSample */
+
+// common
+.g-sample-circle-panel {
+	background-color: #000000;
+	position: relative;
+	overflow: hidden;
+	border-radius: 50%;
+}
+.g-sample-result {
+	background-color: #EDEDED;
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
+
+.g-sample-button-container {
+	width: 280px; height: 230px;
+}
+.g-sample-button-disable {
+	width: 100px;
+}
+.g-sample-button-fixed {
+	font-size: 20px; display: inline-block; margin-right: 10px; color: #FFFFFF;
+}
+.g-sample-button-fixed2 {
+	width: 280px;
+}
+.g-sample-button-group-text {
+	font-size: 20px; display: inline-block; margin-right: 10px; color: #FFFFFF;
+}

--- a/garnet/src/ButtonSample.less
+++ b/garnet/src/ButtonSample.less
@@ -3,12 +3,14 @@
 // common
 .g-sample-circle-panel {
 	background-color: #000000;
+
 	position: relative;
-	overflow: hidden;
 	border-radius: 50%;
+	overflow: hidden;
 }
 .g-sample-result {
 	background-color: #EDEDED;
+
 	position: fixed;
 	width: 100%;
 	min-height: 160px;
@@ -18,12 +20,14 @@
 }
 .g-sample-text {
 	display: inline-block;
+
 	font-size: 20px;
 	color: #FFFFFF;
 }
 
 .g-sample-button-container {
-	width: 280px; height: 230px;
+	width: 280px;
+	height: 230px;
 }
 .g-sample-button-disable {
 	width: 100px;

--- a/garnet/src/CheckboxSample.js
+++ b/garnet/src/CheckboxSample.js
@@ -14,16 +14,15 @@ var CheckboxPanel = kind({
 		onResult: ''
 	},
 	classes: 'g-layout-absolute-wrapper',
-	style: 'border-radius: 50%; background-color: #000000;',
 	components: [
-		{classes: 'g-layout-absolute-center g-sample-setting', style: 'width: ' + ri.scale(255) + 'px; height: ' + ri.scale(230) + 'px;', components: [
-			{content: 'Checkboxes : ', style: 'margin-left: ' + ri.scale(10) + 'px; font-size: ' + ri.scale(20) + 'px; display: inline-block; margin-right: ' + ri.scale(10) + 'px; color: #FFFFFF;'},
+		{classes: 'g-layout-absolute-center g-sample-setting', classes: 'g-sample-checkbox-container', components: [
+			{content: 'Checkboxes : ', classes: 'g-samle-checkbox-checkboxes-text'},
 			{tag: 'br'},
 			{kind: Checkbox, onchange:'checkboxChanged'},
 			{kind: Checkbox, onchange:'checkboxChanged', checked: true},
 			{kind: Checkbox, onchange:'checkboxChanged', disabled: true},
 			{kind: Checkbox, onchange:'checkboxChanged', checked: true, disabled: true},
-			{content: 'Grouped Checkboxes : ', style: 'font-size: ' + ri.scale(20) + 'px; display: inline-block; margin-right: ' + ri.scale(10) + 'px; color: #FFFFFF;'},
+			{content: 'Grouped Checkboxes : ', classes: 'g-samle-checkbox-checkboxes-group-text'},
 			{kind: Group, onActivate:'groupActivated', components: [
 				{kind: Checkbox, checked: true},
 				{kind: Checkbox},
@@ -51,7 +50,7 @@ module.exports = kind({
 		{content: '< Checkbox Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'Checkboxes', classes: 'g-sample-subheader'},
-		{kind: CheckboxPanel, style: 'position: relative;', onResult: 'result'},
+		{kind: CheckboxPanel, classes: 'g-sample-circle-panel', onResult: 'result'},
 
 		{src: '@../assets/btn_command_next.svg', classes: 'g-sample-result', components: [
 			{content: 'Result', classes: 'g-sample-subheader'},

--- a/garnet/src/CheckboxSample.js
+++ b/garnet/src/CheckboxSample.js
@@ -16,13 +16,13 @@ var CheckboxPanel = kind({
 	classes: 'g-layout-absolute-wrapper',
 	components: [
 		{classes: 'g-layout-absolute-center g-sample-setting', classes: 'g-sample-checkbox-container', components: [
-			{content: 'Checkboxes : ', classes: 'g-samle-checkbox-checkboxes-text'},
+			{content: 'Checkboxes : ', classes: 'g-sample-text'},
 			{tag: 'br'},
 			{kind: Checkbox, onchange:'checkboxChanged'},
 			{kind: Checkbox, onchange:'checkboxChanged', checked: true},
 			{kind: Checkbox, onchange:'checkboxChanged', disabled: true},
 			{kind: Checkbox, onchange:'checkboxChanged', checked: true, disabled: true},
-			{content: 'Grouped Checkboxes : ', classes: 'g-samle-checkbox-checkboxes-group-text'},
+			{content: 'Grouped Checkboxes : ', classes: 'g-sample-text'},
 			{kind: Group, onActivate:'groupActivated', components: [
 				{kind: Checkbox, checked: true},
 				{kind: Checkbox},

--- a/garnet/src/CheckboxSample.js
+++ b/garnet/src/CheckboxSample.js
@@ -2,7 +2,6 @@ require('garnet');
 
 var
 	kind = require('enyo/kind'),
-	ri = require('enyo/resolution'),
 	Group = require('enyo/Group'),
 	Checkbox = require('garnet/Checkbox'),
 	Panel = require('garnet/Panel');
@@ -15,7 +14,7 @@ var CheckboxPanel = kind({
 	},
 	classes: 'g-layout-absolute-wrapper',
 	components: [
-		{classes: 'g-layout-absolute-center g-sample-setting', classes: 'g-sample-checkbox-container', components: [
+		{classes: 'g-sample-checkbox-container g-layout-absolute-center g-sample-setting', components: [
 			{content: 'Checkboxes : ', classes: 'g-sample-text'},
 			{tag: 'br'},
 			{kind: Checkbox, onchange:'checkboxChanged'},

--- a/garnet/src/CheckboxSample.less
+++ b/garnet/src/CheckboxSample.less
@@ -16,7 +16,7 @@
 	color: #FFFFFF;
 }
 
-// sample specific classes
+// Sample specific classes
 
 .g-sample-checkbox-container {
 	width: 255px;

--- a/garnet/src/CheckboxSample.less
+++ b/garnet/src/CheckboxSample.less
@@ -7,13 +7,12 @@
 	overflow: hidden;
 	border-radius: 50%;
 }
+.g-sample-text {
+	display: inline-block;
+	font-size: 20px;
+	color: #FFFFFF;
+}
 
 .g-sample-checkbox-container {
-	width: 255px; height: 230px;
-}
-.g-samle-checkbox-checkboxes-text {
-	margin-left: 10px; font-size: 20px; display: inline-block; margin-right: 10px; color: #FFFFFF;
-}
-.g-samle-checkbox-checkboxes-group-text {
-	font-size: 20px; display: inline-block; margin-right: 10px; color: #FFFFFF;
+	width: 255px; height: 200px;
 }

--- a/garnet/src/CheckboxSample.less
+++ b/garnet/src/CheckboxSample.less
@@ -3,16 +3,19 @@
 // common
 .g-sample-circle-panel {
 	background-color: #000000;
+
 	position: relative;
-	overflow: hidden;
 	border-radius: 50%;
+	overflow: hidden;
 }
 .g-sample-text {
 	display: inline-block;
+
 	font-size: 20px;
 	color: #FFFFFF;
 }
 
 .g-sample-checkbox-container {
-	width: 255px; height: 200px;
+	width: 255px;
+	height: 200px;
 }

--- a/garnet/src/CheckboxSample.less
+++ b/garnet/src/CheckboxSample.less
@@ -1,6 +1,7 @@
 /* CheckboxSample */
 
-// common
+// Common classes
+
 .g-sample-circle-panel {
 	background-color: #000000;
 
@@ -14,6 +15,8 @@
 	font-size: 20px;
 	color: #FFFFFF;
 }
+
+// sample specific classes
 
 .g-sample-checkbox-container {
 	width: 255px;

--- a/garnet/src/CheckboxSample.less
+++ b/garnet/src/CheckboxSample.less
@@ -1,1 +1,19 @@
 /* CheckboxSample */
+
+// common
+.g-sample-circle-panel {
+	background-color: #000000;
+	position: relative;
+	overflow: hidden;
+	border-radius: 50%;
+}
+
+.g-sample-checkbox-container {
+	width: 255px; height: 230px;
+}
+.g-samle-checkbox-checkboxes-text {
+	margin-left: 10px; font-size: 20px; display: inline-block; margin-right: 10px; color: #FFFFFF;
+}
+.g-samle-checkbox-checkboxes-group-text {
+	font-size: 20px; display: inline-block; margin-right: 10px; color: #FFFFFF;
+}

--- a/garnet/src/CommandBarSample.js
+++ b/garnet/src/CommandBarSample.js
@@ -3,7 +3,6 @@ require('garnet');
 // dafult commandBar sample
 var
 	kind = require('enyo/kind'),
-	ri = require('enyo/resolution'),
 	Button = require('garnet/Button'),
 	Panel = require('garnet/Panel'),
 	Scroller = require('garnet/Scroller'),

--- a/garnet/src/CommandBarSample.js
+++ b/garnet/src/CommandBarSample.js
@@ -22,8 +22,8 @@ var DefaultCommandBarPanel = kind({
 			classes: 'enyo-fit g-layout-text-center',
 			components: [
 				{kind: Title, content: 'Title'},
-				{style: 'padding-top: 60px; width: 200px; margin: auto;', content: 'Garnet is a UI library built for wearable devices and is based on Enyo. Garnet supports LG smart watch as well as the emulator provided. Browser-wise, Garnet supports the browser on LG smart watch, Firefox 16, Opera 15, Safari 3.1, Chrome 27 and their higher versions.'},
-				{kind: Button, style: 'margin: ' + ri.scale(20) + 'px 0 ' + ri.scale(116) + 'px;', content: 'OK!!!'}
+				{classes: 'g-sample-commandbar-content', content: 'Garnet is a UI library built for wearable devices and is based on Enyo. Garnet supports LG smart watch as well as the emulator provided. Browser-wise, Garnet supports the browser on LG smart watch, Firefox 16, Opera 15, Safari 3.1, Chrome 27 and their higher versions.'},
+				{kind: Button, classes: 'g-sample-commandbar-button', content: 'OK!!!'}
 			]
 		}
 	],
@@ -50,8 +50,8 @@ var SingleCommandBarPanel = kind({
 			classes: 'enyo-fit g-layout-text-center',
 			components: [
 				{kind: Title, content: 'Title'},
-				{style: 'padding-top: 60px; width: 200px; margin: auto;', content: 'Garnet is a UI library built for wearable devices and is based on Enyo. Garnet supports LG smart watch as well as the emulator provided. Browser-wise, Garnet supports the browser on LG smart watch, Firefox 16, Opera 15, Safari 3.1, Chrome 27 and their higher versions.'},
-				{kind: Button, style: 'margin: ' + ri.scale(20) + 'px 0 ' + ri.scale(116) + 'px;', content: 'OK!!!'}
+				{classes: 'g-sample-commandbar-content', content: 'Garnet is a UI library built for wearable devices and is based on Enyo. Garnet supports LG smart watch as well as the emulator provided. Browser-wise, Garnet supports the browser on LG smart watch, Firefox 16, Opera 15, Safari 3.1, Chrome 27 and their higher versions.'},
+				{kind: Button, classes: 'g-sample-commandbar-button', content: 'OK!!!'}
 			]
 		}
 	],
@@ -77,8 +77,8 @@ var CustomCommandBarPanel = kind({
 			classes: 'enyo-fit g-layout-text-center',
 			components: [
 				{kind: Title, content: 'Title'},
-				{style: 'padding-top: 60px; width: 200px; margin: auto;', content: 'Garnet is a UI library built for wearable devices and is based on Enyo. Garnet supports LG smart watch as well as the emulator provided. Browser-wise, Garnet supports the browser on LG smart watch, Firefox 16, Opera 15, Safari 3.1, Chrome 27 and their higher versions.'},
-				{kind: Button, style: 'margin: ' + ri.scale(20) + 'px 0 ' + ri.scale(116) + 'px;', content: 'OK!!!'}
+				{classes: 'g-sample-commandbar-content', content: 'Garnet is a UI library built for wearable devices and is based on Enyo. Garnet supports LG smart watch as well as the emulator provided. Browser-wise, Garnet supports the browser on LG smart watch, Firefox 16, Opera 15, Safari 3.1, Chrome 27 and their higher versions.'},
+				{kind: Button, classes: 'g-sample-commandbar-button', content: 'OK!!!'}
 			]
 		}
 	],
@@ -105,25 +105,25 @@ module.exports = kind({
 		{content: '< CommandBar Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'Default / Single / Custom', classes: 'g-sample-subheader'},
-		{style: 'position: relative; height: 100%;', components: [
+		{classes: 'g-sample-panels', components: [
 			{
 				name: 'commandBar1',
 				kind: DefaultCommandBarPanel,
-				style: 'background-color: #000000; position: relative; display: inline-block; overflow: hidden;'
+				classes: 'g-sample-panel-margin'
 			},
 			{
 				name: 'commandBar2',
 				kind: SingleCommandBarPanel,
-				style: 'background-color: #000000; position: relative; display: inline-block; margin-left: ' + ri.scale(10) + 'px; overflow: hidden;'
+				classes: 'g-sample-panel-margin'
 			},
 			{
 				name: 'commandBar3',
 				kind: CustomCommandBarPanel,
-				style: 'background-color: #000000; position: relative; display: inline-block; margin-left: ' + ri.scale(10) + 'px; overflow: hidden;'
+				classes: 'g-sample-panel-margin'
 			}
 		]},
 
-		{style: 'position: fixed; width: 100%; min-height: ' + ri.scale(160)+ 'px; bottom: 0; z-index: 9999; background-color: #EDEDED; opacity: 0.8;', classes: 'g-sample-result', components: [
+		{classes: 'g-sample-result', components: [
 			{content: 'Result', classes: 'g-sample-subheader'},
 			{name: 'result', allowHtml: true, content: 'No button pressed yet.', classes: 'g-sample-description'}
 		]}

--- a/garnet/src/CommandBarSample.less
+++ b/garnet/src/CommandBarSample.less
@@ -1,6 +1,7 @@
 /* CommandBarSample */
 
-// Common
+// Common classes
+
 .g-sample-panels {
 	position: relative;
 	height: 100%;
@@ -23,6 +24,8 @@
 	z-index: 9999;
 	opacity: 0.8;
 }
+
+// Sample specific classes
 
 .g-sample-commandbar-content {
 	width: 200px;

--- a/garnet/src/CommandBarSample.less
+++ b/garnet/src/CommandBarSample.less
@@ -2,17 +2,20 @@
 
 // Common
 .g-sample-panels {
-	position: relative; height: 100%;
+	position: relative;
+	height: 100%;
 }
 .g-sample-panel-margin {
 	background-color: #000000;
+
 	position: relative;
-	overflow: hidden;
 	display: inline-block;
 	margin-right: 10px;
+	overflow: hidden;
 }
 .g-sample-result {
 	background-color: #EDEDED;
+
 	position: fixed;
 	width: 100%;
 	min-height: 160px;
@@ -22,7 +25,9 @@
 }
 
 .g-sample-commandbar-content {
-	padding-top: 60px; width: 200px; margin: auto;
+	width: 200px;
+	margin: auto;
+	padding-top: 60px;
 }
 .g-sample-commandbar-button {
 	margin: 20px 0 116px;

--- a/garnet/src/CommandBarSample.less
+++ b/garnet/src/CommandBarSample.less
@@ -1,1 +1,29 @@
 /* CommandBarSample */
+
+// Common
+.g-sample-panels {
+	position: relative; height: 100%;
+}
+.g-sample-panel-margin {
+	background-color: #000000;
+	position: relative;
+	overflow: hidden;
+	display: inline-block;
+	margin-right: 10px;
+}
+.g-sample-result {
+	background-color: #EDEDED;
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
+
+.g-sample-commandbar-content {
+	padding-top: 60px; width: 200px; margin: auto;
+}
+.g-sample-commandbar-button {
+	margin: 20px 0 116px;
+}

--- a/garnet/src/ConfirmPanelSample.js
+++ b/garnet/src/ConfirmPanelSample.js
@@ -179,7 +179,6 @@ var PanelManager = kind({
 		onPushPanel: 'pushPanel',
 		onPopPanel: 'popPanel'
 	},
-	classes: 'enyo-fit',
 	components: [
 		{kind: ConfirmBasePanel, classes: 'g-sample-panel'}
 	],

--- a/garnet/src/ConfirmPanelSample.js
+++ b/garnet/src/ConfirmPanelSample.js
@@ -12,9 +12,7 @@ var
 	Scroller = require('garnet/Scroller'),
 	PopupPanelScroller = require('garnet/PopupPanelScroller'),
 	IconButton = require('garnet/IconButton'),
-	PanelManager = require('garnet/PanelManager'),
-
-	panelStyle = 'width: ' + ri.scale(320) + 'px; height: ' + ri.scale(320) + 'px; position: relative; display: inline-block;';
+	PanelManager = require('garnet/PanelManager')
 
 var OneTextPanel = kind({
 	name: 'confirmPanelNoScrollNoIcon',
@@ -147,10 +145,10 @@ var ConfirmBasePanel = kind({
 		onCancel: 'result'
 	},
 	components: [
-		{name: 'button1', kind: Button, style: 'margin:' + ri.scale(20) + 'px ' + ri.scale(5) +'px ' + ri.scale(5) +'px; width:' + ri.scale(310) + 'px', ontap: 'showPanel', content: 'Only text'},
-		{name: 'button2', kind: Button, style: 'margin:' + ri.scale(5) + 'px; width:' + ri.scale(310) + 'px', ontap: 'showPanel', content: 'Scroll + Text'},
-		{name: 'button3', kind: Button, style: 'margin:' + ri.scale(5) + 'px; width:' + ri.scale(310) + 'px', ontap: 'showPanel', content: 'Icon + Title + Text'},
-		{name: 'button4', kind: Button, style: 'margin:' + ri.scale(5) + 'px; width:' + ri.scale(310) + 'px', ontap: 'showPanel', content: 'Scroll+Icon+Title+Text'}
+		{name: 'button1', kind: Button, classes: 'g-sample-confirm-panel-button', ontap: 'showPanel', content: 'Only text'},
+		{name: 'button2', kind: Button, classes: 'g-sample-confirm-panel-button', ontap: 'showPanel', content: 'Scroll + Text'},
+		{name: 'button3', kind: Button, classes: 'g-sample-confirm-panel-button', ontap: 'showPanel', content: 'Icon + Title + Text'},
+		{name: 'button4', kind: Button, classes: 'g-sample-confirm-panel-button', ontap: 'showPanel', content: 'Scroll+Icon+Title+Text'}
 	],
 	showPanel: function(inSender, inEvent) {
 		var name = inSender.name;
@@ -218,8 +216,8 @@ module.exports = kind({
 		{content: '< Confirm Panel Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'Confirm with only Text/Scroll + Text /Icon+Title+Text/ Scorll + Icon + Title+ Text ', classes: 'g-sample-subheader'},
-		{style: panelStyle, kind: PanelManager},
-		{style: 'position: fixed; width: 100%; min-height: +' + ri.scale(160) + 'px; bottom: 0; z-index: 9999; background-color: #EDEDED; opacity: 0.8;', classes: 'g-sample-result', components: [
+		{kind: PanelManager, classes: 'g-sample-panel-manager'},
+		{classes: 'g-sample-result', components: [
 			{content: 'Result', classes: 'g-sample-subheader'},
 			{name: 'result', allowHtml: true, content: 'No button pressed yet.', classes: 'g-sample-description'}
 		]}

--- a/garnet/src/ConfirmPanelSample.js
+++ b/garnet/src/ConfirmPanelSample.js
@@ -2,8 +2,7 @@ require('garnet');
 
 var
 	kind = require('enyo/kind'),
-	utils = require('enyo/utils'),
-	ri = require('enyo/resolution');
+	utils = require('enyo/utils');
 
 var
 	Button = require('garnet/Button'),
@@ -12,7 +11,7 @@ var
 	Scroller = require('garnet/Scroller'),
 	PopupPanelScroller = require('garnet/PopupPanelScroller'),
 	IconButton = require('garnet/IconButton'),
-	PanelManager = require('garnet/PanelManager')
+	PanelManager = require('garnet/PanelManager');
 
 var OneTextPanel = kind({
 	name: 'confirmPanelNoScrollNoIcon',
@@ -182,7 +181,7 @@ var PanelManager = kind({
 	},
 	classes: 'enyo-fit',
 	components: [
-		{kind: ConfirmBasePanel}
+		{kind: ConfirmBasePanel, classes: 'g-sample-panel'}
 	],
 	pushPanel: function (inSender, inEvent) {
 		var type = {

--- a/garnet/src/ConfirmPanelSample.less
+++ b/garnet/src/ConfirmPanelSample.less
@@ -9,6 +9,7 @@
 }
 .g-sample-result {
 	background-color: #EDEDED;
+
 	position: fixed;
 	width: 100%;
 	min-height: 160px;
@@ -18,7 +19,8 @@
 }
 
 .g-sample-confirm-panel-button {
-	margin:5px; width:310px;
+	width:310px;
+	margin:5px;
 }
 .g-sample-confirm-panel-button:first-child {
 	margin:20px 5px 5px;

--- a/garnet/src/ConfirmPanelSample.less
+++ b/garnet/src/ConfirmPanelSample.less
@@ -1,1 +1,25 @@
 /* ConfirmPanelSample */
+
+// Common
+.g-sample-panel-manager {
+	position: relative;
+	display: inline-block;
+	width: 320px;
+	height: 320px;
+}
+.g-sample-result {
+	background-color: #EDEDED;
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
+
+.g-sample-confirm-panel-button {
+	margin:5px; width:310px;
+}
+.g-sample-confirm-panel-button:first-child {
+	margin:20px 5px 5px;
+}

--- a/garnet/src/ConfirmPanelSample.less
+++ b/garnet/src/ConfirmPanelSample.less
@@ -1,6 +1,7 @@
 /* ConfirmPanelSample */
 
-// Common
+// Common classes
+
 .g-sample-panel-manager {
 	position: relative;
 	display: inline-block;
@@ -17,6 +18,8 @@
 	z-index: 9999;
 	opacity: 0.8;
 }
+
+// Sample specific classes
 
 .g-sample-confirm-panel-button {
 	width:310px;

--- a/garnet/src/ConfirmPanelSample.less
+++ b/garnet/src/ConfirmPanelSample.less
@@ -2,7 +2,12 @@
 
 // Common classes
 
-.g-sample-panel-manager {
+.g-sample-panel {
+	background-color: #000000;
+
+	position: relative;
+	overflow: hidden;
+}.g-sample-panel-manager {
 	position: relative;
 	display: inline-block;
 	width: 320px;

--- a/garnet/src/ContextualPanelSample.js
+++ b/garnet/src/ContextualPanelSample.js
@@ -12,9 +12,6 @@ var
 	Scroller = require('garnet/Scroller'),
 	PanelManager = require('garnet/PanelManager');
 
-var
-	panelStyle = 'width: ' + ri.scale(320) + 'px; height: ' + ri.scale(320) + 'px; position: relative; display: inline-block; ';
-
 var OneButtonPanel = kind({
 	name: 'g.sample.OneButtonPanel',
 	kind: ContextualPanel,
@@ -109,9 +106,9 @@ var ContextualBasePanel = kind({
 		onButtonTap: 'result'
 	},
 	components: [
-		{name: 'oneButton', kind: Button, style: 'margin: ' + ri.scale(55)+ 'px ' + ri.scale(5) + 'px ' + ri.scale(5)+ 'px; width: ' + ri.scale(310) + 'px;', ontap: 'showPanel', content: 'Click here to show panel!'},
-		{name: 'twoButton', kind: Button, style: 'margin: ' + ri.scale(5) + 'px; width: ' + ri.scale(310) + 'px;', ontap: 'showPanel', content: 'Click here to show panel!'},
-		{name: 'threeButton', kind: Button, style: 'margin: ' + ri.scale(5) + 'px; width: ' + ri.scale(310) + 'px;', ontap: 'showPanel', content: 'Click here to show panel!'}
+		{name: 'oneButton', kind: Button, classes: 'g-sample-contextual-panel-button:first-child', ontap: 'showPanel', content: 'Click here to show panel!'},
+		{name: 'twoButton', kind: Button, classes: 'g-sample-contextual-panel-button', ontap: 'showPanel', content: 'Click here to show panel!'},
+		{name: 'threeButton', kind: Button, classes: 'g-sample-contextual-panel-button', ontap: 'showPanel', content: 'Click here to show panel!'}
 	],
 	showPanel: function(inSender, inEvent) {
 		var name = inSender.name;
@@ -176,8 +173,8 @@ module.exports = kind({
 		{content: '< ContextualPanel Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'Contextual with 1 button / 2 buttons / 3 buttons', classes: 'g-sample-subheader'},
-		{style: panelStyle, kind: PanelManager},
-		{style: 'position: fixed; width: 100%; min-height: +' + ri.scale(160) + 'px; bottom: 0; z-index: 9999; background-color: #EDEDED; opacity: 0.8;', classes: 'g-sample-result', components: [
+		{kind: PanelManager, classes: 'g-sample-panel-manager'},
+		{classes: 'g-sample-result', components: [
 			{content: 'Result', classes: 'g-sample-subheader'},
 			{name: 'result', allowHtml: true, content: 'No button pressed yet.', classes: 'g-sample-description'}
 		]}

--- a/garnet/src/ContextualPanelSample.js
+++ b/garnet/src/ContextualPanelSample.js
@@ -137,7 +137,6 @@ var PanelManager = kind({
 		onPushPanel: 'pushPanel',
 		onPopPanel: 'popPanel'
 	},
-	classes: 'enyo-fit',
 	components: [
 		{kind: ContextualBasePanel}
 	],

--- a/garnet/src/ContextualPanelSample.js
+++ b/garnet/src/ContextualPanelSample.js
@@ -2,8 +2,7 @@ require('garnet');
 
 var
 	kind = require('enyo/kind'),
-	utils = require('enyo/utils'),
-	ri = require('enyo/resolution');
+	utils = require('enyo/utils');
 
 var
 	Button = require('garnet/Button'),

--- a/garnet/src/ContextualPanelSample.less
+++ b/garnet/src/ContextualPanelSample.less
@@ -1,1 +1,25 @@
 /* ContextualPanelSample */
+
+// Common
+.g-sample-panel-manager {
+	position: relative;
+	display: inline-block;
+	width: 320px;
+	height: 320px;
+}
+.g-sample-result {
+	background-color: #EDEDED;
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
+
+.g-sample-contextual-panel-button {
+	margin:5px; width:310px;
+}
+.g-sample-contextual-panel-button:first-child {
+	margin:55px 5px 5px;
+}

--- a/garnet/src/ContextualPanelSample.less
+++ b/garnet/src/ContextualPanelSample.less
@@ -1,6 +1,7 @@
 /* ContextualPanelSample */
 
-// Common
+// Common classes
+
 .g-sample-panel-manager {
 	position: relative;
 	display: inline-block;
@@ -17,6 +18,8 @@
 	z-index: 9999;
 	opacity: 0.8;
 }
+
+// Sample specific classes
 
 .g-sample-contextual-panel-button {
 	width:310px;

--- a/garnet/src/ContextualPanelSample.less
+++ b/garnet/src/ContextualPanelSample.less
@@ -9,6 +9,7 @@
 }
 .g-sample-result {
 	background-color: #EDEDED;
+
 	position: fixed;
 	width: 100%;
 	min-height: 160px;
@@ -18,7 +19,8 @@
 }
 
 .g-sample-contextual-panel-button {
-	margin:5px; width:310px;
+	width:310px;
+	margin:5px;
 }
 .g-sample-contextual-panel-button:first-child {
 	margin:55px 5px 5px;

--- a/garnet/src/DataGridListSample.js
+++ b/garnet/src/DataGridListSample.js
@@ -101,13 +101,12 @@ var DataGridListPanel = kind({
 	knob: true,
 	selection: false,
 	classes: 'g-layout-absolute-wrapper',
-	style: 'background-color: #000000;',
 	components: [{
 		name: 'list',
 		kind: DataGridList,
 		controlsPerPage: 8,
 		spacing: 0,
-		style: 'width: ' + ri.scale(232) + 'px; height: ' + ri.scale(320) + 'px; margin: auto; background-color: #000000;',
+		classes: 'g-sample-gridlist-panel',
 		headerComponents: [{kind: Title, content: 'Title: long text will fade out'}],
 		components: [{
 			kind: DataGridListItem
@@ -135,7 +134,7 @@ var DataGridListCirclePanel = kind({
 		controlsPerPage: 8,
 		spacing: 0,
 		minHeight: 106,
-		style: 'width: ' + ri.scale(230) + 'px; height: ' + ri.scale(320) + 'px; margin: auto; background-color: #000000;',
+		classes: 'g-sample-gridlist-panel',
 		headerComponents: [{kind: Title, content: 'Title'}],
 		components: [{
 			kind: DataGridListCircleItem
@@ -156,24 +155,24 @@ var DataGridListSample = module.exports = kind({
 		}, {
 			name: 'gridListCircle',
 			kind: DataGridListCirclePanel,
-			style: 'position: relative; display: inline-block; margin-right: ' + ri.scale(20) + 'px;',
+			classes: 'g-sample-panel-margin',
 			selection: true,
 			selectionType: 'multi'
 		}, {
 			name: 'gridListMulti',
 			kind: DataGridListPanel,
-			style: 'position: relative; display: inline-block; margin-right: ' + ri.scale(20) + 'px;',
+			classes: 'g-sample-panel-margin',
 			selection: true,
 			selectionType: 'multi'
 		}, {
 			name: 'gridListSingleCircle',
 			kind: DataGridListCirclePanel,
-			style: 'position: relative; display: inline-block; margin-right: ' + ri.scale(20) + 'px;',
+			classes: 'g-sample-panel-margin',
 			selection: true
 		}, {
 			name: 'gridListSingle',
 			kind: DataGridListPanel,
-			style: 'position: relative; display: inline-block; margin-right: ' + ri.scale(20) + 'px;',
+			classes: 'g-sample-panel-margin',
 			selection: true
 		}
 	],

--- a/garnet/src/DataGridListSample.js
+++ b/garnet/src/DataGridListSample.js
@@ -13,7 +13,7 @@ var
 
 var DataGridListImageItem = kind({
 	name: 'g.sample.DataGridListImageItem',
-	classes: 'g-sample-gridlist-imageitem',
+	classes: 'g-sample-datagridlist-imageitem',
 	components: [{
 		name: 'image',
 		kind: EnyoImage
@@ -73,7 +73,7 @@ var DataGridListItem = kind({
 var DataGridListCircleImageItem = kind({
 	name: 'g.sample.DataGridListCircleImageItem',
 	kind: DataGridListImageItem,
-	classes: 'g-sample-gridlist-circle-imageitem'
+	classes: 'g-sample-datagridlist-circle-imageitem'
 });
 
 var DataGridListCircleItem = kind({
@@ -106,7 +106,7 @@ var DataGridListPanel = kind({
 		kind: DataGridList,
 		controlsPerPage: 8,
 		spacing: 0,
-		classes: 'g-sample-gridlist-panel',
+		classes: 'g-sample-datagridlist-panel',
 		headerComponents: [{kind: Title, content: 'Title: long text will fade out'}],
 		components: [{
 			kind: DataGridListItem
@@ -134,7 +134,7 @@ var DataGridListCirclePanel = kind({
 		controlsPerPage: 8,
 		spacing: 0,
 		minHeight: 106,
-		classes: 'g-sample-gridlist-panel',
+		classes: 'g-sample-datagridlist-panel',
 		headerComponents: [{kind: Title, content: 'Title'}],
 		components: [{
 			kind: DataGridListCircleItem

--- a/garnet/src/DataGridListSample.js
+++ b/garnet/src/DataGridListSample.js
@@ -2,7 +2,6 @@ require('garnet');
 
 var
 	kind = require('enyo/kind'),
-	ri = require('enyo/resolution'),
 	Collection = require('enyo/Collection.js'),
 	EmptyBinding = require('enyo/EmptyBinding.js'),
 	EnyoImage = require('enyo/Image'),

--- a/garnet/src/DataGridListSample.less
+++ b/garnet/src/DataGridListSample.less
@@ -1,6 +1,18 @@
 /* DataGridListSample */
 
-.g-sample-gridlist-imageitem{
+// Common
+.g-sample-panel-margin {
+	background-color: #000000;
+	position: relative;
+	overflow: hidden;
+	display: inline-block;
+	margin-right: 10px;
+}
+
+.g-sample-gridlist-panel {
+	width: 232px; height: 320px; margin: auto; background-color: #000000;
+}
+.g-sample-gridlist-imageitem {
 	width: 127px;
 	height: 127px;
 	cursor: pointer;

--- a/garnet/src/DataGridListSample.less
+++ b/garnet/src/DataGridListSample.less
@@ -3,30 +3,39 @@
 // Common
 .g-sample-panel-margin {
 	background-color: #000000;
+
 	position: relative;
-	overflow: hidden;
 	display: inline-block;
 	margin-right: 10px;
+	overflow: hidden;
 }
 
 .g-sample-gridlist-panel {
-	width: 232px; height: 320px; margin: auto; background-color: #000000;
+	background-color: #000000;
+
+	width: 232px;
+	height: 320px;
+	margin: auto;
 }
 .g-sample-gridlist-imageitem {
 	width: 127px;
 	height: 127px;
-	cursor: pointer;
+
 	text-align: center;
+
+	cursor: pointer;
 }
 .g-sample-gridlist-imageitem img {
+	background-size: contain;
+
 	width: 107px;
 	height: 107px;
-	background-size: contain;
 }
 .g-sample-gridlist-circle-imageitem img {
+	background-size: contain;
+
 	width: 82px;
 	height: 82px;
-	background-size: contain;
 	border-radius: 100%;
 	margin-top: 0.8px;
 }
@@ -36,24 +45,28 @@
 	overflow: hidden;
 }
 .g-sample-gridlist-circle-imageitem .caption{
+	width: 92px;
+	height: 20px;
 	margin-top: 0px;
 	margin-left: 15px;
 	margin-right: 15px;
+
 	font-size: 18px;
-	width: 92px;
-	height: 20px;
 	color: #FAFAFA;
+
 	-webkit-mask-image: -webkit-linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
 	-webkit-mask-image: linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
 }
 .g-sample-gridlist-imageitem.disabled {
 	opacity: 0.4;
+
 	filter: alpha(opacity=40);
 }
 
 /* GridList Imageitem */
 .selection-enabled .g-sample-gridlist-imageitem.g-selection-overlay-support.selected .g-icon-button {
 	background-position: 0 -325.8px;
+
 	margin-top: 0px;
 	margin-left: 5px;
 	margin-right: 15px;
@@ -67,6 +80,7 @@
 }
 .selection-enabled .g-sample-gridlist-circle-imageitem.g-selection-overlay-support.selected .g-icon-button {
 	background-position: 0 -331px;
+
 	margin-top: 0px;
 	margin-left: 5px;
 	margin-right: 0;
@@ -76,5 +90,5 @@
 	width: 107px;
 	height: 88px;
 	margin-top: 0;
-	margin-left: 0px;
+	margin-left: 0;
 }

--- a/garnet/src/DataGridListSample.less
+++ b/garnet/src/DataGridListSample.less
@@ -43,14 +43,14 @@
 	margin-top: 0.8px;
 }
 .g-sample-datagridlist-imageitem .caption{
-	width: 0px;
-	height: 0px;
+	width: 0;
+	height: 0;
 	overflow: hidden;
 }
 .g-sample-datagridlist-circle-imageitem .caption{
 	width: 92px;
 	height: 20px;
-	margin-top: 0px;
+	margin-top: 0;
 	margin-left: 15px;
 	margin-right: 15px;
 
@@ -70,7 +70,7 @@
 .selection-enabled .g-sample-datagridlist-imageitem.g-selection-overlay-support.selected .g-icon-button {
 	background-position: 0 -325.8px;
 
-	margin-top: 0px;
+	margin-top: 0;
 	margin-left: 5px;
 	margin-right: 15px;
 }
@@ -84,7 +84,7 @@
 .selection-enabled .g-sample-datagridlist-circle-imageitem.g-selection-overlay-support.selected .g-icon-button {
 	background-position: 0 -331px;
 
-	margin-top: 0px;
+	margin-top: 0;
 	margin-left: 5px;
 	margin-right: 0;
 }

--- a/garnet/src/DataGridListSample.less
+++ b/garnet/src/DataGridListSample.less
@@ -13,14 +13,14 @@
 
 // Sample specific classes
 
-.g-sample-gridlist-panel {
+.g-sample-datagridlist-panel {
 	background-color: #000000;
 
 	width: 232px;
 	height: 320px;
 	margin: auto;
 }
-.g-sample-gridlist-imageitem {
+.g-sample-datagridlist-imageitem {
 	width: 127px;
 	height: 127px;
 
@@ -28,13 +28,13 @@
 
 	cursor: pointer;
 }
-.g-sample-gridlist-imageitem img {
+.g-sample-datagridlist-imageitem img {
 	background-size: contain;
 
 	width: 107px;
 	height: 107px;
 }
-.g-sample-gridlist-circle-imageitem img {
+.g-sample-datagridlist-circle-imageitem img {
 	background-size: contain;
 
 	width: 82px;
@@ -42,12 +42,12 @@
 	border-radius: 100%;
 	margin-top: 0.8px;
 }
-.g-sample-gridlist-imageitem .caption{
+.g-sample-datagridlist-imageitem .caption{
 	width: 0px;
 	height: 0px;
 	overflow: hidden;
 }
-.g-sample-gridlist-circle-imageitem .caption{
+.g-sample-datagridlist-circle-imageitem .caption{
 	width: 92px;
 	height: 20px;
 	margin-top: 0px;
@@ -60,35 +60,35 @@
 	-webkit-mask-image: -webkit-linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
 	-webkit-mask-image: linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
 }
-.g-sample-gridlist-imageitem.disabled {
+.g-sample-datagridlist-imageitem.disabled {
 	opacity: 0.4;
 
 	filter: alpha(opacity=40);
 }
 
 /* GridList Imageitem */
-.selection-enabled .g-sample-gridlist-imageitem.g-selection-overlay-support.selected .g-icon-button {
+.selection-enabled .g-sample-datagridlist-imageitem.g-selection-overlay-support.selected .g-icon-button {
 	background-position: 0 -325.8px;
 
 	margin-top: 0px;
 	margin-left: 5px;
 	margin-right: 15px;
 }
-.g-sample-gridlist-imageitem .g-selection-overlay-support-scrim .g-selection-overlay-support-checkbox {
+.g-sample-datagridlist-imageitem .g-selection-overlay-support-scrim .g-selection-overlay-support-checkbox {
 	position: absolute;
 	width: 107px;
 	height: 107px;
 	margin-top: 0;
 	margin-left: 0;
 }
-.selection-enabled .g-sample-gridlist-circle-imageitem.g-selection-overlay-support.selected .g-icon-button {
+.selection-enabled .g-sample-datagridlist-circle-imageitem.g-selection-overlay-support.selected .g-icon-button {
 	background-position: 0 -331px;
 
 	margin-top: 0px;
 	margin-left: 5px;
 	margin-right: 0;
 }
-.g-sample-gridlist-circle-imageitem .g-selection-overlay-support-scrim .g-selection-overlay-support-checkbox {
+.g-sample-datagridlist-circle-imageitem .g-selection-overlay-support-scrim .g-selection-overlay-support-checkbox {
 	position: absolute;
 	width: 107px;
 	height: 88px;

--- a/garnet/src/DataGridListSample.less
+++ b/garnet/src/DataGridListSample.less
@@ -1,6 +1,7 @@
 /* DataGridListSample */
 
-// Common
+// Common classes
+
 .g-sample-panel-margin {
 	background-color: #000000;
 
@@ -9,6 +10,8 @@
 	margin-right: 10px;
 	overflow: hidden;
 }
+
+// Sample specific classes
 
 .g-sample-gridlist-panel {
 	background-color: #000000;

--- a/garnet/src/DataGridListwithCardsSample.js
+++ b/garnet/src/DataGridListwithCardsSample.js
@@ -82,7 +82,6 @@ var DataGridListCardsPanel = kind({
 	kind: Panel,
 	knob: true,
 	classes: 'g-layout-absolute-wrapper',
-	style: 'width: ' + ri.scale(320) + 'px; height: ' + ri.scale(320) + 'px; background-color: #000000;',
 	components: [
 		{
 			name: 'list',
@@ -93,7 +92,7 @@ var DataGridListCardsPanel = kind({
 			minHeight: ri.scale(232),
 			minWidth: ri.scale(212),
 			scrollerOptions: {maxHeight: ri.scale(370) + 'px'},
-			style: 'width: ' + ri.scale(212) + 'px; height: ' + ri.scale(320) + 'px; padding-top: ' + ri.scale(6) + 'px; margin: auto; background-color: #000000;',
+			classes: 'g-sample-gridlist-panel-card',
 			headerComponents: [{kind: Title, content: 'Title: long text will fade out'}],
 			components: [
 				{kind: DataGridListCardsItem}
@@ -110,7 +109,6 @@ var DataGridListCardsCirclePanel = kind({
 	kind: Panel,
 	knob: true,
 	classes: 'g-layout-absolute-wrapper',
-	style: 'width: ' + ri.scale(320) + 'px; height: ' + ri.scale(320) + 'px; background-color: #000000;',
 	components: [
 		{
 			name: 'list',
@@ -121,7 +119,7 @@ var DataGridListCardsCirclePanel = kind({
 			minHeight: ri.scale(252),
 			minWidth: ri.scale(212),
 			scrollerOptions: {maxHeight: ri.scale(370) + 'px'},
-			style: 'width: ' + ri.scale(212) + 'px; height: ' + ri.scale(320) + 'px; padding-top: ' + ri.scale(6) + 'px; margin: auto; background-color: #000000;',
+			classes: 'g-sample-gridlist-panel-card',
 			headerComponents: [{kind: Title, content: 'Title'}],
 			components: [
 				{kind: DataGridListCardsCircleItem}
@@ -140,8 +138,8 @@ module.exports = kind({
 		{content: '< Data Grid List with Cards Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'Data Grid List with Cards', classes: 'g-sample-subheader'},
-		{name: 'gridList', kind: DataGridListCardsPanel, style: 'position: relative; display: inline-block; margin-right: ' + ri.scale(10) + 'px'},
-		{name: 'gridListCircle', kind: DataGridListCardsCirclePanel, style: 'position: relative; display: inline-block;'}
+		{name: 'gridList', kind: DataGridListCardsPanel, classes: 'g-sample-panel-margin g-common-width-height-fit'},
+		{name: 'gridListCircle', kind: DataGridListCardsCirclePanel, classes: 'g-sample-panel-margin g-common-width-height-fit'}
 	],
 	bindings: [
 		{from: '.collection', to: '.$.gridList.collection'},

--- a/garnet/src/DataGridListwithCardsSample.js
+++ b/garnet/src/DataGridListwithCardsSample.js
@@ -12,7 +12,7 @@ var
 
 var DataGridListCardsImageItem = kind({
 	name: 'g.sample.DataGridListCardsImageItem',
-	classes: 'g-sample-gridlistcards-imageitem',
+	classes: 'g-sample-datagridlist-cards-imageitem',
 	components: [
 		{name: 'image', kind: EnyoImage},
 		{name: 'caption', classes: 'caption'}
@@ -58,7 +58,7 @@ var DataGridListCardsItem = kind({
 var DataGridListCardsCircleImageItem = kind({
 	name: 'g.sample.DataGridListCardsCircleImageItem',
 	kind: DataGridListCardsImageItem,
-	classes: 'g-sample-gridlistcards-circle-imageitem'
+	classes: 'g-sample-datagridlist-cards-circle-imageitem'
 });
 
 var DataGridListCardsCircleItem = kind({
@@ -92,7 +92,7 @@ var DataGridListCardsPanel = kind({
 			minHeight: ri.scale(232),
 			minWidth: ri.scale(212),
 			scrollerOptions: {maxHeight: ri.scale(370) + 'px'},
-			classes: 'g-sample-gridlist-panel-card',
+			classes: 'g-sample-datagridlist-panel-card',
 			headerComponents: [{kind: Title, content: 'Title: long text will fade out'}],
 			components: [
 				{kind: DataGridListCardsItem}
@@ -119,7 +119,7 @@ var DataGridListCardsCirclePanel = kind({
 			minHeight: ri.scale(252),
 			minWidth: ri.scale(212),
 			scrollerOptions: {maxHeight: ri.scale(370) + 'px'},
-			classes: 'g-sample-gridlist-panel-card',
+			classes: 'g-sample-datagridlist-panel-card',
 			headerComponents: [{kind: Title, content: 'Title'}],
 			components: [
 				{kind: DataGridListCardsCircleItem}

--- a/garnet/src/DataGridListwithCardsSample.js
+++ b/garnet/src/DataGridListwithCardsSample.js
@@ -139,7 +139,7 @@ module.exports = kind({
 
 		{content: 'Data Grid List with Cards', classes: 'g-sample-subheader'},
 		{name: 'gridList', kind: DataGridListCardsPanel, classes: 'g-sample-panel-margin g-common-width-height-fit'},
-		{name: 'gridListCircle', kind: DataGridListCardsCirclePanel, classes: 'g-sample-panel-margin g-common-width-height-fit'}
+		{name: 'gridListCircle', kind: DataGridListCardsCirclePanel, classes: 'g-sample-circle-panel-margin g-common-width-height-fit'}
 	],
 	bindings: [
 		{from: '.collection', to: '.$.gridList.collection'},

--- a/garnet/src/DataGridListwithCardsSample.less
+++ b/garnet/src/DataGridListwithCardsSample.less
@@ -3,19 +3,27 @@
 // Common
 .g-sample-panel-margin {
 	background-color: #000000;
+
 	position: relative;
-	overflow: hidden;
 	display: inline-block;
 	margin-right: 10px;
+	overflow: hidden;
 }
 
 .g-sample-gridlist-panel-card {
-	width: 212px; height: 320px; padding-top: 6px; margin: auto; background-color: #000000;
+	background-color: #000000;
+
+	width: 212px;
+	height: 320px;
+	padding-top: 6px;
+	margin: auto;
 }
 .g-sample-gridlistcards-imageitem.g-selection-overlay-support.item{
 	width: 212px;
 	height: 212px;
+
 	text-align: center;
+
 	cursor: pointer;
 }
 .g-sample-gridlistcards-imageitem.g-selection-overlay-support.item img {
@@ -26,7 +34,9 @@
 .g-sample-gridlistcards-circle-imageitem.g-selection-overlay-support.item{
 	width: 212px;
 	height: 212px;
+
 	text-align: center;
+
 	cursor: pointer;
 }
 .g-sample-gridlistcards-circle-imageitem.g-selection-overlay-support.item img {
@@ -35,12 +45,14 @@
 	border-radius: 100%;
 }
 .g-sample-gridlistcards-circle-imageitem .caption{
-	margin-left: 54px;
-	margin-top: -3px;
-	font-size: 22px;
 	width: 106px;
 	height: 22px;
+	margin-left: 54px;
+	margin-top: -3px;
+
+	font-size: 22px;
 	color: #FAFAFA;
+
 	-webkit-mask-image: -webkit-linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
 	-webkit-mask-image: linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
 }

--- a/garnet/src/DataGridListwithCardsSample.less
+++ b/garnet/src/DataGridListwithCardsSample.less
@@ -10,6 +10,14 @@
 	margin-right: 10px;
 	overflow: hidden;
 }
+.g-sample-panel-margin {
+	background-color: #000000;
+
+	position: relative;
+	display: inline-block;
+	margin-right: 10px;
+	overflow: hidden;
+}
 
 // Sample specific classes
 

--- a/garnet/src/DataGridListwithCardsSample.less
+++ b/garnet/src/DataGridListwithCardsSample.less
@@ -1,5 +1,17 @@
 /* DataGridListwithCardsSample */
 
+// Common
+.g-sample-panel-margin {
+	background-color: #000000;
+	position: relative;
+	overflow: hidden;
+	display: inline-block;
+	margin-right: 10px;
+}
+
+.g-sample-gridlist-panel-card {
+	width: 212px; height: 320px; padding-top: 6px; margin: auto; background-color: #000000;
+}
 .g-sample-gridlistcards-imageitem.g-selection-overlay-support.item{
 	width: 212px;
 	height: 212px;

--- a/garnet/src/DataGridListwithCardsSample.less
+++ b/garnet/src/DataGridListwithCardsSample.less
@@ -1,6 +1,7 @@
 /* DataGridListwithCardsSample */
 
-// Common
+// Common classes
+
 .g-sample-panel-margin {
 	background-color: #000000;
 
@@ -9,6 +10,8 @@
 	margin-right: 10px;
 	overflow: hidden;
 }
+
+// Sample specific classes
 
 .g-sample-gridlist-panel-card {
 	background-color: #000000;

--- a/garnet/src/DataGridListwithCardsSample.less
+++ b/garnet/src/DataGridListwithCardsSample.less
@@ -13,7 +13,7 @@
 
 // Sample specific classes
 
-.g-sample-gridlist-panel-card {
+.g-sample-datagridlist-panel-card {
 	background-color: #000000;
 
 	width: 212px;
@@ -21,7 +21,7 @@
 	padding-top: 6px;
 	margin: auto;
 }
-.g-sample-gridlistcards-imageitem.g-selection-overlay-support.item{
+.g-sample-datagridlist-cards-imageitem.g-selection-overlay-support.item{
 	width: 212px;
 	height: 212px;
 
@@ -29,12 +29,12 @@
 
 	cursor: pointer;
 }
-.g-sample-gridlistcards-imageitem.g-selection-overlay-support.item img {
+.g-sample-datagridlist-cards-imageitem.g-selection-overlay-support.item img {
 	width: 212px;
 	height: 212px;
 	margin-top: 0.8px;
 }
-.g-sample-gridlistcards-circle-imageitem.g-selection-overlay-support.item{
+.g-sample-datagridlist-cards-circle-imageitem.g-selection-overlay-support.item{
 	width: 212px;
 	height: 212px;
 
@@ -42,12 +42,12 @@
 
 	cursor: pointer;
 }
-.g-sample-gridlistcards-circle-imageitem.g-selection-overlay-support.item img {
+.g-sample-datagridlist-cards-circle-imageitem.g-selection-overlay-support.item img {
 	width: 212px;
 	height: 212px;
 	border-radius: 100%;
 }
-.g-sample-gridlistcards-circle-imageitem .caption{
+.g-sample-datagridlist-cards-circle-imageitem .caption{
 	width: 106px;
 	height: 22px;
 	margin-left: 54px;
@@ -61,10 +61,10 @@
 }
 
 /* GridList Imageitem */
-.selection-enabled .g-sample-gridlistcards-imageitem.g-selection-overlay-support.selected .g-icon-button {
+.selection-enabled .g-sample-datagridlist-cards-imageitem.g-selection-overlay-support.selected .g-icon-button {
 	background-position: 0 -96px;
 }
-.g-sample-gridlistcards-imageitem .g-selection-overlay-support-scrim .g-selection-overlay-support-checkbox {
+.g-sample-datagridlist-cards-imageitem .g-selection-overlay-support-scrim .g-selection-overlay-support-checkbox {
 	position: absolute;
 	margin-top: 0;
 	margin-left: 0;

--- a/garnet/src/DataListSample.js
+++ b/garnet/src/DataListSample.js
@@ -101,7 +101,7 @@ var DataListSample = module.exports = kind({
 		{content: '< Data List Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'Data List', classes: 'g-sample-subheader'},
-		{name: 'listPanel', kind: DataListPanel, classes: 'g-sample-datalist-panel'}
+		{name: 'listPanel', kind: DataListPanel, classes: 'g-sample-panel'}
 	],
 	bindings: [
 		{from: '.collection', to: '.$.listPanel.collection'}

--- a/garnet/src/DataListSample.less
+++ b/garnet/src/DataListSample.less
@@ -1,12 +1,15 @@
 /* DataListSample */
 
-// Common
+// Common classes
+
 .g-sample-panel {
 	background-color: #000000;
 
 	position: relative;
 	overflow: hidden;
 }
+
+// Sample specific classes
 
 .g-sample-datalist-header {
 	height: 124px;

--- a/garnet/src/DataListSample.less
+++ b/garnet/src/DataListSample.less
@@ -3,6 +3,7 @@
 // Common
 .g-sample-panel {
 	background-color: #000000;
+
 	position: relative;
 	overflow: hidden;
 }
@@ -20,21 +21,23 @@
 	height: 71px;
 	border-bottom: 1px solid #202328;
 	overflow: hidden;
+
 	cursor: pointer;
 }
 .g-sample-datalist-item-icon {
 	position: absolute;
+	width: 48px;
+	height: 48px;
+	margin: auto 0;
 	top: 0;
 	bottom: 0;
 	left: 10px;
-	margin: auto 0;
-	width: 48px;
-	height: 48px;
 }
 .g-sample-datalist-item-title {
 	width: 232px;
 	height: 32px;
 	margin-left: 68px;
+
 	font-size: 28px;
 	color: #FAFAFA;
 }
@@ -42,6 +45,7 @@
 	width: 232px;
 	height: 26px;
 	margin: 5px 0 0 68px;
+
 	font-size: 22px;
 	color: #A0A0A0;
 }

--- a/garnet/src/DataListSample.less
+++ b/garnet/src/DataListSample.less
@@ -1,14 +1,12 @@
 /* DataListSample */
 
-.g-sample-datalist-panel {
+// Common
+.g-sample-panel {
+	background-color: #000000;
 	position: relative;
-	display: inline-block;
-	margin-left: 10px;
 	overflow: hidden;
 }
-.g-sample-datalist {
-	background-color: #000000;
-}
+
 .g-sample-datalist-header {
 	height: 124px;
 }

--- a/garnet/src/DataListwithCardsSample.js
+++ b/garnet/src/DataListwithCardsSample.js
@@ -19,11 +19,10 @@ var DataListCardsPanel = kind({
 			kind: DataList,
 			controlsPerPage: 2,
 			cards: true,
-			style: 'background-color: #000000;',
 			components: [
 				{ontap: 'showPopup', components: [
 					{name: 'listItem', classes: 'g-sample-datalistcards-item', components: [
-						{name: 'iconUrl', kind: EnyoImage, style: 'width: ' + ri.scale(320) + 'px; height: ' + ri.scale(320) + 'px;'}
+						{name: 'iconUrl', kind: EnyoImage, classes: 'g-common-width-height-fit'}
 					]}
 				], bindings: [
 					{from: '.model.iconUrl', to: '.$.iconUrl.src'}
@@ -48,12 +47,12 @@ var DataListSmallCardsPanel = kind({
 			controlsPerPage: 2,
 			cards: true,
 			itemHeight: ri.scale(216),
-			style: 'height: ' + ri.scale(320) + 'px; width: ' + ri.scale(240) + 'px; margin-left: ' + ri.scale(40) + 'px;',
+			classes: 'g-sample-datalistcards-list',
 			headerComponents: [
-				{style: 'height: ' + ri.scale(70) + 'px;'}
+				{classes: 'g-sample-datalistcards-list-header'}
 			],
 			footerComponents: [
-				{style: 'height: ' + ri.scale(34) + 'px;'}
+				{classes: 'g-sample-datalistcards-list-footer'}
 			],
 			components: [
 				{ontap: 'showPopup', components: [
@@ -79,8 +78,10 @@ module.exports = kind({
 		{content: '< Data List with Cards Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'Data List with Cards', classes: 'g-sample-subheader'},
-		{name: 'listPanel', kind: DataListCardsPanel, style: 'position: relative; display: inline-block;'},
-		{name: 'listPanel2', kind: DataListSmallCardsPanel, style: 'border-radius: 100%; position: relative; display: inline-block; margin-left: ' + ri.scale(10) + 'px;'}
+		{classes: 'g-sample-panels', components: [
+			{name: 'listPanel', kind: DataListCardsPanel, classes: 'g-sample-panel-margin'},
+			{name: 'listPanel2', kind: DataListSmallCardsPanel, classes: 'g-sample-circle-panel-margin'}
+		]}
 	],
 	bindings: [
 		{from: '.collection', to: '.$.listPanel.collection'},

--- a/garnet/src/DataListwithCardsSample.js
+++ b/garnet/src/DataListwithCardsSample.js
@@ -21,7 +21,7 @@ var DataListCardsPanel = kind({
 			cards: true,
 			components: [
 				{ontap: 'showPopup', components: [
-					{name: 'listItem', classes: 'g-sample-datalistcards-item', components: [
+					{name: 'listItem', classes: 'g-sample-datalist-cards-item', components: [
 						{name: 'iconUrl', kind: EnyoImage, classes: 'g-common-width-height-fit'}
 					]}
 				], bindings: [
@@ -47,18 +47,18 @@ var DataListSmallCardsPanel = kind({
 			controlsPerPage: 2,
 			cards: true,
 			itemHeight: ri.scale(216),
-			classes: 'g-sample-datalistcards-list',
+			classes: 'g-sample-datalist-cards-list',
 			headerComponents: [
-				{classes: 'g-sample-datalistcards-list-header'}
+				{classes: 'g-sample-datalist-cards-list-header'}
 			],
 			footerComponents: [
-				{classes: 'g-sample-datalistcards-list-footer'}
+				{classes: 'g-sample-datalist-cards-list-footer'}
 			],
 			components: [
 				{ontap: 'showPopup', components: [
-					{name: 'listItem', classes: 'g-sample-datalistsmallcards-item', components: [
+					{name: 'listItem', classes: 'g-sample-datalist-smallcards-item', components: [
 						{name: 'iconUrl', kind: EnyoImage},
-						{classes: 'g-sample-datalistsmallcards-title', content: 'title'}
+						{classes: 'g-sample-datalist-smallcards-title', content: 'title'}
 					]}
 				], bindings: [
 					{from: '.model.iconUrl', to: '.$.iconUrl.src'}

--- a/garnet/src/DataListwithCardsSample.less
+++ b/garnet/src/DataListwithCardsSample.less
@@ -26,28 +26,28 @@
 
 // Sample specific classes
 
-.g-sample-datalistcards-list {
+.g-sample-datalist-cards-list {
 	width: 240px;
 	height: 320px;
 	margin-left: 40px;
 }
-.g-sample-datalistcards-list-header {
+.g-sample-datalist-cards-list-header {
 	height: 70px;
 }
-.g-sample-datalistcards-list-footer {
+.g-sample-datalist-cards-list-footer {
 	height: 34px;
 }
-.g-sample-datalistcards-item {
+.g-sample-datalist-cards-item {
 	height: 320px;
 
 	line-height: 320px;
 }
 
-.g-sample-datalistsmallcards-item {
+.g-sample-datalist-smallcards-item {
 	width: 240px;
 }
 
-.g-sample-datalistsmallcards-item img {
+.g-sample-datalist-smallcards-item img {
 	display: block;
 	width: 184px;
 	height: 184px;
@@ -57,7 +57,7 @@
 	margin-top: 0.3px;
 }
 
-.g-sample-datalistsmallcards-title {
+.g-sample-datalist-smallcards-title {
 	width: 240px;
 	height: 24px;
 	margin-bottom: 8px;

--- a/garnet/src/DataListwithCardsSample.less
+++ b/garnet/src/DataListwithCardsSample.less
@@ -1,6 +1,7 @@
 /* DataListwithCardsSample */
 
-// Common
+// Common classes
+
 .g-sample-panel-margin {
 	background-color: #000000;
 
@@ -22,6 +23,8 @@
 	position: relative;
 	height: 100%;
 }
+
+// Sample specific classes
 
 .g-sample-datalistcards-list {
 	width: 240px;

--- a/garnet/src/DataListwithCardsSample.less
+++ b/garnet/src/DataListwithCardsSample.less
@@ -3,25 +3,30 @@
 // Common
 .g-sample-panel-margin {
 	background-color: #000000;
+
 	position: relative;
-	overflow: hidden;
 	display: inline-block;
 	margin-right: 10px;
+	overflow: hidden;
 }
 .g-sample-circle-panel-margin {
 	background-color: #000000;
+
 	position: relative;
-	overflow: hidden;
 	display: inline-block;
 	border-radius: 50%;
 	margin-right: 10px;
+	overflow: hidden;
 }
 .g-sample-panels {
-	position: relative; height: 100%;
+	position: relative;
+	height: 100%;
 }
 
 .g-sample-datalistcards-list {
-	height: 320px; width: 240px; margin-left: 40px;
+	width: 240px;
+	height: 320px;
+	margin-left: 40px;
 }
 .g-sample-datalistcards-list-header {
 	height: 70px;
@@ -31,6 +36,7 @@
 }
 .g-sample-datalistcards-item {
 	height: 320px;
+
 	line-height: 320px;
 }
 
@@ -39,10 +45,10 @@
 }
 
 .g-sample-datalistsmallcards-item img {
+	display: block;
 	width: 184px;
 	height: 184px;
 	border-radius: 100%;
-	display: block;
 	margin-left: auto;
 	margin-right: auto;
 	margin-top: 0.3px;
@@ -51,7 +57,8 @@
 .g-sample-datalistsmallcards-title {
 	width: 240px;
 	height: 24px;
+	margin-bottom: 8px;
+	
 	font-size: 24px;
 	text-align: center;
-	margin-bottom: 8px;
 }

--- a/garnet/src/DataListwithCardsSample.less
+++ b/garnet/src/DataListwithCardsSample.less
@@ -1,5 +1,34 @@
 /* DataListwithCardsSample */
 
+// Common
+.g-sample-panel-margin {
+	background-color: #000000;
+	position: relative;
+	overflow: hidden;
+	display: inline-block;
+	margin-right: 10px;
+}
+.g-sample-circle-panel-margin {
+	background-color: #000000;
+	position: relative;
+	overflow: hidden;
+	display: inline-block;
+	border-radius: 50%;
+	margin-right: 10px;
+}
+.g-sample-panels {
+	position: relative; height: 100%;
+}
+
+.g-sample-datalistcards-list {
+	height: 320px; width: 240px; margin-left: 40px;
+}
+.g-sample-datalistcards-list-header {
+	height: 70px;
+}
+.g-sample-datalistcards-list-footer {
+	height: 34px;
+}
 .g-sample-datalistcards-item {
 	height: 320px;
 	line-height: 320px;

--- a/garnet/src/DataListwithCheckboxesSample.js
+++ b/garnet/src/DataListwithCheckboxesSample.js
@@ -21,7 +21,7 @@ var CheckboxItemBase = kind({
 	},
 	components: [
 		{name: 'title', classes: 'checkbox-item-title'},
-		{tag: 'hr', style: 'border: 0; color: #202328; height: ' + ri.scale(1) + 'px; background-color: #202328; bottom: 0;'}
+		{tag: 'hr', classes: 'g-sample-datalistcheckbox-checkbox-item-border'}
 	],
 	bindings: [
 		{from: '.title', to: '.$.title.content'},
@@ -65,13 +65,12 @@ var CheckableDataListPanel = kind({
 			controlsPerPage: 4,
 			selection: true,
 			selectionType: 'multi',
-			style: 'background-color: #000000;',
 			headerComponents: [{kind: Title, content: 'Title'}],
 			components: [
 				{kind: CheckboxItem, ontap: 'tapItem'}
 			],
 			footerComponents: [
-				{style: 'height: ' + ri.scale(116) + 'px;'}
+				{classes: 'g-sample-datalistcheckbox-footer'}
 			]
 		}
 	],
@@ -126,7 +125,7 @@ module.exports = kind({
 		{content: '< Data List with Checkboxes Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'Data List with Checkboxes', classes: 'g-sample-subheader'},
-		{name: 'checkableListPanel', kind: CheckableDataListPanel, style: 'position: relative;', onResult: 'result'},
+		{name: 'checkableListPanel', kind: CheckableDataListPanel, classes: 'g-sample-panel', onResult: 'result'},
 
 		{src: '@../assets/btn_command_next.svg', classes: 'g-sample-result', components: [
 			{content: 'Result', classes: 'g-sample-subheader'},

--- a/garnet/src/DataListwithCheckboxesSample.js
+++ b/garnet/src/DataListwithCheckboxesSample.js
@@ -2,7 +2,6 @@ require('garnet');
 
 var
 	kind = require('enyo/kind'),
-	ri = require('enyo/resolution'),
 	Collection = require('enyo/Collection.js'),
 	EmptyBinding = require('enyo/EmptyBinding.js'),
 	Item = require('garnet/Item'),

--- a/garnet/src/DataListwithCheckboxesSample.js
+++ b/garnet/src/DataListwithCheckboxesSample.js
@@ -14,14 +14,14 @@ var
 var CheckboxItemBase = kind({
 	name: 'g.sample.CheckboxItemBase',
 	kind: Item,
-	classes: 'g-sample-datalistcheckbox-checkbox-item',
+	classes: 'g-sample-datalist-checkboxes-checkbox-item',
 	published: {
 		title: '',
 		selected: false
 	},
 	components: [
 		{name: 'title', classes: 'checkbox-item-title'},
-		{tag: 'hr', classes: 'g-sample-datalistcheckbox-checkbox-item-border'}
+		{tag: 'hr', classes: 'g-sample-datalist-checkboxes-checkbox-item-border'}
 	],
 	bindings: [
 		{from: '.title', to: '.$.title.content'},
@@ -70,7 +70,7 @@ var CheckableDataListPanel = kind({
 				{kind: CheckboxItem, ontap: 'tapItem'}
 			],
 			footerComponents: [
-				{classes: 'g-sample-datalistcheckbox-footer'}
+				{classes: 'g-sample-datalist-checkboxes-footer'}
 			]
 		}
 	],

--- a/garnet/src/DataListwithCheckboxesSample.less
+++ b/garnet/src/DataListwithCheckboxesSample.less
@@ -21,12 +21,12 @@
 
 // Sample specific classes
 
-.g-sample-datalistcheckbox-footer {
+.g-sample-datalist-checkboxes-footer {
 	height: 116px;
 }
 
 /* Checkbox Item */
-.g-sample-datalistcheckbox-checkbox-item{
+.g-sample-datalist-checkboxes-checkbox-item{
 	position: relative; /* Do not omit this. It's critical */
 	height: 72px;
 
@@ -34,7 +34,7 @@
 
 	cursor: pointer;
 }
-.g-sample-datalistcheckbox-checkbox-item .checkbox-item-title {
+.g-sample-datalist-checkboxes-checkbox-item .checkbox-item-title {
 	width: 186px;
 	height: 72px;
 	margin-left: 96px;
@@ -45,7 +45,7 @@
 	-webkit-mask-image: -webkit-linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
 	-webkit-mask-image: linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
 }
-.g-sample-datalistcheckbox-checkbox-item-border {
+.g-sample-datalist-checkboxes-checkbox-item-border {
 	background-color: #202328;
 	height: 1px;
 	border: 0;
@@ -53,7 +53,7 @@
 
 	color: #202328;
 }
-.g-sample-datalistcheckbox-checkbox-item.disabled {
+.g-sample-datalist-checkboxes-checkbox-item.disabled {
 	opacity: 0.4;
 
 	filter: alpha(opacity=40);
@@ -62,6 +62,6 @@
 .g-selection-overlay-support-scrim {
 	display: inline;
 }
-.g-sample-datalistcheckbox-checkbox-item.pressed .g-selection-overlay-support-scrim .g-icon-button {
+.g-sample-datalist-checkboxes-checkbox-item.pressed .g-selection-overlay-support-scrim .g-icon-button {
 	background-position: 0 -48px;
 }

--- a/garnet/src/DataListwithCheckboxesSample.less
+++ b/garnet/src/DataListwithCheckboxesSample.less
@@ -3,11 +3,13 @@
 // Common
 .g-sample-panel {
 	background-color: #000000;
+
 	position: relative;
 	overflow: hidden;
 }
 .g-sample-result {
 	background-color: #EDEDED;
+
 	position: fixed;
 	width: 100%;
 	min-height: 160px;
@@ -22,25 +24,35 @@
 
 /* Checkbox Item */
 .g-sample-datalistcheckbox-checkbox-item{
-	height: 72px;
-	line-height: 72px;
 	position: relative; /* Do not omit this. It's critical */
+	height: 72px;
+
+	line-height: 72px;
+
 	cursor: pointer;
 }
 .g-sample-datalistcheckbox-checkbox-item .checkbox-item-title {
 	width: 186px;
 	height: 72px;
 	margin-left: 96px;
+
 	font-size: 28px;
 	color: #FAFAFA;
+
 	-webkit-mask-image: -webkit-linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
 	-webkit-mask-image: linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
 }
 .g-sample-datalistcheckbox-checkbox-item-border {
-	border: 0; color: #202328; height: 1px; background-color: #202328; bottom: 0;
+	background-color: #202328;
+	height: 1px;
+	border: 0;
+	bottom: 0;
+
+	color: #202328;
 }
 .g-sample-datalistcheckbox-checkbox-item.disabled {
 	opacity: 0.4;
+
 	filter: alpha(opacity=40);
 }
 /* This for always showing checkbox */

--- a/garnet/src/DataListwithCheckboxesSample.less
+++ b/garnet/src/DataListwithCheckboxesSample.less
@@ -1,8 +1,23 @@
 /* DataListwithCheckboxesSample */
 
-.g-sample-datalistcheckbox-footer-comp {
+// Common
+.g-sample-panel {
+	background-color: #000000;
+	position: relative;
+	overflow: hidden;
+}
+.g-sample-result {
+	background-color: #EDEDED;
+	position: fixed;
 	width: 100%;
-	height: 93px;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
+
+.g-sample-datalistcheckbox-footer {
+	height: 116px;
 }
 
 /* Checkbox Item */
@@ -20,6 +35,9 @@
 	color: #FAFAFA;
 	-webkit-mask-image: -webkit-linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
 	-webkit-mask-image: linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
+}
+.g-sample-datalistcheckbox-checkbox-item-border {
+	border: 0; color: #202328; height: 1px; background-color: #202328; bottom: 0;
 }
 .g-sample-datalistcheckbox-checkbox-item.disabled {
 	opacity: 0.4;

--- a/garnet/src/DataListwithCheckboxesSample.less
+++ b/garnet/src/DataListwithCheckboxesSample.less
@@ -1,6 +1,7 @@
 /* DataListwithCheckboxesSample */
 
-// Common
+// Common classes
+
 .g-sample-panel {
 	background-color: #000000;
 
@@ -17,6 +18,8 @@
 	z-index: 9999;
 	opacity: 0.8;
 }
+
+// Sample specific classes
 
 .g-sample-datalistcheckbox-footer {
 	height: 116px;

--- a/garnet/src/DataListwithIconBadgeSample.js
+++ b/garnet/src/DataListwithIconBadgeSample.js
@@ -25,7 +25,7 @@ var IconBadgeItem = kind({
 		{name: 'newIconBadge', kind: Icon, src: '@../assets/badge_unread.svg', classes: 'icon-badge-item-new-icon'},
 		{name: 'infoIconBadge', kind: Icon, src: '@../assets/badge_extra_info.svg', classes: 'icon-badge-item-info-icon'},
 		{name: 'title', classes: 'icon-badge-item-title'},
-		{tag: 'hr', style: 'border: 0; color: #202328; height: ' + ri.scale(1) + 'px; background-color: #202328; bottom: 0;'}
+		{tag: 'hr', classes: 'g-datalist-icon-badge-item-border'}
 	],
 	bindings: [
 		{from: '.model.albumTitle', to: '.$.title.content'},
@@ -68,7 +68,6 @@ var IconBadgeDataListPanel = kind({
 			controlsPerPage: 4,
 			selection: false,
 			multipleSelection: false,
-			style: 'background-color: #000000;',
 			headerComponents: [{kind: Title, content: 'Title'}],
 			components: [
 				{kind: IconBadgeItem}
@@ -87,7 +86,7 @@ module.exports = kind({
 		{content: '< Data List with Icon Badge Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'Data List with Icon Badge', classes: 'g-sample-subheader'},
-		{name: 'iconBadgeListPanel', kind: IconBadgeDataListPanel, style: 'position: relative;'}
+		{name: 'iconBadgeListPanel', kind: IconBadgeDataListPanel, classes: 'g-sample-panel'}
 	],
 	bindings: [
 		{from: '.collection', to: '.$.iconBadgeListPanel.collection'}

--- a/garnet/src/DataListwithIconBadgeSample.js
+++ b/garnet/src/DataListwithIconBadgeSample.js
@@ -2,7 +2,6 @@ require('garnet');
 
 var
 	kind = require('enyo/kind'),
-	ri = require('enyo/resolution'),
 	Collection = require('enyo/Collection.js'),
 	EmptyBinding = require('enyo/EmptyBinding.js'),
 	Item = require('garnet/Item'),

--- a/garnet/src/DataListwithIconBadgeSample.js
+++ b/garnet/src/DataListwithIconBadgeSample.js
@@ -14,7 +14,7 @@ var
 var IconBadgeItem = kind({
 	name: 'g.sample.IconBadgeItem',
 	kind: Item,
-	classes: 'g-datalist-icon-badge-item',
+	classes: 'g-datalist-iconbadge-item',
 	published: {
 		title: '',
 		newIcon: false,
@@ -25,7 +25,7 @@ var IconBadgeItem = kind({
 		{name: 'newIconBadge', kind: Icon, src: '@../assets/badge_unread.svg', classes: 'icon-badge-item-new-icon'},
 		{name: 'infoIconBadge', kind: Icon, src: '@../assets/badge_extra_info.svg', classes: 'icon-badge-item-info-icon'},
 		{name: 'title', classes: 'icon-badge-item-title'},
-		{tag: 'hr', classes: 'g-datalist-icon-badge-item-border'}
+		{tag: 'hr', classes: 'g-datalist-iconbadge-item-border'}
 	],
 	bindings: [
 		{from: '.model.albumTitle', to: '.$.title.content'},

--- a/garnet/src/DataListwithIconBadgeSample.less
+++ b/garnet/src/DataListwithIconBadgeSample.less
@@ -4,29 +4,39 @@
 // Common
 .g-sample-panel {
 	background-color: #000000;
+
 	position: relative;
 	overflow: hidden;
 }
 
 .g-datalist-icon-badge-item{
-	height: 72px;
-	line-height: 72px;
 	position: relative; /* Do not omit this. It's critical */
+	height: 72px;
+
+	line-height: 72px;
 }
 .g-datalist-icon-badge-item .icon-badge-item-title {
 	width: 186px;
 	height: 72px;
 	margin-left: 96px;
+
 	font-size: 28px;
 	color: #FAFAFA;
+
 	-webkit-mask-image: -webkit-linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
 	-webkit-mask-image: linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
 }
 .g-datalist-icon-badge-item-border {
-	border: 0; color: #202328; height: 1px; background-color: #202328; bottom: 0;
+	background-color: #202328;
+	height: 1px;
+	border: 0;
+	bottom: 0;
+
+	color: #202328;
 }
 .g-datalist-icon-badge-item.disabled {
 	opacity: 0.4;
+
 	filter: alpha(opacity=40);
 }
 .g-datalist-icon-badge-item .icon-badge-item-icon {

--- a/garnet/src/DataListwithIconBadgeSample.less
+++ b/garnet/src/DataListwithIconBadgeSample.less
@@ -12,13 +12,13 @@
 
 // Sample specific classes
 
-.g-datalist-icon-badge-item{
+.g-datalist-iconbadge-item{
 	position: relative; /* Do not omit this. It's critical */
 	height: 72px;
 
 	line-height: 72px;
 }
-.g-datalist-icon-badge-item .icon-badge-item-title {
+.g-datalist-iconbadge-item .icon-badge-item-title {
 	width: 186px;
 	height: 72px;
 	margin-left: 96px;
@@ -29,7 +29,7 @@
 	-webkit-mask-image: -webkit-linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
 	-webkit-mask-image: linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
 }
-.g-datalist-icon-badge-item-border {
+.g-datalist-iconbadge-item-border {
 	background-color: #202328;
 	height: 1px;
 	border: 0;
@@ -37,12 +37,12 @@
 
 	color: #202328;
 }
-.g-datalist-icon-badge-item.disabled {
+.g-datalist-iconbadge-item.disabled {
 	opacity: 0.4;
 
 	filter: alpha(opacity=40);
 }
-.g-datalist-icon-badge-item .icon-badge-item-icon {
+.g-datalist-iconbadge-item .icon-badge-item-icon {
 	position: absolute;
 	display: inline-block;
 	width: 48px;
@@ -50,14 +50,14 @@
 	margin-left: 38px;
 	margin-top: 15px;
 }
-.g-datalist-icon-badge-item .icon-badge-item-new-icon {
+.g-datalist-iconbadge-item .icon-badge-item-new-icon {
 	position: absolute;
 	width: 24px;
 	height: 24px;
 	margin-left: 62px;
 	margin-top: 15px;
 }
-.g-datalist-icon-badge-item .icon-badge-item-info-icon {
+.g-datalist-iconbadge-item .icon-badge-item-info-icon {
 	position: absolute;
 	width: 24px;
 	height: 24px;

--- a/garnet/src/DataListwithIconBadgeSample.less
+++ b/garnet/src/DataListwithIconBadgeSample.less
@@ -1,5 +1,13 @@
 /* DataListwithIconBadgeSample */
 
+
+// Common
+.g-sample-panel {
+	background-color: #000000;
+	position: relative;
+	overflow: hidden;
+}
+
 .g-datalist-icon-badge-item{
 	height: 72px;
 	line-height: 72px;
@@ -13,6 +21,9 @@
 	color: #FAFAFA;
 	-webkit-mask-image: -webkit-linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
 	-webkit-mask-image: linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
+}
+.g-datalist-icon-badge-item-border {
+	border: 0; color: #202328; height: 1px; background-color: #202328; bottom: 0;
 }
 .g-datalist-icon-badge-item.disabled {
 	opacity: 0.4;

--- a/garnet/src/DataListwithIconBadgeSample.less
+++ b/garnet/src/DataListwithIconBadgeSample.less
@@ -1,13 +1,16 @@
 /* DataListwithIconBadgeSample */
 
 
-// Common
+// Common classes
+
 .g-sample-panel {
 	background-color: #000000;
 
 	position: relative;
 	overflow: hidden;
 }
+
+// Sample specific classes
 
 .g-datalist-icon-badge-item{
 	position: relative; /* Do not omit this. It's critical */

--- a/garnet/src/DataListwithRadioButtonsSample.js
+++ b/garnet/src/DataListwithRadioButtonsSample.js
@@ -14,14 +14,14 @@ var
 var RadioButtonItemBase = kind({
 	name: 'g.sample.RadioButtonItemBase',
 	kind: Item,
-	classes: 'g-datalist-radiobutton-item',
+	classes: 'g-datalist-radiobuttons-item',
 	published: {
 		title: '',
 		selected: false
 	},
 	components: [
 		{name: 'title', classes: 'radiobutton-item-title'},
-		{tag: 'hr', classes: 'g-datalist-radiobutton-item-border'}
+		{tag: 'hr', classes: 'g-datalist-radiobuttons-item-border'}
 	],
 	bindings: [
 		{from: '.title', to: '.$.title.content'},
@@ -75,7 +75,7 @@ var RadioDataListPanel = kind({
 				{kind: RadioButtonItem, ontap: 'tapItem'}
 			],
 			footerComponents: [
-				{classes: 'g-datalist-radiobutton-footer'}
+				{classes: 'g-datalist-radiobuttons-footer'}
 			]
 		}
 	],

--- a/garnet/src/DataListwithRadioButtonsSample.js
+++ b/garnet/src/DataListwithRadioButtonsSample.js
@@ -2,7 +2,6 @@ require('garnet');
 
 var
 	kind = require('enyo/kind'),
-	ri = require('enyo/resolution'),
 	Collection = require('enyo/Collection.js'),
 	EmptyBinding = require('enyo/EmptyBinding.js'),
 	Item = require('garnet/Item'),

--- a/garnet/src/DataListwithRadioButtonsSample.js
+++ b/garnet/src/DataListwithRadioButtonsSample.js
@@ -21,7 +21,7 @@ var RadioButtonItemBase = kind({
 	},
 	components: [
 		{name: 'title', classes: 'radiobutton-item-title'},
-		{tag: 'hr', style: 'border: 0; color: #202328; height: ' + ri.scale(1) + 'px; background-color: #202328; bottom: 0;'}
+		{tag: 'hr', classes: 'g-datalist-radiobutton-item-border'}
 	],
 	bindings: [
 		{from: '.title', to: '.$.title.content'},
@@ -70,13 +70,12 @@ var RadioDataListPanel = kind({
 			controlsPerPage: 4,
 			groupSelection: true,
 			selection: true,
-			style: 'background-color: #000000;',
 			headerComponents: [{kind: Title, content: 'DataList with Radio Buttons'}],
 			components: [
 				{kind: RadioButtonItem, ontap: 'tapItem'}
 			],
 			footerComponents: [
-				{style: 'height: ' + ri.scale(116) + 'px;'}
+				{classes: 'g-datalist-radiobutton-footer'}
 			]
 		}
 	],
@@ -116,7 +115,7 @@ module.exports = kind({
 		{content: '< DataList with Radio Buttons Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'DataList with Radio Buttons', classes: 'g-sample-subheader'},
-		{name: 'radioDataListPanel', kind: RadioDataListPanel, style: 'position: relative;', onResult: 'result'},
+		{name: 'radioDataListPanel', kind: RadioDataListPanel, classes: 'g-sample-panel', onResult: 'result'},
 
 		{src: '@../assets/btn_command_next.svg', classes: 'g-sample-result', components: [
 			{content: 'Result', classes: 'g-sample-subheader'},

--- a/garnet/src/DataListwithRadioButtonsSample.less
+++ b/garnet/src/DataListwithRadioButtonsSample.less
@@ -21,11 +21,11 @@
 
 // Sample specific classes
 
-.g-datalist-radiobutton-footer {
+.g-datalist-radiobuttons-footer {
 	height: 116px;
 }
 /* RadioButton Item */
-.g-datalist-radiobutton-item{
+.g-datalist-radiobuttons-item{
 	position: relative; /* Do not omit this. It's critical */
 	height: 72px;
 
@@ -33,7 +33,7 @@
 
 	cursor: pointer;
 }
-.g-datalist-radiobutton-item .radiobutton-item-title {
+.g-datalist-radiobuttons-item .radiobutton-item-title {
 	width: 186px;
 	height: 72px;
 	margin-left: 38px;
@@ -44,7 +44,7 @@
 	-webkit-mask-image: -webkit-linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
 	-webkit-mask-image: linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
 }
-.g-datalist-radiobutton-item-border {
+.g-datalist-radiobuttons-item-border {
 	background-color: #202328;
 
 	height: 1px;
@@ -53,7 +53,7 @@
 
 	color: #202328;
 }
-.g-datalist-radiobutton-item.disabled {
+.g-datalist-radiobuttons-item.disabled {
 	opacity: 0.4;
 
 	filter: alpha(opacity=40);
@@ -72,6 +72,6 @@
 .g-selection-overlay-support.active .g-icon-button {
 	background-position: 0 -144px;
 }
-.g-datalist-radiobutton-item.pressed .g-selection-overlay-support-scrim .g-icon-button {
+.g-datalist-radiobuttons-item.pressed .g-selection-overlay-support-scrim .g-icon-button {
 	background-position: 0 -48px;
 }

--- a/garnet/src/DataListwithRadioButtonsSample.less
+++ b/garnet/src/DataListwithRadioButtonsSample.less
@@ -3,11 +3,13 @@
 // Common
 .g-sample-panel {
 	background-color: #000000;
+
 	position: relative;
 	overflow: hidden;
 }
 .g-sample-result {
 	background-color: #EDEDED;
+
 	position: fixed;
 	width: 100%;
 	min-height: 160px;
@@ -21,25 +23,36 @@
 }
 /* RadioButton Item */
 .g-datalist-radiobutton-item{
-	height: 72px;
-	line-height: 72px;
 	position: relative; /* Do not omit this. It's critical */
+	height: 72px;
+
+	line-height: 72px;
+
 	cursor: pointer;
 }
 .g-datalist-radiobutton-item .radiobutton-item-title {
 	width: 186px;
 	height: 72px;
 	margin-left: 38px;
+
 	font-size: 28px;
 	color: #FAFAFA;
+
 	-webkit-mask-image: -webkit-linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
 	-webkit-mask-image: linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
 }
 .g-datalist-radiobutton-item-border {
-	border: 0; color: #202328; height: 1px; background-color: #202328; bottom: 0;
+	background-color: #202328;
+
+	height: 1px;
+	border: 0;
+	bottom: 0;
+
+	color: #202328;
 }
 .g-datalist-radiobutton-item.disabled {
 	opacity: 0.4;
+
 	filter: alpha(opacity=40);
 }
 /* This for always showing radiobutton */

--- a/garnet/src/DataListwithRadioButtonsSample.less
+++ b/garnet/src/DataListwithRadioButtonsSample.less
@@ -1,8 +1,23 @@
 /* DataListwithRadioButtonsSample */
 
-.g-listradio-footer-comp {
+// Common
+.g-sample-panel {
+	background-color: #000000;
+	position: relative;
+	overflow: hidden;
+}
+.g-sample-result {
+	background-color: #EDEDED;
+	position: fixed;
 	width: 100%;
-	height: 93px;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
+
+.g-datalist-radiobutton-footer {
+	height: 116px;
 }
 /* RadioButton Item */
 .g-datalist-radiobutton-item{
@@ -19,6 +34,9 @@
 	color: #FAFAFA;
 	-webkit-mask-image: -webkit-linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
 	-webkit-mask-image: linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
+}
+.g-datalist-radiobutton-item-border {
+	border: 0; color: #202328; height: 1px; background-color: #202328; bottom: 0;
 }
 .g-datalist-radiobutton-item.disabled {
 	opacity: 0.4;

--- a/garnet/src/DataListwithRadioButtonsSample.less
+++ b/garnet/src/DataListwithRadioButtonsSample.less
@@ -1,6 +1,7 @@
 /* DataListwithRadioButtonsSample */
 
-// Common
+// Common classes
+
 .g-sample-panel {
 	background-color: #000000;
 
@@ -17,6 +18,8 @@
 	z-index: 9999;
 	opacity: 0.8;
 }
+
+// Sample specific classes
 
 .g-datalist-radiobutton-footer {
 	height: 116px;

--- a/garnet/src/DatePickerPanelSample.js
+++ b/garnet/src/DatePickerPanelSample.js
@@ -8,7 +8,6 @@ var SampleDatePickerPanel = kind({
 	name: 'g.sample.DatePickerPanel',
 	kind: GarnetDatePickerPanel,
 	locale: 'en-US',
-	style: 'position: relative;',
 	mode: 'year'
 });
 
@@ -19,9 +18,9 @@ module.exports = kind({
 		{content: '< Date Picker Panel Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'Date Picker Panel', classes: 'g-sample-subheader'},
-		{name: 'datepicker', kind: SampleDatePickerPanel, style: 'position: relative;'},
+		{name: 'datepicker', kind: SampleDatePickerPanel, classes: 'g-sample-panel'},
 
-		{style: 'position: fixed; width: 100%; min-height: 160px; bottom: 0; z-index: 9999; background-color: #EDEDED; opacity: 0.8;', classes: 'g-sample-result', components: [
+		{classes: 'g-sample-result', components: [
 			{content: 'Result', classes: 'g-sample-subheader'},
 			{name: 'result', allowHtml: true, content: 'No button pressed yet.', classes: 'g-sample-description'}
 		]}

--- a/garnet/src/DatePickerPanelSample.less
+++ b/garnet/src/DatePickerPanelSample.less
@@ -1,6 +1,7 @@
 /* DatePickerPanelSample */
 
-// Common
+// Common classes
+
 .g-sample-panel {
 	background-color: #000000;
 

--- a/garnet/src/DatePickerPanelSample.less
+++ b/garnet/src/DatePickerPanelSample.less
@@ -3,11 +3,13 @@
 // Common
 .g-sample-panel {
 	background-color: #000000;
+
 	position: relative;
 	overflow: hidden;
 }
 .g-sample-result {
 	background-color: #EDEDED;
+
 	position: fixed;
 	width: 100%;
 	min-height: 160px;

--- a/garnet/src/DatePickerPanelSample.less
+++ b/garnet/src/DatePickerPanelSample.less
@@ -1,1 +1,17 @@
 /* DatePickerPanelSample */
+
+// Common
+.g-sample-panel {
+	background-color: #000000;
+	position: relative;
+	overflow: hidden;
+}
+.g-sample-result {
+	background-color: #EDEDED;
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}

--- a/garnet/src/FormSample.js
+++ b/garnet/src/FormSample.js
@@ -18,9 +18,7 @@ var
 	DatePickerPanel    = require('garnet/DatePickerPanel'),
 	PickerPanel        = require('garnet/PickerPanel'),
 	MultiPickerPanel   = require('garnet/MultiPickerPanel'),
-	PanelManager       = require('garnet/PanelManager'),
-
-	panelStyle = 'width: ' + ri.scale(320) + 'px; height: ' + ri.scale(320) + 'px; position: relative; display: inline-block;';
+	PanelManager       = require('garnet/PanelManager');
 
 var Formatter = kind.singleton({
 	name: 'g.sample.Formatter',
@@ -218,8 +216,8 @@ var
 		datePickerButtonWithValue:       {name: 'datePickerWithValue', kind: SampleDatePickerPanel},
 		pickerPanelButton:               {name: 'pickerPanel', kind: CollectionPickerPanel, title:true, titleContent: 'PickerTitle', ontap: 'hidePickerPanelPopup'},
 		pickerPanelButtonWithValue:      {name: 'pickerPanelWithValue', kind: CollectionPickerPanel, title:true, titleContent: 'PickerTitle',ontap: 'hidePickerPanelPopupWithValue'},
-		multiPickerPanelButton:          {name: 'multiPickerPanel', kind: CollectionMultiPickerPanel, title:true, titleContent: 'MultiPickerTitle', style: 'position: relative; display: inline-block; margin-right: 20px;', selection: true, multipleSelection: true},
-		multiPickerPanelButtonWithValue: {name: 'multiPickerPanelWithValue', kind: CollectionMultiPickerPanel, title:true, titleContent: 'MultiPickerTitle', style: 'position: relative; display: inline-block; margin-right: 20px;', selection: true, multipleSelection: true}
+		multiPickerPanelButton:          {name: 'multiPickerPanel', kind: CollectionMultiPickerPanel, title:true, titleContent: 'MultiPickerTitle', selection: true, multipleSelection: true},
+		multiPickerPanelButtonWithValue: {name: 'multiPickerPanelWithValue', kind: CollectionMultiPickerPanel, title:true, titleContent: 'MultiPickerTitle', selection: true, multipleSelection: true}
 	},
 
 	today = new Date(),
@@ -242,11 +240,10 @@ var FormPanel = kind({
 	handlers: {
 		onUpdate: 'updateContent'
 	},
-	style: 'position: relative; background-color: #000000;overflow: hidden;',
-	classes: 'g-common-width-height-fit g-layout-absolute-wrapper',
+	classes: 'g-sample-panel g-common-width-height-fit g-layout-absolute-wrapper',
 	components: [
-		{classes: 'g-common-width-height-fit', style: 'overflow: hidden;', components: [
-			{kind: Scroller, scrollIndicatorEnabled: true, style: 'width: ' + ri.scale(320) + 'px; height: ' + ri.scale(320) + 'px; border-radius: 50%; background-color: #000000;', components: [
+		{classes: 'g-common-width-height-fit', components: [
+			{kind: Scroller, scrollIndicatorEnabled: true, classes: 'g-sample-panel g-common-width-height-fit', components: [
 				{kind: Title, content: 'Title: long text will fade out'},
 				//
 				{kind: FormLabel, content: 'Form Picker Buttons : <br>> Time Picker - current', allowHtml: 'true'},
@@ -272,8 +269,8 @@ var FormPanel = kind({
 				{kind: FormLabel, content: 'Form Buttons'},
 				{kind: FormButton, content: '+Add new'},
 				{kind: FormToolDecorator, components: [
-					{kind: FormButton, content: 'Special', style: 'width: ' + ri.scale(118) + 'px; margin-right: ' + ri.scale(4) + 'px; font-size: ' + ri.scale(20) + 'px;'},
-					{kind: FormButton, content: '+Add new', style: 'width: ' + ri.scale(120) + 'px; font-size: ' + ri.scale(20) + 'px;'}
+					{kind: FormButton, content: 'Special', classes: 'g-sample-form-button1'},
+					{kind: FormButton, content: '+Add new', classes: 'g-sample-form-button2'}
 				]},
 				//
 				{kind: FormLabel, content: 'Form Inputs'},
@@ -284,12 +281,12 @@ var FormPanel = kind({
 					{kind: FormInput, value: 'Guide Text'}
 				]},
 				{kind: FormToolDecorator, components: [
-					{kind: FormInputDecorator, style: 'width: ' + ri.scale(185) + 'px; margin-right: ' + ri.scale(6) + 'px;', components: [
+					{kind: FormInputDecorator, classes: 'g-sample-form-input', components: [
 						{kind: FormInput, value: 'Guide Text'}
 					]},
 					{kind: IconButton, src: '@../assets/btn_ic_deleted.svg', classes: 'g-common-button-size-small'}
 				]},
-				{style: 'width: 100%; height: ' + ri.scale(70) + 'px;'}
+				{classes: 'g-sample-form-footer'}
 			]}
 		]}
 	],
@@ -413,7 +410,7 @@ module.exports = kind({
 		{content: '< Form Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'Form Picker Buttons / Form Buttons / Form Inputs', classes: 'g-sample-subheader'},
-		{style: panelStyle, kind: PanelManager},
+		{kind: PanelManager, classes: 'g-sample-panel-manager'},
 
 		{src: '@../assets/btn_command_next.svg', classes: 'g-sample-result', components: [
 			{content: 'Result', classes: 'g-sample-subheader'},

--- a/garnet/src/FormSample.js
+++ b/garnet/src/FormSample.js
@@ -2,7 +2,6 @@ require('garnet');
 
 var
 	kind               = require('enyo/kind'),
-	ri                 = require('enyo/resolution'),
 	Collection         = require('enyo/Collection.js'),
 	Title              = require('garnet/Title'),
 	IconButton         = require('garnet/IconButton'),

--- a/garnet/src/FormSample.less
+++ b/garnet/src/FormSample.less
@@ -9,6 +9,7 @@
 }
 .g-sample-result {
 	background-color: #EDEDED;
+
 	position: fixed;
 	width: 100%;
 	min-height: 160px;
@@ -18,13 +19,19 @@
 }
 
 .g-sample-form-button1 {
-	width: 118px; margin-right: 4px; font-size: 20px;
+	width: 118px;
+	margin-right: 4px;
+
+	font-size: 20px;
 }
 .g-sample-form-button2 {
-	width: 120px; font-size: 20px;
+	width: 120px;
+
+	font-size: 20px;
 }
 .g-sample-form-input {
-	width: 185px; margin-right: 6px;
+	width: 185px;
+	margin-right: 6px;
 }
 .g-sample-form-footer {
 	height: 70px;

--- a/garnet/src/FormSample.less
+++ b/garnet/src/FormSample.less
@@ -1,6 +1,7 @@
 /* FormSample */
 
-// Common
+// Common classes
+
 .g-sample-panel-manager {
 	position: relative;
 	display: inline-block;
@@ -17,6 +18,8 @@
 	z-index: 9999;
 	opacity: 0.8;
 }
+
+// Sample specific classes
 
 .g-sample-form-button1 {
 	width: 118px;

--- a/garnet/src/FormSample.less
+++ b/garnet/src/FormSample.less
@@ -1,1 +1,31 @@
 /* FormSample */
+
+// Common
+.g-sample-panel-manager {
+	position: relative;
+	display: inline-block;
+	width: 320px;
+	height: 320px;
+}
+.g-sample-result {
+	background-color: #EDEDED;
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
+
+.g-sample-form-button1 {
+	width: 118px; margin-right: 4px; font-size: 20px;
+}
+.g-sample-form-button2 {
+	width: 120px; font-size: 20px;
+}
+.g-sample-form-input {
+	width: 185px; margin-right: 6px;
+}
+.g-sample-form-footer {
+	height: 70px;
+}

--- a/garnet/src/IconButtonSample.js
+++ b/garnet/src/IconButtonSample.js
@@ -16,11 +16,11 @@ var IconButtonPanel = kind({
 	classes: 'g-layout-absolute-wrapper',
 	components: [
 		{classes: 'g-layout-absolute-center', classes: 'g-sample-icon-button-container', components: [
-			{content: 'Icon Buttons : ', accessibilityLabel: 'check icon', classes: 'g-sample-icon-button-text'},
+			{content: 'Icon Buttons : ', accessibilityLabel: 'check icon', classes: 'g-sample-text'},
 			{tag: 'br'},
 			{kind: IconButton, accessibilityLabel: 'check icon', src: '@../assets/btn_done.svg', ontap: 'tapButton'},
 			{kind: IconButton, accessibilityLabel: 'check icon', src: '@../assets/btn_done.svg', disabled: true, ontap: 'tapButton'},
-			{content: 'Grouped Icon Buttons : ', classes: 'g-sample-icon-button-group-text'},
+			{content: 'Grouped Icon Buttons : ', classes: 'g-sample-text'},
 			{kind: Group, onActivate:'iconGroupActivated', components: [
 				{kind: IconButton, accessibilityLabel: 'check icon', src: '@../assets/btn_done.svg', classes: 'g-common-button-size-small', active: true},
 				{kind: IconButton, accessibilityLabel: 'check icon', src: '@../assets/btn_done.svg', classes: 'g-common-button-size-normal'},

--- a/garnet/src/IconButtonSample.js
+++ b/garnet/src/IconButtonSample.js
@@ -2,7 +2,6 @@ require('garnet');
 
 var
 	kind = require('enyo/kind'),
-	ri = require('enyo/resolution'),
 	Group = require('enyo/Group'),
 	IconButton = require('garnet/IconButton'),
 	Panel = require('garnet/Panel');
@@ -15,7 +14,7 @@ var IconButtonPanel = kind({
 	},
 	classes: 'g-layout-absolute-wrapper',
 	components: [
-		{classes: 'g-layout-absolute-center', classes: 'g-sample-icon-button-container', components: [
+		{classes: 'g-sample-icon-button-container g-layout-absolute-center', components: [
 			{content: 'Icon Buttons : ', accessibilityLabel: 'check icon', classes: 'g-sample-text'},
 			{tag: 'br'},
 			{kind: IconButton, accessibilityLabel: 'check icon', src: '@../assets/btn_done.svg', ontap: 'tapButton'},

--- a/garnet/src/IconButtonSample.js
+++ b/garnet/src/IconButtonSample.js
@@ -14,14 +14,13 @@ var IconButtonPanel = kind({
 		onResult: ''
 	},
 	classes: 'g-layout-absolute-wrapper',
-	style: 'border-radius: 50%; background-color: #000000;',
 	components: [
-		{classes: 'g-layout-absolute-center', style: 'width: ' + ri.scale(255) + 'px; height: ' + ri.scale(230) + 'px;', components: [
-			{content: 'Icon Buttons : ', accessibilityLabel: 'check icon', style: 'margin-left: ' + ri.scale(10) + 'px; font-size: ' + ri.scale(20) + 'px; display: inline-block; margin-right: ' + ri.scale(10) + 'px; color: #FFFFFF;'},
+		{classes: 'g-layout-absolute-center', classes: 'g-sample-icon-button-container', components: [
+			{content: 'Icon Buttons : ', accessibilityLabel: 'check icon', classes: 'g-sample-icon-button-text'},
 			{tag: 'br'},
 			{kind: IconButton, accessibilityLabel: 'check icon', src: '@../assets/btn_done.svg', ontap: 'tapButton'},
 			{kind: IconButton, accessibilityLabel: 'check icon', src: '@../assets/btn_done.svg', disabled: true, ontap: 'tapButton'},
-			{content: 'Grouped Icon Buttons : ', style: 'font-size: ' + ri.scale(20) + 'px; display: inline-block; margin-right: ' + ri.scale(10) + 'px; color: #FFFFFF;'},
+			{content: 'Grouped Icon Buttons : ', classes: 'g-sample-icon-button-group-text'},
 			{kind: Group, onActivate:'iconGroupActivated', components: [
 				{kind: IconButton, accessibilityLabel: 'check icon', src: '@../assets/btn_done.svg', classes: 'g-common-button-size-small', active: true},
 				{kind: IconButton, accessibilityLabel: 'check icon', src: '@../assets/btn_done.svg', classes: 'g-common-button-size-normal'},
@@ -48,7 +47,7 @@ module.exports = kind({
 		{content: '< Icon Button Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'Icon Buttons', classes: 'g-sample-subheader'},
-		{kind: IconButtonPanel, style: 'position: relative;', onResult: 'result'},
+		{kind: IconButtonPanel, classes: 'g-sample-circle-panel', onResult: 'result'},
 
 		{src: '@../assets/btn_command_next.svg', classes: 'g-sample-result', components: [
 			{content: 'Result', classes: 'g-sample-subheader'},

--- a/garnet/src/IconButtonSample.less
+++ b/garnet/src/IconButtonSample.less
@@ -1,1 +1,28 @@
 /* IconButtonSample */
+
+// Common
+.g-sample-circle-panel {
+	background-color: #000000;
+	position: relative;
+	overflow: hidden;
+	border-radius: 50%;
+}
+.g-sample-result {
+	background-color: #EDEDED;
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
+
+.g-sample-icon-button-container {
+	width: 255px; height: 230px;
+}
+.g-sample-icon-button-text {
+	margin-left: 10px; font-size: 20px; display: inline-block; margin-right: 10px; color: #FFFFFF;
+}
+.g-sample-icon-button-group-text {
+	font-size: 20px; display: inline-block; margin-right: 10px; color: #FFFFFF;
+}

--- a/garnet/src/IconButtonSample.less
+++ b/garnet/src/IconButtonSample.less
@@ -3,12 +3,14 @@
 // Common
 .g-sample-circle-panel {
 	background-color: #000000;
+
 	position: relative;
-	overflow: hidden;
 	border-radius: 50%;
+	overflow: hidden;
 }
 .g-sample-result {
 	background-color: #EDEDED;
+
 	position: fixed;
 	width: 100%;
 	min-height: 160px;
@@ -18,10 +20,12 @@
 }
 .g-sample-text {
 	display: inline-block;
+
 	font-size: 20px;
 	color: #FFFFFF;
 }
 
 .g-sample-icon-button-container {
-	width: 255px; height: 230px;
+	width: 255px;
+	height: 230px;
 }

--- a/garnet/src/IconButtonSample.less
+++ b/garnet/src/IconButtonSample.less
@@ -1,6 +1,7 @@
 /* IconButtonSample */
 
-// Common
+// Common classes
+
 .g-sample-circle-panel {
 	background-color: #000000;
 
@@ -24,6 +25,8 @@
 	font-size: 20px;
 	color: #FFFFFF;
 }
+
+// Sample specific classes
 
 .g-sample-icon-button-container {
 	width: 255px;

--- a/garnet/src/IconButtonSample.less
+++ b/garnet/src/IconButtonSample.less
@@ -16,13 +16,12 @@
 	z-index: 9999;
 	opacity: 0.8;
 }
+.g-sample-text {
+	display: inline-block;
+	font-size: 20px;
+	color: #FFFFFF;
+}
 
 .g-sample-icon-button-container {
 	width: 255px; height: 230px;
-}
-.g-sample-icon-button-text {
-	margin-left: 10px; font-size: 20px; display: inline-block; margin-right: 10px; color: #FFFFFF;
-}
-.g-sample-icon-button-group-text {
-	font-size: 20px; display: inline-block; margin-right: 10px; color: #FFFFFF;
 }

--- a/garnet/src/IconSample.js
+++ b/garnet/src/IconSample.js
@@ -10,10 +10,9 @@ var IconPanel = kind({
 	name: 'g.sample.IconPanel',
 	kind: Panel,
 	classes: 'g-layout-absolute-wrapper',
-	style: 'border-radius: 50%; background-color: #000000;',
 	components: [
-		{classes: 'g-layout-absolute-center', style: 'width: ' + ri.scale(255) + 'px; height: ' + ri.scale(230) + 'px;', components: [
-			{content: 'Icons : ', style: 'margin-left: ' + ri.scale(10) + 'px; font-size: ' + ri.scale(20) + 'px; display: inline-block; margin-right: ' + ri.scale(10) + 'px; color: #FFFFFF;'},
+		{classes: 'g-layout-absolute-center', classes: 'g-sample-icon-container', components: [
+			{content: 'Icons : ', classes: 'g-sample-icon-text'},
 			{tag: 'br'},
 			{kind: Icon, src: '@../assets/btn_cancel.svg', classes: 'g-common-button-size-small'},
 			{kind: Icon, src: '@../assets/btn_cancel.svg', classes: 'g-common-button-size-normal'},
@@ -32,7 +31,7 @@ module.exports = kind({
 		{content: '< Icon Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'Icons', classes: 'g-sample-subheader'},
-		{kind: IconPanel, style: 'position: relative;'}
+		{kind: IconPanel, classes: 'g-sample-circle-panel'}
 	],
 	goBack: function(inSender, inEvent) {
 		global.history.go(-1);

--- a/garnet/src/IconSample.js
+++ b/garnet/src/IconSample.js
@@ -2,7 +2,6 @@ require('garnet');
 
 var
 	kind = require('enyo/kind'),
-	ri = require('enyo/resolution'),
 	Icon = require('garnet/Icon'),
 	Panel = require('garnet/Panel');
 
@@ -11,7 +10,7 @@ var IconPanel = kind({
 	kind: Panel,
 	classes: 'g-layout-absolute-wrapper',
 	components: [
-		{classes: 'g-layout-absolute-center', classes: 'g-sample-icon-container', components: [
+		{classes: 'g-sample-icon-container g-layout-absolute-center', components: [
 			{content: 'Icons : ', classes: 'g-sample-text'},
 			{tag: 'br'},
 			{kind: Icon, src: '@../assets/btn_cancel.svg', classes: 'g-common-button-size-small'},

--- a/garnet/src/IconSample.js
+++ b/garnet/src/IconSample.js
@@ -12,7 +12,7 @@ var IconPanel = kind({
 	classes: 'g-layout-absolute-wrapper',
 	components: [
 		{classes: 'g-layout-absolute-center', classes: 'g-sample-icon-container', components: [
-			{content: 'Icons : ', classes: 'g-sample-icon-text'},
+			{content: 'Icons : ', classes: 'g-sample-text'},
 			{tag: 'br'},
 			{kind: Icon, src: '@../assets/btn_cancel.svg', classes: 'g-common-button-size-small'},
 			{kind: Icon, src: '@../assets/btn_cancel.svg', classes: 'g-common-button-size-normal'},

--- a/garnet/src/IconSample.less
+++ b/garnet/src/IconSample.less
@@ -1,5 +1,13 @@
 /* IconSample */
 
+// Common
+.g-sample-circle-panel {
+	background-color: #000000;
+	position: relative;
+	overflow: hidden;
+	border-radius: 50%;
+}
+
 .g-sample .g-sample-icon .g-icon {
 	margin-right: 10px;
 }
@@ -14,4 +22,10 @@
 
 	width: 22px;
 	height: 22px;
+}
+.g-sample-icon-text {
+	margin-left: 10px; font-size: 20px; display: inline-block; margin-right: 10px; color: #FFFFFF;
+}
+.g-sample-icon-container {
+	width: 255px; height: 230px;
 }

--- a/garnet/src/IconSample.less
+++ b/garnet/src/IconSample.less
@@ -3,12 +3,14 @@
 // Common
 .g-sample-circle-panel {
 	background-color: #000000;
+
 	position: relative;
-	overflow: hidden;
 	border-radius: 50%;
+	overflow: hidden;
 }
 .g-sample-text {
 	display: inline-block;
+
 	font-size: 20px;
 	color: #FFFFFF;
 }
@@ -17,17 +19,14 @@
 	margin-right: 10px;
 }
 .g-sample .g-sample-icon .g-sample-button-warning {
-	// Background Properties
-
 	background-repeat: no-repeat;
 	background-size: 22px 22px;
 	background-color: black;
-
-	// Box Properties
 
 	width: 22px;
 	height: 22px;
 }
 .g-sample-icon-container {
-	width: 255px; height: 230px;
+	width: 255px; 
+	height: 230px;
 }

--- a/garnet/src/IconSample.less
+++ b/garnet/src/IconSample.less
@@ -7,6 +7,11 @@
 	overflow: hidden;
 	border-radius: 50%;
 }
+.g-sample-text {
+	display: inline-block;
+	font-size: 20px;
+	color: #FFFFFF;
+}
 
 .g-sample .g-sample-icon .g-icon {
 	margin-right: 10px;
@@ -22,9 +27,6 @@
 
 	width: 22px;
 	height: 22px;
-}
-.g-sample-icon-text {
-	margin-left: 10px; font-size: 20px; display: inline-block; margin-right: 10px; color: #FFFFFF;
 }
 .g-sample-icon-container {
 	width: 255px; height: 230px;

--- a/garnet/src/IconSample.less
+++ b/garnet/src/IconSample.less
@@ -1,6 +1,7 @@
 /* IconSample */
 
-// Common
+// Common classes
+
 .g-sample-circle-panel {
 	background-color: #000000;
 
@@ -14,6 +15,8 @@
 	font-size: 20px;
 	color: #FFFFFF;
 }
+
+// Sample specific classes
 
 .g-sample .g-sample-icon .g-icon {
 	margin-right: 10px;

--- a/garnet/src/MultiPickerPanelSample.js
+++ b/garnet/src/MultiPickerPanelSample.js
@@ -2,7 +2,6 @@ require('garnet');
 
 var
 	kind = require('enyo/kind'),
-	ri = require('enyo/resolution'),
 	Collection = require('enyo/Collection.js'),
 	FormPickerButton = require('garnet/FormPickerButton'),
 	Panel = require('garnet/Panel'),

--- a/garnet/src/MultiPickerPanelSample.js
+++ b/garnet/src/MultiPickerPanelSample.js
@@ -7,9 +7,7 @@ var
 	FormPickerButton = require('garnet/FormPickerButton'),
 	Panel = require('garnet/Panel'),
 	MultiPickerPanel = require('garnet/MultiPickerPanel'),
-	PanelManager = require('garnet/PanelManager'),
-
-	panelStyle = 'width: ' + ri.scale(320) + 'px; height: ' + ri.scale(320) + 'px; position: relative; display: inline-block;';
+	PanelManager = require('garnet/PanelManager');
 
 var Formatter = kind.singleton({
 	/*
@@ -83,7 +81,7 @@ var FormPanel = kind({
 		onUpdate: 'updateContent'
 	},
 	components: [
-		{name: 'multiPickerButton', kind: FormPickerButton, style: 'top: ' + ri.scale(130) + 'px;', ontap: 'showPanel', content: 'Click here!'}
+		{name: 'multiPickerButton', kind: FormPickerButton, classes: 'g-sample-multipicker-panel-button', ontap: 'showPanel', content: 'Click here!'}
 	],
 	initComponents: kind.inherit(function(sup) {
 		return function() {
@@ -116,7 +114,7 @@ var PanelManager = kind({
 		onPopPanel: 'popPanel'
 	},
 	components: [
-		{kind: FormPanel, style: 'position: relative;', onResult: 'result'}
+		{kind: FormPanel, classes: 'g-sample-panel;', onResult: 'result'}
 	],
 	pushPanel: function (inSender, inEvent) {
 		this.pushFloatingPanel(inEvent.panel, inEvent.options);
@@ -133,7 +131,7 @@ module.exports = kind({
 		{content: '< MultiPickerPanel Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'MultiPickerPanel', classes: 'g-sample-subheader'},
-		{style: panelStyle, kind: PanelManager},
+		{kind: PanelManager, classes: 'g-sample-panel-manager'},
 
 		{src: '@../assets/btn_command_next.svg', classes: 'g-sample-result', components: [
 			{content: 'Result', classes: 'g-sample-subheader'},

--- a/garnet/src/MultiPickerPanelSample.less
+++ b/garnet/src/MultiPickerPanelSample.less
@@ -1,1 +1,22 @@
 /* MultiPickerPanelSample */
+
+// Common
+.g-sample-panel-manager {
+	position: relative;
+	display: inline-block;
+	width: 320px;
+	height: 320px;
+}
+.g-sample-result {
+	background-color: #EDEDED;
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
+
+.g-sample-multipicker-panel-button {
+	top: 130px;
+}

--- a/garnet/src/MultiPickerPanelSample.less
+++ b/garnet/src/MultiPickerPanelSample.less
@@ -1,6 +1,7 @@
 /* MultiPickerPanelSample */
 
-// Common
+// Common classes
+
 .g-sample-panel-manager {
 	position: relative;
 	display: inline-block;
@@ -17,6 +18,8 @@
 	z-index: 9999;
 	opacity: 0.8;
 }
+
+// Sample specific classes
 
 .g-sample-multipicker-panel-button {
 	top: 130px;

--- a/garnet/src/MultiPickerPanelSample.less
+++ b/garnet/src/MultiPickerPanelSample.less
@@ -9,6 +9,7 @@
 }
 .g-sample-result {
 	background-color: #EDEDED;
+
 	position: fixed;
 	width: 100%;
 	min-height: 160px;

--- a/garnet/src/PickerPanelSample.js
+++ b/garnet/src/PickerPanelSample.js
@@ -2,7 +2,6 @@ require('garnet');
 
 var
 	kind = require('enyo/kind'),
-	ri = require('enyo/resolution'),
 	Collection = require('enyo/Collection.js'),
 	FormPickerButton = require('garnet/FormPickerButton'),
 	Panel = require('garnet/Panel'),

--- a/garnet/src/PickerPanelSample.js
+++ b/garnet/src/PickerPanelSample.js
@@ -7,9 +7,7 @@ var
 	FormPickerButton = require('garnet/FormPickerButton'),
 	Panel = require('garnet/Panel'),
 	PickerPanel = require('garnet/PickerPanel'),
-	PanelManager = require('garnet/PanelManager'),
-
-	panelStyle = 'width: ' + ri.scale(320) + 'px; height: ' + ri.scale(320) + 'px; position: relative; display: inline-block;';
+	PanelManager = require('garnet/PanelManager');
 
 var Formatter = kind.singleton({
 	/*
@@ -65,9 +63,7 @@ var FormPanel = kind({
 		onUpdate: 'updateContent'
 	},
 	components: [
-		{style: 'position: relative; background-color: #000000;', classes: 'g-common-width-height-fit', components: [
-			{name: 'pickerButton', kind: FormPickerButton, style: 'top: ' + ri.scale(134) + 'px;', ontap: 'showPanel', content: 'Click here!'}
-		]}
+		{name: 'pickerButton', kind: FormPickerButton, classes: 'g-sample-picker-panel-button', ontap: 'showPanel', content: 'Click here!'}
 	],
 	initComponents: kind.inherit(function(sup) {
 		return function() {
@@ -99,7 +95,7 @@ var PanelManager = kind({
 		onPopPanel: 'popPanel'
 	},
 	components: [
-		{kind: FormPanel, style: 'position: relative;', onResult: 'result'}
+		{kind: FormPanel, classes: 'g-sample-panel', onResult: 'result'}
 	],
 	pushPanel: function (inSender, inEvent) {
 		this.pushFloatingPanel(inEvent.panel, inEvent.options);
@@ -116,7 +112,7 @@ module.exports = kind({
 		{content: '< PickerPanel Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'PickerPanel', classes: 'g-sample-subheader'},
-		{style: panelStyle, kind: PanelManager},
+		{kind: PanelManager, classes: 'g-sample-panel-manager'},
 
 		{src: '@../assets/btn_command_next.svg', classes: 'g-sample-result', components: [
 			{content: 'Result', classes: 'g-sample-subheader'},

--- a/garnet/src/PickerPanelSample.less
+++ b/garnet/src/PickerPanelSample.less
@@ -1,6 +1,7 @@
 /* PickerPanelSample */
 
-// Common
+// Common classes
+
 .g-sample-panel {
 	background-color: #000000;
 
@@ -23,6 +24,8 @@
 	z-index: 9999;
 	opacity: 0.8;
 }
+
+// Sample specific classes
 
 .g-sample-picker-panel-button {
 	top: 130px;

--- a/garnet/src/PickerPanelSample.less
+++ b/garnet/src/PickerPanelSample.less
@@ -1,1 +1,27 @@
 /* PickerPanelSample */
+
+// Common
+.g-sample-panel {
+	background-color: #000000;
+	position: relative;
+	overflow: hidden;
+}
+.g-sample-panel-manager {
+	position: relative;
+	display: inline-block;
+	width: 320px;
+	height: 320px;
+}
+.g-sample-result {
+	background-color: #EDEDED;
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
+
+.g-sample-picker-panel-button {
+	top: 130px;
+}

--- a/garnet/src/PickerPanelSample.less
+++ b/garnet/src/PickerPanelSample.less
@@ -3,6 +3,7 @@
 // Common
 .g-sample-panel {
 	background-color: #000000;
+
 	position: relative;
 	overflow: hidden;
 }
@@ -14,6 +15,7 @@
 }
 .g-sample-result {
 	background-color: #EDEDED;
+
 	position: fixed;
 	width: 100%;
 	min-height: 160px;

--- a/garnet/src/PreventTapOnDragSample.js
+++ b/garnet/src/PreventTapOnDragSample.js
@@ -9,9 +9,9 @@ module.exports = kind({
 		{content: '< Prevent Tap On Drag Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'Drag inside the buttons', classes: 'g-sample-subheader'},
-		{style:'background:red; border-radius:10px; margin:10px; padding:40px; display:inline-block; color: white;', content:'Drag inside', ontap:'tap', name:'red'},
-		{style:'background:blue; border-radius:10px; margin:10px; padding:40px; display:inline-block; color: white;', content:'Drag inside', ontap:'tap', name: 'blue', ondragfinish: 'dragfinish'},
-		{name: 'result', allowHtml: true, content: '', style: 'color: black'}
+		{classes:'g-sample-prevent-tap-on-drag-box', content:'Drag inside', ontap:'tap', name:'red'},
+		{classes:'g-sample-prevent-tap-on-drag-box', content:'Drag inside', ontap:'tap', name: 'blue', ondragfinish: 'dragfinish'},
+		{name: 'result', allowHtml: true, content: '', classes: 'g-sample-prevent-tap-on-drag-result'}
 	],
 	dragfinish: function(inSender, inEvent) {
 		inEvent.preventTap();

--- a/garnet/src/PreventTapOnDragSample.less
+++ b/garnet/src/PreventTapOnDragSample.less
@@ -1,1 +1,8 @@
 /* PreventTapOnDragSample */
+
+.g-sample-prevent-tap-on-drag-box {
+	background:red; border-radius:10px; margin:10px; padding:40px; display:inline-block; color: white;
+}
+.g-sample-prevent-tap-on-drag-result {
+	color: black;
+}

--- a/garnet/src/PreventTapOnDragSample.less
+++ b/garnet/src/PreventTapOnDragSample.less
@@ -1,7 +1,14 @@
 /* PreventTapOnDragSample */
 
 .g-sample-prevent-tap-on-drag-box {
-	background:red; border-radius:10px; margin:10px; padding:40px; display:inline-block; color: white;
+	background:red;
+
+	display:inline-block;
+	border-radius:10px;
+	padding:40px;
+	margin:10px;
+
+	color: white;
 }
 .g-sample-prevent-tap-on-drag-result {
 	color: black;

--- a/garnet/src/PreventTapOnDragSample.less
+++ b/garnet/src/PreventTapOnDragSample.less
@@ -1,5 +1,7 @@
 /* PreventTapOnDragSample */
 
+// Sample specific classes
+
 .g-sample-prevent-tap-on-drag-box {
 	background:red;
 

--- a/garnet/src/ProgressBarSample.js
+++ b/garnet/src/ProgressBarSample.js
@@ -2,7 +2,6 @@ require('garnet');
 
 var
 	kind = require('enyo/kind'),
-	ri = require('enyo/resolution'),
 	ConfirmPopup = require('garnet/ConfirmPopup'),
 	FormButton = require('garnet/FormButton'),
 	FormInput = require('garnet/FormInput'),
@@ -29,7 +28,7 @@ var ProgressBarPanel = kind({
 				{name: 'cancel', kind: IconButton, ontap: 'hidePopup', classes: 'g-cancel-image'}
 			],
 			components: [
-				{classes: 'g-common-width-height-fit', classes: 'g-sample-progressbar-popup', components: [
+				{classes: 'g-sample-progressbar-popup g-common-width-height-fit', components: [
 					{name: 'percentage', classes:'g-sample-progressbar-popup-loading', content: 'Loading...'},
 					{kind: ProgressBar, name: 'popupProgress', classes:'g-sample-progressbar-popup-progressbar', progress: 0, max: 100, onChange: 'updateProgressP'},
 					{name: 'percentageP', classes:'g-sample-progressbar-popup-text'}

--- a/garnet/src/ProgressBarSample.js
+++ b/garnet/src/ProgressBarSample.js
@@ -38,7 +38,7 @@ var ProgressBarPanel = kind({
 		{kind: FormLabel, content: 'Progress Bar: set value '},
 		{name: 'progressBar1', kind: ProgressBar, progress: 25, max: 100, classes: 'g-sample-progressbar-progressbar1'},
 		{name: 'progressBar2', kind: ProgressBar, progress: 25, bgProgress: 75, max: 100, classes: 'g-sample-progressbar-progressbar2'},
-		{kind: FormToolDecorator, classes: '', components: [
+		{kind: FormToolDecorator, components: [
 			{name: 'input' ,kind: FormInput, value: 25, classes: 'g-sample-form-input'},
 			{kind: FormButton, content:'Set', ontap: 'changeValue', classes: 'g-sample-form-value'}
 		]},

--- a/garnet/src/ProgressBarSample.js
+++ b/garnet/src/ProgressBarSample.js
@@ -19,10 +19,9 @@ var ProgressBarPanel = kind({
 		onCancel: 'hidePopup',
 		onPopUpAnimationEnd: 'popupAnimationFinished'
 	},
-	style: 'border-radius: 50%; background-color: #000000;',
 	components: [
-		{style: 'width: 100%; height: ' + ri.scale(10) + 'px;'},
-		{name: 'popupButton', kind: FormButton, ontap: 'showPopup', content: 'Popup', style: 'width: ' + ri.scale(140) + 'px; margin: auto; display: block;'},
+		{classes: 'g-sample-progressbar-header'},
+		{name: 'popupButton', kind: FormButton, ontap: 'showPopup', content: 'Popup', classes: 'g-sample-progressbar-popup-button'},
 		{
 			name: 'confirmPopupWithOnlyCancelButton',
 			kind: ConfirmPopup,
@@ -30,23 +29,23 @@ var ProgressBarPanel = kind({
 				{name: 'cancel', kind: IconButton, ontap: 'hidePopup', classes: 'g-cancel-image'}
 			],
 			components: [
-				{classes: 'g-common-width-height-fit', style: 'overflow: hidden; top: 28%;', components: [
-					{name: 'percentage', style:'font-size: ' + ri.scale(28) + 'px; width: ' + ri.scale(240) + 'px; margin: ' + ri.scale(97) + 'px ' + ri.scale(20) + 'px ' + ri.scale(15) + 'px ' + ri.scale(20) + 'px; text-align: center; display: inline-block; color: #FAFAFA;', content: 'Loading...'},
-					{kind: ProgressBar, name: 'popupProgress', style:'left: 12%; width: ' + ri.scale(240) + 'px;', progress: 0, max: 100, onChange: 'updateProgressP'},
-					{name: 'percentageP', style:'font-size: ' + ri.scale(26) + 'px; width: ' + ri.scale(240) + 'px; margin: ' + ri.scale(15) + 'px ' + ri.scale(30) + 'px 0; line-height: ' + ri.scale(26) + 'px; text-align: center; display: inline-block; color: #1CD2D2;'}
+				{classes: 'g-common-width-height-fit', classes: 'g-sample-progressbar-popup', components: [
+					{name: 'percentage', classes:'g-sample-progressbar-popup-loading', content: 'Loading...'},
+					{kind: ProgressBar, name: 'popupProgress', classes:'g-sample-progressbar-popup-progressbar', progress: 0, max: 100, onChange: 'updateProgressP'},
+					{name: 'percentageP', classes:'g-sample-progressbar-popup-text'}
 				]}
 			]
 		},
 		{kind: FormLabel, content: 'Progress Bar: set value '},
-		{name: 'progressBar1', kind: ProgressBar, progress: 25, max: 100, style: 'margin: ' + ri.scale(10) + 'px ' + ri.scale(18) + 'px ' + ri.scale(12) + 'px;'},
-		{name: 'progressBar2', kind: ProgressBar, progress: 25, bgProgress: 75, max: 100, style: 'margin: ' + ri.scale(10) + 'px ' + ri.scale(18) + 'px ' + ri.scale(12) + 'px;'},
-		{kind: FormToolDecorator, style: 'text-align: center;', components: [
-			{name: 'input' ,kind: FormInput, value: 25, style: 'width: ' + ri.scale(150) + 'px; margin-right: ' + ri.scale(10) + 'px;'},
-			{kind: FormButton, content:'Set', ontap: 'changeValue', style: 'width: ' + ri.scale(80) + 'px;'}
+		{name: 'progressBar1', kind: ProgressBar, progress: 25, max: 100, classes: 'g-sample-progressbar-progressbar1'},
+		{name: 'progressBar2', kind: ProgressBar, progress: 25, bgProgress: 75, max: 100, classes: 'g-sample-progressbar-progressbar2'},
+		{kind: FormToolDecorator, classes: '', components: [
+			{name: 'input' ,kind: FormInput, value: 25, classes: 'g-sample-form-input'},
+			{kind: FormButton, content:'Set', ontap: 'changeValue', classes: 'g-sample-form-value'}
 		]},
-		{kind: FormToolDecorator, style: 'text-align: center;', components: [
-			{kind: FormButton, content:'-', ontap: 'decValue', style: 'width: ' + ri.scale(70) + 'px; margin: 0 ' + ri.scale(4) + 'px 0 ' + ri.scale(45) + 'px;'},
-			{kind: FormButton, content:'+', ontap: 'incValue', style: 'width: ' + ri.scale(70) + 'px; margin-right: ' + ri.scale(45) + 'px;'}
+		{kind: FormToolDecorator, classes: 'g-sample-probressbar-tooldecorator', components: [
+			{kind: FormButton, content:'-', ontap: 'decValue', classes: 'g-sample-form-button-minus'},
+			{kind: FormButton, content:'+', ontap: 'incValue', classes: 'g-sample-form-button-plus'}
 		]}
 	],
 	changeValue: function(inSender, inEvent) {
@@ -96,7 +95,7 @@ module.exports = kind({
 		{content: '< Progress Bar Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'ProgressBars', classes: 'g-sample-subheader'},
-		{kind: ProgressBarPanel, style: 'position: relative;'}
+		{kind: ProgressBarPanel, classes: 'g-sample-circle-panel'}
 	],
 	goBack: function(inSender, inEvent) {
 		global.history.go(-1);

--- a/garnet/src/ProgressBarSample.less
+++ b/garnet/src/ProgressBarSample.less
@@ -1,1 +1,49 @@
 /* ProgressBarSample */
+
+// Common
+.g-sample-circle-panel {
+	background-color: #000000;
+	position: relative;
+	overflow: hidden;
+	border-radius: 50%;
+}
+
+.g-sample-progressbar-header {
+	width: 100%; height: 10px;
+}
+.g-sample-progressbar-popup-button {
+	width: 140px; margin: auto; display: block;
+}
+.g-sample-progressbar-popup {
+	overflow: hidden; top: 28%;
+}
+.g-sample-progressbar-popup-loading {
+	font-size: 28px; width: 240px; margin: 97px 20px 15px 20px; text-align: center; display: inline-block; color: #FAFAFA;
+}
+.g-sample-progressbar-popup-progressbar {
+	left: 12%; width: 240px;
+}
+.g-sample-progressbar-popup-text {
+	font-size: 26px; width: 240px; margin: 15px 30px 0; line-height: 26px; text-align: center; display: inline-block; color: #1CD2D2;
+}
+.g-sample-progressbar-progressbar1 {
+	margin: 10px 18px 12px;
+}
+.g-sample-progressbar-progressbar2 {
+	margin: 10px 18px 12px;
+}
+.g-sample-probressbar-tooldecorator {
+	text-align: center;
+}
+.g-sample-form-input {
+	width: 150px; margin-right: 10px;
+}
+.g-sample-form-value {
+	width: 80px;
+}
+.g-sample-form-button-minus {
+	width: 70px; margin: 0 4px 0 45px;
+}
+.g-sample-form-button-plus {
+	width: 70px; margin-right: 45px;
+}

--- a/garnet/src/ProgressBarSample.less
+++ b/garnet/src/ProgressBarSample.less
@@ -1,6 +1,7 @@
 /* ProgressBarSample */
 
-// Common
+// Common classes
+
 .g-sample-circle-panel {
 	background-color: #000000;
 
@@ -8,6 +9,8 @@
 	border-radius: 50%;
 	overflow: hidden;
 }
+
+// Sample specific classes
 
 .g-sample-progressbar-header {
 	width: 100%;

--- a/garnet/src/ProgressBarSample.less
+++ b/garnet/src/ProgressBarSample.less
@@ -3,28 +3,47 @@
 // Common
 .g-sample-circle-panel {
 	background-color: #000000;
+
 	position: relative;
-	overflow: hidden;
 	border-radius: 50%;
+	overflow: hidden;
 }
 
 .g-sample-progressbar-header {
-	width: 100%; height: 10px;
+	width: 100%;
+	height: 10px;
 }
 .g-sample-progressbar-popup-button {
-	width: 140px; margin: auto; display: block;
+	display: block;
+	width: 140px;
+	margin: auto;
 }
 .g-sample-progressbar-popup {
-	overflow: hidden; top: 28%;
+	top: 28%;
+	overflow: hidden;
 }
 .g-sample-progressbar-popup-loading {
-	font-size: 28px; width: 240px; margin: 97px 20px 15px 20px; text-align: center; display: inline-block; color: #FAFAFA;
+	display: inline-block;
+	width: 240px;
+	margin: 97px 20px 15px 20px;
+
+	text-align: center;
+	font-size: 28px;
+	color: #FAFAFA;
 }
 .g-sample-progressbar-popup-progressbar {
-	left: 12%; width: 240px;
+	width: 240px;
+	left: 12%;
 }
 .g-sample-progressbar-popup-text {
-	font-size: 26px; width: 240px; margin: 15px 30px 0; line-height: 26px; text-align: center; display: inline-block; color: #1CD2D2;
+	display: inline-block;
+	width: 240px;
+	margin: 15px 30px 0;
+
+	line-height: 26px;
+	text-align: center;
+	font-size: 26px;
+	color: #1CD2D2;
 }
 .g-sample-progressbar-progressbar1 {
 	margin: 10px 18px 12px;
@@ -36,14 +55,17 @@
 	text-align: center;
 }
 .g-sample-form-input {
-	width: 150px; margin-right: 10px;
+	width: 150px;
+	margin-right: 10px;
 }
 .g-sample-form-value {
 	width: 80px;
 }
 .g-sample-form-button-minus {
-	width: 70px; margin: 0 4px 0 45px;
+	width: 70px;
+	margin: 0 4px 0 45px;
 }
 .g-sample-form-button-plus {
-	width: 70px; margin-right: 45px;
+	width: 70px;
+	margin-right: 45px;
 }

--- a/garnet/src/SpinnerSample.js
+++ b/garnet/src/SpinnerSample.js
@@ -9,10 +9,9 @@ var
 var SpinnerPanel = kind({
 	name: 'g.sample.SpinnerPanel',
 	kind: Panel,
-	style: 'border-radius: 50%; background-color: #000000;',
 	components: [
-		{classes: 'g-layout-absolute-center', style: 'width: ' + ri.scale(244) + 'px; height: ' + ri.scale(110) + 'px;', components: [
-			{kind: Spinner, style: 'width: 100%', content: 'Connecting to the server'}
+		{classes: 'g-sample-spinner-container g-layout-absolute-center', components: [
+			{kind: Spinner, classes: 'g-sample-spinner-width', content: 'Connecting to the server'}
 		]}
 	]
 });
@@ -20,9 +19,8 @@ var SpinnerPanel = kind({
 var TextSpinnerPanel = kind({
 	name: 'g.sample.TextSpinnerPanel',
 	kind: Panel,
-	style: 'border-radius: 50%; background-color: #000000;',
 	components: [
-		{kind: Spinner, classes: 'g-layout-absolute-center', style: 'position: absolute;'}
+		{kind: Spinner, classes: 'g-layout-absolute-center', classes: 'g-sample-spinner-text-spinner'}
 	]
 });
 
@@ -33,16 +31,16 @@ module.exports = kind({
 		{content: '< Spinner Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'Spinners', classes: 'g-sample-subheader'},
-		{style: 'position: relative; height: 100%', components: [
+		{classes: 'g-sample-panels', components: [
 			{
 				name: 'spinnerPanel',
 				kind: SpinnerPanel,
-				style: 'background-color: #000000; position: relative; display: inline-block; overflow: hidden;'
+				classes: 'g-sample-circle-panel-margin'
 			},
 			{
 				name: 'textSpinnerPanel',
 				kind: TextSpinnerPanel,
-				style: 'background-color: #000000; position: relative; display: inline-block; overflow: hidden;'
+				classes: 'g-sample-circle-panel-margin'
 			}
 		]}
 	],

--- a/garnet/src/SpinnerSample.js
+++ b/garnet/src/SpinnerSample.js
@@ -2,7 +2,6 @@ require('garnet');
 
 var
 	kind = require('enyo/kind'),
-	ri = require('enyo/resolution'),
 	Spinner = require('garnet/Spinner'),
 	Panel = require('garnet/Panel');
 
@@ -20,7 +19,7 @@ var TextSpinnerPanel = kind({
 	name: 'g.sample.TextSpinnerPanel',
 	kind: Panel,
 	components: [
-		{kind: Spinner, classes: 'g-layout-absolute-center', classes: 'g-sample-spinner-text-spinner'}
+		{kind: Spinner, classes: 'g-sample-spinner-text-spinner g-layout-absolute-center'}
 	]
 });
 

--- a/garnet/src/SpinnerSample.less
+++ b/garnet/src/SpinnerSample.less
@@ -3,18 +3,21 @@
 // Common
 .g-sample-circle-panel-margin {
 	background-color: #000000;
+
 	position: relative;
-	overflow: hidden;
 	display: inline-block;
 	border-radius: 50%;
 	margin-right: 10px;
+	overflow: hidden;
 }
 .g-sample-panels {
-	position: relative; height: 100%;
+	position: relative;
+	height: 100%;
 }
 
 .g-sample-spinner-container {
-	width: 244px; height: 110px;
+	width: 244px;
+	height: 110px;
 }
 .g-sample-spinner-width {
 	width: 100%

--- a/garnet/src/SpinnerSample.less
+++ b/garnet/src/SpinnerSample.less
@@ -1,6 +1,7 @@
 /* SpinnerSample */
 
-// Common
+// Common classes
+
 .g-sample-circle-panel-margin {
 	background-color: #000000;
 
@@ -14,6 +15,8 @@
 	position: relative;
 	height: 100%;
 }
+
+// Sample specific classes
 
 .g-sample-spinner-container {
 	width: 244px;

--- a/garnet/src/SpinnerSample.less
+++ b/garnet/src/SpinnerSample.less
@@ -1,1 +1,24 @@
 /* SpinnerSample */
+
+// Common
+.g-sample-circle-panel-margin {
+	background-color: #000000;
+	position: relative;
+	overflow: hidden;
+	display: inline-block;
+	border-radius: 50%;
+	margin-right: 10px;
+}
+.g-sample-panels {
+	position: relative; height: 100%;
+}
+
+.g-sample-spinner-container {
+	width: 244px; height: 110px;
+}
+.g-sample-spinner-width {
+	width: 100%
+}
+.g-sample-spinner-text-spinner {
+	position: absolute;
+}

--- a/garnet/src/TimePickerPanelSample.js
+++ b/garnet/src/TimePickerPanelSample.js
@@ -31,16 +31,16 @@ module.exports = kind({
 		{content: '< Time Picker Panel Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'Time Picker Panel', classes: 'g-sample-subheader'},
-		{style: 'position: relative; height: 100%', components: [
+		{classes: 'g-sample-panels', components: [
 			{
 				name: 'timePicker12Panel',
 				kind: TimePicker12Panel,
-				style: 'background-color: #000000; position: relative; display: inline-block; overflow: hidden;'
+				classes: 'g-sample-panel-margin'
 			},
 			{
 				name: 'timePicker24Panel',
 				kind: TimePicker24Panel,
-				style: 'background-color: #000000; position: relative; display: inline-block; margin-left: ' + ri.scale(10) + 'px; overflow: hidden;'
+				classes: 'g-sample-panel-margin'
 			}
 		]},
 

--- a/garnet/src/TimePickerPanelSample.js
+++ b/garnet/src/TimePickerPanelSample.js
@@ -2,7 +2,6 @@ require('garnet');
 
 var
 	kind = require('enyo/kind'),
-	ri = require('enyo/resolution'),
 	GarnetTimePickerPanel = require('garnet/TimePickerPanel');
 
 var TimePicker12Panel = kind({

--- a/garnet/src/TimePickerPanelSample.less
+++ b/garnet/src/TimePickerPanelSample.less
@@ -2,14 +2,16 @@
 
 // Common
 .g-sample-panels {
-	position: relative; height: 100%;
+	position: relative;
+	height: 100%;
 }
 .g-sample-panel-margin {
 	background-color: #000000;
+
 	position: relative;
-	overflow: hidden;
 	display: inline-block;
 	margin-right: 10px;
+	overflow: hidden;
 }
 .g-sample-result {
 	background-color: #EDEDED;

--- a/garnet/src/TimePickerPanelSample.less
+++ b/garnet/src/TimePickerPanelSample.less
@@ -1,6 +1,7 @@
 /* TimePickerPanelSample */
 
-// Common
+// Common classes
+
 .g-sample-panels {
 	position: relative;
 	height: 100%;

--- a/garnet/src/TimePickerPanelSample.less
+++ b/garnet/src/TimePickerPanelSample.less
@@ -1,1 +1,22 @@
 /* TimePickerPanelSample */
+
+// Common
+.g-sample-panels {
+	position: relative; height: 100%;
+}
+.g-sample-panel-margin {
+	background-color: #000000;
+	position: relative;
+	overflow: hidden;
+	display: inline-block;
+	margin-right: 10px;
+}
+.g-sample-result {
+	background-color: #EDEDED;
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}

--- a/garnet/src/TitleSample.js
+++ b/garnet/src/TitleSample.js
@@ -22,8 +22,8 @@ var TitlePanel = kind({
 			scrollIndicatorEnabled: true,
 			components: [
 				{name: 'title', kind: Title, content: 'Title: long text will fade out', ontap: 'tapTitle', onclick: 'clickTitle'},
-				{style: 'padding-top: ' + ri.scale(60)+ 'px; width: ' + ri.scale(200) + 'px; margin: auto;', content: 'Garnet is a UI library built for wearable devices and is based on Enyo. Garnet supports LG smart watch as well as the emulator provided. Browser-wise, Garnet supports the browser on LG smart watch, Firefox 16, Opera 15, Safari 3.1, Chrome 27 and their higher versions.'},
-				{kind: Button, content: 'OK!!!', ontap: 'tapButton', style: 'margin: ' + ri.scale(20) + 'px 0 ' + ri.scale(70) + 'px;'}
+				{classes: 'g-sample-title-content', content: 'Garnet is a UI library built for wearable devices and is based on Enyo. Garnet supports LG smart watch as well as the emulator provided. Browser-wise, Garnet supports the browser on LG smart watch, Firefox 16, Opera 15, Safari 3.1, Chrome 27 and their higher versions.'},
+				{kind: Button, content: 'OK!!!', ontap: 'tapButton', classes: 'g-sample-title-button'}
 			]
 		}
 	],
@@ -47,7 +47,7 @@ module.exports = kind({
 		{content: '< Title ( + BodyText ) Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'Title with a scrollable content area', classes: 'g-sample-subheader'},
-		{kind: TitlePanel, style: 'position: relative;', onResult: 'result'},
+		{kind: TitlePanel, classes: 'g-sample-panel', onResult: 'result'},
 
 		{src: '@../assets/btn_command_next.svg', classes: 'g-sample-result', components: [
 			{content: 'Result', classes: 'g-sample-subheader'},

--- a/garnet/src/TitleSample.js
+++ b/garnet/src/TitleSample.js
@@ -2,7 +2,6 @@ require('garnet');
 
 var
 	kind = require('enyo/kind'),
-	ri = require('enyo/resolution'),
 	Button = require('garnet/Button'),
 	Scroller = require('garnet/Scroller'),
 	Panel = require('garnet/Panel'),

--- a/garnet/src/TitleSample.less
+++ b/garnet/src/TitleSample.less
@@ -1,1 +1,24 @@
 /* TitleSample */
+
+// Common
+.g-sample-panel {
+	background-color: #000000;
+	position: relative;
+	overflow: hidden;
+}
+.g-sample-result {
+	background-color: #EDEDED;
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
+
+.g-sample-title-content {
+	padding-top: 60px; width: 200px; margin: auto;
+}
+.g-sample-title-button {
+	margin: 20px 0 70px;
+}

--- a/garnet/src/TitleSample.less
+++ b/garnet/src/TitleSample.less
@@ -1,6 +1,7 @@
 /* TitleSample */
 
-// Common
+// Common classes
+
 .g-sample-panel {
 	background-color: #000000;
 
@@ -17,6 +18,8 @@
 	z-index: 9999;
 	opacity: 0.8;
 }
+
+// Sample specific classes
 
 .g-sample-title-content {
 	width: 200px;

--- a/garnet/src/TitleSample.less
+++ b/garnet/src/TitleSample.less
@@ -3,11 +3,13 @@
 // Common
 .g-sample-panel {
 	background-color: #000000;
+
 	position: relative;
 	overflow: hidden;
 }
 .g-sample-result {
 	background-color: #EDEDED;
+
 	position: fixed;
 	width: 100%;
 	min-height: 160px;
@@ -17,7 +19,9 @@
 }
 
 .g-sample-title-content {
-	padding-top: 60px; width: 200px; margin: auto;
+	width: 200px;
+	margin: auto;
+	padding-top: 60px;
 }
 .g-sample-title-button {
 	margin: 20px 0 70px;

--- a/garnet/src/ToastPanelSample.js
+++ b/garnet/src/ToastPanelSample.js
@@ -2,12 +2,11 @@ require('garnet');
 
 var
 	kind = require('enyo/kind'),
-	ri = require('enyo/resolution'),
 
 	Button = require('garnet/Button'),
 	ToastPanel = require('garnet/ToastPanel'),
 	Panel = require('garnet/Panel'),
-	PanelManager = require('garnet/PanelManager');;
+	PanelManager = require('garnet/PanelManager');
 
 var SampleToast = kind({
 	name: 'toast',

--- a/garnet/src/ToastPanelSample.js
+++ b/garnet/src/ToastPanelSample.js
@@ -7,10 +7,7 @@ var
 	Button = require('garnet/Button'),
 	ToastPanel = require('garnet/ToastPanel'),
 	Panel = require('garnet/Panel'),
-	PanelManager = require('garnet/PanelManager');
-
-var
-	panelStyle = 'width: ' + ri.scale(320) + 'px; height: ' + ri.scale(320) + 'px; position: relative; display: inline-block; ';
+	PanelManager = require('garnet/PanelManager');;
 
 var SampleToast = kind({
 	name: 'toast',
@@ -25,7 +22,7 @@ var ToastBasePanel = kind({
 	kind: Panel,
 	classes: 'g-layout-absolute-wrapper', // for button
 	components: [
-		{kind: Button, style: 'position: absolute; width: ' + ri.scale(310) + 'px; margin: auto;', classes: 'g-layout-absolute-center g-layout-absolute-middle', ontap: 'showPanel', content: 'Click here'}
+		{kind: Button, classes: 'g-sample-toast-panel-container g-layout-absolute-center g-layout-absolute-middle', ontap: 'showPanel', content: 'Click here'}
 	],
 	showPanel: function(inSender, inEvent) {
 		this.bubbleUp('onPushPanel', {panelName: name, owner: this});
@@ -58,7 +55,7 @@ module.exports = kind({
 		{content: '< Toast Panel Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'Toast', classes: 'g-sample-subheader'},
-		{style: panelStyle, kind: PanelManager}
+		{kind: PanelManager, classes: 'g-sample-panel-manager'}
 	],
 	goBack: function(inSender, inEvent) {
 		global.history.go(-1);

--- a/garnet/src/ToastPanelSample.js
+++ b/garnet/src/ToastPanelSample.js
@@ -34,7 +34,6 @@ var PanelManager = kind({
 	handlers: {
 		onPushPanel: 'pushPanel'
 	},
-	classes: 'enyo-fit',
 	components: [
 		{kind: ToastBasePanel}
 	],

--- a/garnet/src/ToastPanelSample.less
+++ b/garnet/src/ToastPanelSample.less
@@ -1,1 +1,13 @@
 /* ToastPanelSample */
+
+// Common
+.g-sample-panel-manager {
+	position: relative;
+	display: inline-block;
+	width: 320px;
+	height: 320px;
+}
+
+.g-sample-toast-panel-container {
+	position: absolute; width: 310px; margin: auto;
+}

--- a/garnet/src/ToastPanelSample.less
+++ b/garnet/src/ToastPanelSample.less
@@ -1,12 +1,15 @@
 /* ToastPanelSample */
 
-// Common
+// Common classes
+
 .g-sample-panel-manager {
 	position: relative;
 	display: inline-block;
 	width: 320px;
 	height: 320px;
 }
+
+// Sample specific classes
 
 .g-sample-toast-panel-container {
 	position: absolute;

--- a/garnet/src/ToastPanelSample.less
+++ b/garnet/src/ToastPanelSample.less
@@ -9,5 +9,7 @@
 }
 
 .g-sample-toast-panel-container {
-	position: absolute; width: 310px; margin: auto;
+	position: absolute;
+	width: 310px;
+	margin: auto;
 }

--- a/garnet/src/ToggleButtonSample.js
+++ b/garnet/src/ToggleButtonSample.js
@@ -2,7 +2,6 @@ require('garnet');
 
 var
 	kind = require('enyo/kind'),
-	ri = require('enyo/resolution'),
 	Group = require('enyo/Group'),
 	ToggleButton = require('garnet/ToggleButton'),
 	Panel = require('garnet/Panel');

--- a/garnet/src/ToggleButtonSample.js
+++ b/garnet/src/ToggleButtonSample.js
@@ -19,7 +19,7 @@ var ToggleButtonPanel = kind({
 			{kind: ToggleButton, value: true, content: '1', ontap: 'tapButton'},
 			{kind: ToggleButton, content: '2', ontap: 'tapButton'},
 			{kind: ToggleButton, disabled: true, content: 'Disabled', ontap: 'tapButton'},
-			{content: 'Grouped ToggleButtons : ', classes: 'g-sample-toggle-icon-button-group-text'},
+			{content: 'Grouped ToggleButtons : ', classes: 'g-sample-text'},
 			{kind: Group, components: [
 				{kind: ToggleButton, active: true, content: 'AA', ontap: 'tapButton'},
 				{kind: ToggleButton, content: 'BB', ontap: 'tapButton'},

--- a/garnet/src/ToggleButtonSample.js
+++ b/garnet/src/ToggleButtonSample.js
@@ -14,13 +14,12 @@ var ToggleButtonPanel = kind({
 		onResult: ''
 	},
 	classes: 'g-layout-absolute-wrapper',
-	style: 'border-radius: 50%; background-color: #000000;',
 	components: [
-		{classes: 'g-layout-absolute-center', style: 'width: ' + ri.scale(280) + 'px; height: ' + ri.scale(230) + 'px;', components: [
+		{classes: 'g-layout-absolute-center g-sample-toggle-icon-button-container', components: [
 			{kind: ToggleButton, value: true, content: '1', ontap: 'tapButton'},
 			{kind: ToggleButton, content: '2', ontap: 'tapButton'},
 			{kind: ToggleButton, disabled: true, content: 'Disabled', ontap: 'tapButton'},
-			{content: 'Grouped ToggleButtons : ', style: 'font-size: ' + ri.scale(20) + 'px; display: inline-block; margin-right: ' + ri.scale(10) + 'px; color: #FFFFFF;'},
+			{content: 'Grouped ToggleButtons : ', classes: 'g-sample-toggle-icon-button-group-text'},
 			{kind: Group, components: [
 				{kind: ToggleButton, active: true, content: 'AA', ontap: 'tapButton'},
 				{kind: ToggleButton, content: 'BB', ontap: 'tapButton'},
@@ -41,9 +40,9 @@ module.exports = kind({
 		{content: '< Toggle Button Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'Toggle Buttons', classes: 'g-sample-subheader'},
-		{kind: ToggleButtonPanel, style: 'position: relative;', onResult: 'result'},
+		{kind: ToggleButtonPanel, classes: 'g-sample-circle-panel', onResult: 'result'},
 
-		{style: 'position: fixed; width: 100%; min-height: +' + ri.scale(160) + 'px; bottom: 0; z-index: 9999; background-color: #EDEDED; opacity: 0.8;', classes: 'g-sample-result', components: [
+		{classes: 'g-sample-result', components: [
 			{content: 'Result', classes: 'g-sample-subheader'},
 			{name: 'result', allowHtml: true, content: 'No action yet', classes: 'g-sample-description'}
 		]}

--- a/garnet/src/ToggleButtonSample.js
+++ b/garnet/src/ToggleButtonSample.js
@@ -15,7 +15,7 @@ var ToggleButtonPanel = kind({
 	},
 	classes: 'g-layout-absolute-wrapper',
 	components: [
-		{classes: 'g-layout-absolute-center g-sample-toggle-icon-button-container', components: [
+		{classes: 'g-layout-absolute-center g-sample-toggle-button-container', components: [
 			{kind: ToggleButton, value: true, content: '1', ontap: 'tapButton'},
 			{kind: ToggleButton, content: '2', ontap: 'tapButton'},
 			{kind: ToggleButton, disabled: true, content: 'Disabled', ontap: 'tapButton'},

--- a/garnet/src/ToggleButtonSample.less
+++ b/garnet/src/ToggleButtonSample.less
@@ -26,7 +26,7 @@
 
 // Sample specific classes
 
-.g-sample-toggle-icon-button-container {
+.g-sample-toggle-button-container {
 	width: 280px;
 	height: 230px;
 }

--- a/garnet/src/ToggleButtonSample.less
+++ b/garnet/src/ToggleButtonSample.less
@@ -1,1 +1,25 @@
 /* ToggleButtonSample */
+
+// Common
+.g-sample-circle-panel {
+	background-color: #000000;
+	position: relative;
+	overflow: hidden;
+	border-radius: 50%;
+}
+.g-sample-result {
+	background-color: #EDEDED;
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
+
+.g-sample-toggle-icon-button-container {
+	width: 280px; height: 230px;
+}
+.g-sample-toggle-icon-button-group-text {
+	font-size: 20px; display: inline-block; margin-right: 10px; color: #FFFFFF;
+}

--- a/garnet/src/ToggleButtonSample.less
+++ b/garnet/src/ToggleButtonSample.less
@@ -4,8 +4,8 @@
 .g-sample-circle-panel {
 	background-color: #000000;
 	position: relative;
-	overflow: hidden;
 	border-radius: 50%;
+	overflow: hidden;
 }
 .g-sample-result {
 	background-color: #EDEDED;
@@ -18,10 +18,12 @@
 }
 .g-sample-text {
 	display: inline-block;
+
 	font-size: 20px;
 	color: #FFFFFF;
 }
 
 .g-sample-toggle-icon-button-container {
-	width: 280px; height: 230px;
+	width: 280px;
+	height: 230px;
 }

--- a/garnet/src/ToggleButtonSample.less
+++ b/garnet/src/ToggleButtonSample.less
@@ -1,6 +1,7 @@
 /* ToggleButtonSample */
 
-// Common
+// Common classes
+
 .g-sample-circle-panel {
 	background-color: #000000;
 	position: relative;
@@ -22,6 +23,8 @@
 	font-size: 20px;
 	color: #FFFFFF;
 }
+
+// Sample specific classes
 
 .g-sample-toggle-icon-button-container {
 	width: 280px;

--- a/garnet/src/ToggleButtonSample.less
+++ b/garnet/src/ToggleButtonSample.less
@@ -16,10 +16,12 @@
 	z-index: 9999;
 	opacity: 0.8;
 }
+.g-sample-text {
+	display: inline-block;
+	font-size: 20px;
+	color: #FFFFFF;
+}
 
 .g-sample-toggle-icon-button-container {
 	width: 280px; height: 230px;
-}
-.g-sample-toggle-icon-button-group-text {
-	font-size: 20px; display: inline-block; margin-right: 10px; color: #FFFFFF;
 }

--- a/garnet/src/ToggleIconButtonSample.js
+++ b/garnet/src/ToggleIconButtonSample.js
@@ -17,16 +17,15 @@ var ToggleIconButtonPanel = kind({
 		onResult: ''
 	},
 	classes: 'g-layout-absolute-wrapper',
-	style: 'border-radius: 50%; background-color: #000000;',
 	components: [
-		{classes: 'g-layout-absolute-center', style: 'width: ' + ri.scale(280) + 'px; height: ' + ri.scale(230) + 'px;', components: [
-			{content: 'Toggle Icon Buttons : ', style: 'margin-left: ' + ri.scale(10) + 'px; font-size: ' + ri.scale(20) + 'px; display: inline-block; margin-right: ' + ri.scale(10) + 'px; color: #FFFFFF;'},
+		{classes: 'g-sample-toggle-icon-button-container g-layout-absolute-center', components: [
+			{content: 'Toggle Icon Buttons : ', classes: 'g-sample-toggle-icon-button-text'},
 			{tag: 'br'},
 			{kind: ToggleIconButton, src: '@../assets/switch_default_oi_transparent.svg', classes: 'g-sample-toggle-icon-button-size', active: true},
 			{kind: ToggleIconButton, src: '@../assets/switch_default_transparent.svg', classes: 'g-sample-toggle-icon-button-size'},
 			{kind: ToggleIconButton, src: '@../assets/switch_default_oi_transparent.svg', classes: 'g-sample-toggle-icon-button-size', pending: true, ontap: 'togglePending'},
 			{kind: ToggleIconButton, src: '@../assets/switch_default_transparent.svg', classes: 'g-sample-toggle-icon-button-size', disabled: true},
- 			{content: 'Grouped Icon Buttons : ', style: 'font-size: ' + ri.scale(20) + 'px; display: inline-block; margin-right: ' + ri.scale(10) + 'px; color: #FFFFFF;'},
+ 			{content: 'Grouped Icon Buttons : ', classes: 'g-sample-toggle-icon-button-group-text'},
 			{kind: Group, onActivate:'iconGroupActivated', components: [
 				{kind: ToggleIconButton, src: '@../assets/switch_default_transparent.svg', classes: 'g-common-toggle-icon-button-size-normal', active: true},
 				{kind: ToggleIconButton, src: '@../assets/switch_default_oi_transparent.svg', classes: 'g-common-toggle-icon-button-size-normal'},
@@ -65,7 +64,7 @@ module.exports = kind({
 		{content: '< Toggle Icon Button Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'Toggle Icon Buttons', classes: 'g-sample-subheader'},
-		{kind: ToggleIconButtonPanel, style: 'position: relative;', onResult: 'result'},
+		{kind: ToggleIconButtonPanel, classes: 'g-sample-circle-panel', onResult: 'result'},
 
 		{src: '@../assets/btn_command_next.svg', classes: 'g-sample-result', components: [
 			{content: 'Result', classes: 'g-sample-subheader'},

--- a/garnet/src/ToggleIconButtonSample.js
+++ b/garnet/src/ToggleIconButtonSample.js
@@ -2,7 +2,6 @@ require('garnet');
 
 var
 	kind = require('enyo/kind'),
-	ri = require('enyo/resolution'),
 	Group = require('enyo/Group'),
 	ToggleIconButton = require('garnet/ToggleIconButton'),
 	Panel = require('garnet/Panel');

--- a/garnet/src/ToggleIconButtonSample.less
+++ b/garnet/src/ToggleIconButtonSample.less
@@ -1,6 +1,7 @@
 /* ToggleIconButtonSample */
 
-// Common
+// Common classes
+
 .g-sample-circle-panel {
 	background-color: #000000;
 
@@ -17,6 +18,8 @@
 	z-index: 9999;
 	opacity: 0.8;
 }
+
+// Sample specific classes
 
 .g-sample .g-toggle-icon-button {
 	margin-right: 2px;

--- a/garnet/src/ToggleIconButtonSample.less
+++ b/garnet/src/ToggleIconButtonSample.less
@@ -1,5 +1,22 @@
 /* ToggleIconButtonSample */
 
+// Common
+.g-sample-circle-panel {
+	background-color: #000000;
+	position: relative;
+	overflow: hidden;
+	border-radius: 50%;
+}
+.g-sample-result {
+	background-color: #EDEDED;
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
+
 .g-sample .g-toggle-icon-button {
 	margin-right: 2px;
 }
@@ -7,4 +24,13 @@
 	width: 60px;
 	height: 60px;
 	background-size: 60px 360px, 60px 120px;
+}
+.g-sample-toggle-icon-button-container {
+	width: 280px; height: 230px;
+}
+.g-sample-toggle-icon-button-text {
+	margin-left: 10px; font-size: 20px; display: inline-block; margin-right: 10px; color: #FFFFFF;
+}
+.g-sample-toggle-icon-button-group-text {
+	font-size: 20px; display: inline-block; margin-right: 10px; color: #FFFFFF;
 }

--- a/garnet/src/ToggleIconButtonSample.less
+++ b/garnet/src/ToggleIconButtonSample.less
@@ -3,9 +3,10 @@
 // Common
 .g-sample-circle-panel {
 	background-color: #000000;
+
 	position: relative;
-	overflow: hidden;
 	border-radius: 50%;
+	overflow: hidden;
 }
 .g-sample-result {
 	background-color: #EDEDED;
@@ -21,16 +22,27 @@
 	margin-right: 2px;
 }
 .g-sample-toggle-icon-button-size {
+	background-size: 60px 360px, 60px 120px;
+
 	width: 60px;
 	height: 60px;
-	background-size: 60px 360px, 60px 120px;
 }
 .g-sample-toggle-icon-button-container {
-	width: 280px; height: 230px;
+	width: 280px;
+	height: 230px;
 }
 .g-sample-toggle-icon-button-text {
-	margin-left: 10px; font-size: 20px; display: inline-block; margin-right: 10px; color: #FFFFFF;
+	display: inline-block;
+	margin-left: 10px;
+	margin-right: 10px;
+
+	font-size: 20px;
+	color: #FFFFFF;
 }
 .g-sample-toggle-icon-button-group-text {
-	font-size: 20px; display: inline-block; margin-right: 10px; color: #FFFFFF;
+	display: inline-block;
+	margin-right: 10px;
+
+	font-size: 20px;
+	color: #FFFFFF;
 }

--- a/garnet/src/WheelSliderControllerSample.js
+++ b/garnet/src/WheelSliderControllerSample.js
@@ -8,95 +8,33 @@ var
 	Popup = require('garnet/Popup'),
 	WheelSliderController = require('garnet/WheelSliderController');
 
-var WheelSliderControllerPopup = kind({
-	name: 'g.sample.WheelSliderControllerPopup',
-	kind: Panel,
-	events: {
-		onResult: ''
-	},
-	classes: 'enyo-unselectable garnet',
-	style: 'position: relative;',
-	components: [
-		{style: 'position: relative;', classes: 'g-common-width-height-fit g-layout-absolute-wrapper', components: [
-			{
-				name: 'panel',
-				kind: WheelSliderController,
-				style: 'position: relative; border-radius: 50%; background-color: #000000;',
-				minimumValue: -100,
-				maximumValue: 100,
-				stepValue: 10,
-				value: 50,
-				onChange: 'changeEventHandler',
-				onChanging: 'changingEventHandler'
-			}
-		]}
-	],
-	changingEventHandler: function(inSender, inEvent) {
-		this.doResult({msg: 'changing inEvent.value : ' + inEvent.value});
-	},
-	changeEventHandler: function(inSender, inEvent) {
-		this.doResult({msg: 'change inEvent.value : ' + inEvent.value});
-	}
-});
-
 var WheelSliderControllerPanel = kind({
 	name: 'g.sample.WheelSliderController',
 	kind: Panel,
 	events: {
 		onResult: ''
 	},
-	classes: 'enyo-unselectable garnet',
-	style: 'position: relative;',
+	classes: 'g-common-width-height-fit g-layout-absolute-wrapper',
 	components: [
-		{style: 'position: relative;', classes: 'g-common-width-height-fit g-layout-absolute-wrapper', components: [
-			{
-				name: 'panel',
-				kind: WheelSliderController,
-				style: 'position: relative; border-radius: 50%; background-color: #000000;',
-				minimumValue: -100,
-				maximumValue: 100,
-				stepValue: 10,
-				value: 50,
-				onChange: 'changeEventHandler',
-				onChanging: 'changingEventHandler'
-			},
-			{style: 'width: ' + ri.scale(320) + 'px; height: ' + ri.scale(320) + 'px; pointer-events: none;', components: [
-				{name: 'sampleValue', content: '', style: 'pointer-events: auto; margin-left: 20%; display: block; width: 60%; margin-top: ' + ri.scale(60) + 'px; height: ' + ri.scale(99) + 'px; text-align: center; font-weight: 400; font-size: ' + ri.scale(100) + 'px;'},
-				{content: 'Brightness', style: 'pointer-events: auto; margin-left: 10%; display: block; width: 80%; text-align: center; color: #FFFFFF; font-weight: 800; font-size: ' + ri.scale(22) + 'px;'},
-				{style:'margin-top: ' + ri.scale(15) + 'px;', components: [
-					{name: 'cancel', kind: IconButton, accessibilityLabel: 'cancel', ontap: 'tapCancel', classes: 'g-sample-wheel-slider-cancel-image'},
-					{name: 'ok', kind: IconButton, accessibilityLabel: 'ok', ontap: 'tapOK', classes: 'g-sample-wheel-slider-ok-image'}
-				]}
-			]}
-		]},
 		{
-			name: 'popup',
-			kind: Popup,
-			ignoreWheelControl: false,
-			handlers: {
-				onPopUpAnimationEnd: 'popupAnimationFinished',
-				onChange: 'showPopup',
-				onChanging: 'showPopup'
-			},
-			components: [
-				{kind: WheelSliderControllerPopup}
-			],
-			popupAnimationFinished: function() {
-				if (this.showing) {
-					this.startJob('hidePopup', this.hidePopup, 3000);
-				} else {
-					this.stopJob('hidePopup');
-				}
-			},
-			showPopup: function(inSender, inEvent) {
-				this.stopJob('hidePopup');
-				this.startJob('hidePopup', this.hidePopup, 3000);
-			},
-			hidePopup: function() {
-				this.hide();
-				this.stopJob('hidePopup');
-			}
-		}
+			name: 'panel',
+			kind: WheelSliderController,
+			classes: 'g-sample-circle-panel',
+			minimumValue: -100,
+			maximumValue: 100,
+			stepValue: 10,
+			value: 50,
+			onChange: 'changeEventHandler',
+			onChanging: 'changingEventHandler'
+		},
+		{classes: 'g-common-width-height-fit g-sample-pointer-evetns-none', components: [
+			{name: 'sampleValue', content: '', classes: 'g-sample-wheel-slider-value'},
+			{content: 'Brightness', classes: 'g-sample-wheel-slider-text'},
+			{classes:'g-sample-wheel-slider-container', components: [
+				{name: 'cancel', kind: IconButton, accessibilityLabel: 'cancel', ontap: 'tapCancel', classes: 'g-sample-wheel-slider-cancel-image'},
+				{name: 'ok', kind: IconButton, accessibilityLabel: 'ok', ontap: 'tapOK', classes: 'g-sample-wheel-slider-ok-image'}
+			]}
+		]}
 	],
 	bindings: [
 		{from: '.$.panel.value', to: '.$.sampleValue.content'}
@@ -111,11 +49,9 @@ var WheelSliderControllerPanel = kind({
 	}),
 	tapCancel: function(inSender, inEvent) {
 		this.doResult({msg: 'Cancel button tapped !!'});
-		this.$.popup.show();
 	},
 	tapOK: function(inSender, inEvent) {
 		this.doResult({msg: 'OK button tapped !!'});
-		this.$.popup.show();
 	},
 	changingEventHandler: function(inSender, inEvent) {
 		this.doResult({msg: 'changing inEvent.value : ' + inEvent.value});
@@ -132,7 +68,7 @@ var WheelSliderControllerSample = module.exports = kind({
 		{content: '< Wheel Slider Controller Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'Wheel Slider Panel', classes: 'g-sample-subheader'},
-		{kind: WheelSliderControllerPanel, onResult: 'result'},
+		{kind: WheelSliderControllerPanel, classes: 'g-sample-panel', onResult: 'result'},
 
 		{src: '@../assets/btn_command_next.svg', classes: 'g-sample-result', components: [
 			{content: 'Result', classes: 'g-sample-subheader'},

--- a/garnet/src/WheelSliderControllerSample.js
+++ b/garnet/src/WheelSliderControllerSample.js
@@ -2,10 +2,8 @@ require('garnet');
 
 var
 	kind = require('enyo/kind'),
-	ri = require('enyo/resolution'),
 	IconButton = require('garnet/IconButton'),
 	Panel = require('garnet/Panel'),
-	Popup = require('garnet/Popup'),
 	WheelSliderController = require('garnet/WheelSliderController');
 
 var WheelSliderControllerPanel = kind({

--- a/garnet/src/WheelSliderControllerSample.js
+++ b/garnet/src/WheelSliderControllerSample.js
@@ -28,11 +28,11 @@ var WheelSliderControllerPanel = kind({
 			onChanging: 'changingEventHandler'
 		},
 		{classes: 'g-common-width-height-fit g-sample-pointer-evetns-none', components: [
-			{name: 'sampleValue', content: '', classes: 'g-sample-wheel-slider-value'},
-			{content: 'Brightness', classes: 'g-sample-wheel-slider-text'},
-			{classes:'g-sample-wheel-slider-container', components: [
-				{name: 'cancel', kind: IconButton, accessibilityLabel: 'cancel', ontap: 'tapCancel', classes: 'g-sample-wheel-slider-cancel-image'},
-				{name: 'ok', kind: IconButton, accessibilityLabel: 'ok', ontap: 'tapOK', classes: 'g-sample-wheel-slider-ok-image'}
+			{name: 'sampleValue', content: '', classes: 'g-sample-wheelslider-value'},
+			{content: 'Brightness', classes: 'g-sample-wheelslider-text'},
+			{classes:'g-sample-wheelslider-container', components: [
+				{name: 'cancel', kind: IconButton, accessibilityLabel: 'cancel', ontap: 'tapCancel', classes: 'g-sample-wheelslider-cancel-image'},
+				{name: 'ok', kind: IconButton, accessibilityLabel: 'ok', ontap: 'tapOK', classes: 'g-sample-wheelslider-ok-image'}
 			]}
 		]}
 	],

--- a/garnet/src/WheelSliderControllerSample.less
+++ b/garnet/src/WheelSliderControllerSample.less
@@ -3,17 +3,20 @@
 // Common
 .g-sample-panel {
 	background-color: #000000;
+
 	position: relative;
 	overflow: hidden;
 }
 .g-sample-circle-panel {
 	background-color: #000000;
+
 	position: relative;
-	overflow: hidden;
 	border-radius: 50%;
+	overflow: hidden;
 }
 .g-sample-result {
 	background-color: #EDEDED;
+
 	position: fixed;
 	width: 100%;
 	min-height: 160px;
@@ -21,25 +24,48 @@
 	z-index: 9999;
 	opacity: 0.8;
 }
+.g-sample-pointer-evetns-none {
+	pointer-events: none;
+}
 
 .g-sample .g-sample-wheel-slider-ok-image {
 	.g-common-ok;
-	pointer-events: auto;
+
 	margin: 0 75px 0 17px;
+
+	pointer-events: auto;
 }
 .g-sample .g-sample-wheel-slider-cancel-image {
 	.g-common-cancel;
-	pointer-events: auto;
+
 	margin: 0 17px 0 75px;
-}
-.g-sample-pointer-evetns-none {
-	
+
+	pointer-events: auto;
 }
 .g-sample-wheel-slider-value {
-	pointer-events: auto; margin-left: 20%; display: block; width: 60%; margin-top: 60px; height: 99px; text-align: center; font-weight: 400; font-size: 100px;
+	display: block;
+	width: 60%;
+	height: 99px;
+	margin-top: 60px;
+	margin-left: 20%;
+
+	text-align: center;
+	font-weight: 400;
+	font-size: 100px;
+
+	pointer-events: auto;
 }
 .g-sample-wheel-slider-text {
-	pointer-events: auto; margin-left: 10%; display: block; width: 80%; text-align: center; color: #FFFFFF; font-weight: 800; font-size: 22px;
+	display: block;
+	width: 80%;
+	margin-left: 10%;
+
+	text-align: center;
+	color: #FFFFFF;
+	font-weight: 800;
+	font-size: 22px;
+
+	pointer-events: auto;
 }
 .g-sample-wheel-slider-container {
 	margin-top: 15px;

--- a/garnet/src/WheelSliderControllerSample.less
+++ b/garnet/src/WheelSliderControllerSample.less
@@ -31,21 +31,21 @@
 
 // Sample specific classes
 
-.g-sample .g-sample-wheel-slider-ok-image {
+.g-sample .g-sample-wheelslider-ok-image {
 	.g-common-ok;
 
 	margin: 0 75px 0 17px;
 
 	pointer-events: auto;
 }
-.g-sample .g-sample-wheel-slider-cancel-image {
+.g-sample .g-sample-wheelslider-cancel-image {
 	.g-common-cancel;
 
 	margin: 0 17px 0 75px;
 
 	pointer-events: auto;
 }
-.g-sample-wheel-slider-value {
+.g-sample-wheelslider-value {
 	display: block;
 	width: 60%;
 	height: 99px;
@@ -58,7 +58,7 @@
 
 	pointer-events: auto;
 }
-.g-sample-wheel-slider-text {
+.g-sample-wheelslider-text {
 	display: block;
 	width: 80%;
 	margin-left: 10%;
@@ -70,6 +70,6 @@
 
 	pointer-events: auto;
 }
-.g-sample-wheel-slider-container {
+.g-sample-wheelslider-container {
 	margin-top: 15px;
 }

--- a/garnet/src/WheelSliderControllerSample.less
+++ b/garnet/src/WheelSliderControllerSample.less
@@ -1,5 +1,27 @@
 /* WheelSliderControllerSample */
 
+// Common
+.g-sample-panel {
+	background-color: #000000;
+	position: relative;
+	overflow: hidden;
+}
+.g-sample-circle-panel {
+	background-color: #000000;
+	position: relative;
+	overflow: hidden;
+	border-radius: 50%;
+}
+.g-sample-result {
+	background-color: #EDEDED;
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
+
 .g-sample .g-sample-wheel-slider-ok-image {
 	.g-common-ok;
 	pointer-events: auto;
@@ -9,4 +31,16 @@
 	.g-common-cancel;
 	pointer-events: auto;
 	margin: 0 17px 0 75px;
+}
+.g-sample-pointer-evetns-none {
+	
+}
+.g-sample-wheel-slider-value {
+	pointer-events: auto; margin-left: 20%; display: block; width: 60%; margin-top: 60px; height: 99px; text-align: center; font-weight: 400; font-size: 100px;
+}
+.g-sample-wheel-slider-text {
+	pointer-events: auto; margin-left: 10%; display: block; width: 80%; text-align: center; color: #FFFFFF; font-weight: 800; font-size: 22px;
+}
+.g-sample-wheel-slider-container {
+	margin-top: 15px;
 }

--- a/garnet/src/WheelSliderControllerSample.less
+++ b/garnet/src/WheelSliderControllerSample.less
@@ -1,6 +1,7 @@
 /* WheelSliderControllerSample */
 
-// Common
+// Common classes
+
 .g-sample-panel {
 	background-color: #000000;
 
@@ -27,6 +28,8 @@
 .g-sample-pointer-evetns-none {
 	pointer-events: none;
 }
+
+// Sample specific classes
 
 .g-sample .g-sample-wheel-slider-ok-image {
 	.g-common-ok;


### PR DESCRIPTION
## Issue

: Need to clean up style and classes properties in JavaScript files and definitions in CSS files
## Fix
- Used class properties instead of using style properties
- Added some comments
- Renamed css classes
- Converted 0px to 0
- Refactor css

Checklist :

JSHint : No error ( Using gulp )
Sample : No error
Doc : No error ( Done, without errors. )

Enyo-DCO-1.1-Signed-off-by: YB Sung yb.sung@lge.com
