### PR TITLE
Garnet: Handle the events in Pickers, PopupPanels to bubble normally

### DIFF
--- a/garnet/src/ConfirmPanelSample.js
+++ b/garnet/src/ConfirmPanelSample.js
@@ -3,145 +3,23 @@ require('garnet');
 var
 	kind = require('enyo/kind'),
 	Control = require('enyo/Control'),
-	utils = require('enyo/utils');
 
-var
 	Button = require('garnet/Button'),
+	IconButton = require('garnet/IconButton'),
+	PopupPanelScroller = require('garnet/PopupPanelScroller'),
 	Panel = require('garnet/Panel'),
 	ConfirmPanel = require('garnet/ConfirmPanel'),
-	PopupPanelScroller = require('garnet/PopupPanelScroller'),
-	IconButton = require('garnet/IconButton'),
 	PanelManager = require('garnet/PanelManager');
-
-var OneTextPanel = kind({
-	name: 'confirmPanelNoScrollNoIcon',
-	kind: ConfirmPanel,
-	handlers: {
-		onHide: 'hidePanel',
-		onOK: 'tapOK',
-		onCancel: 'tapCancel'
-	},
-	components: [
-		{
-			kind: PopupPanelScroller,
-			components: [
-				{content: 'All the labels follow guideline.'}
-			]
-		}
-	],
-	hidePanel: function(inSender, inEvent) {
-		this.fromPanel.triggerHandler('onHide2', {originalEvent: utils.clone(inEvent, true)});
-		return true;
-	},
-	tapOK: function(inSender, inEvent) {
-		this.fromPanel.triggerHandler('onOK', {originalEvent: utils.clone(inEvent, true)});
-		return true;
-	},
-	tapCancel: function(inSender, inEvent) {
-		this.fromPanel.triggerHandler('onCancel', {originalEvent: utils.clone(inEvent, true)});
-		return true;
-	}
-});
-
-var ScrollTextPanel = kind({
-	name: 'confirmPanelWithScrollNoIcon',
-	kind: ConfirmPanel,
-	handlers: {
-		onHide: 'hidePanel'
-	},
-	buttonComponents: [
-		{name: 'ok', kind: IconButton, ontap: 'tapOK', classes: 'g-ok-image'}
-	],
-	components: [
-		{
-			kind: PopupPanelScroller,
-			components: [
-				{content: 'Garnet is a UI library built for wearable devices and is based on Enyo. Garnet supports LG smart watch'}
-			]
-		}
-	],
-	hidePanel: function(inSender, inEvent) {
-		this.fromPanel.triggerHandler('onHide2', {originalEvent: utils.clone(inEvent, true)});
-		return true;
-	},
-	tapOK: function(inSender, inEvent) {
-		this.fromPanel.triggerHandler('onOK', {originalEvent: {originator: this, type: 'onOK'}});
-		return true;
-	}
-});
-
-var IconTitleTextPanel = kind({
-	name: 'confirmPanelWithIconNoScroll',
-	kind: ConfirmPanel,
-	handlers: {
-		onHide: 'hidePanel'
-	},
-	buttonComponents: [
-		{name: 'ok2', kind: IconButton, ontap: 'tapOK', classes: 'g-ok-image'}
-	],
-	components: [
-		{
-			kind: PopupPanelScroller,
-			icon: true,
-			iconSrc: '@../assets/ic_warning.svg',
-			title: true,
-			titleContent: 'test',
-			components: [
-				{content: 'All the labels follow guideline.'}
-			]
-		}
-	],
-	hidePanel: function(inSender, inEvent) {
-		this.fromPanel.triggerHandler('onHide2', {originalEvent: utils.clone(inEvent, true)});
-		return true;
-	},
-	tapOK: function(inSender, inEvent) {
-		this.fromPanel.triggerHandler('onOK', {originalEvent: {originator: this, type: 'onOK'}});
-		return true;
-	}
-});
-
-var ScrollIconTitleTextPanel = kind({
-	name: 'confirmPanelWithIconAndScroll',
-	kind: ConfirmPanel,
-	handlers: {
-		onHide: 'hidePanel',
-		onOK: 'tapOK',
-		onCancel: 'tapCancel'
-	},
-	components: [
-		{
-			kind: PopupPanelScroller,
-			icon: true,
-			iconSrc: '@../assets/ic_warning.svg',
-			title: true,
-			titleContent: 'ScrollIconTitleTextPanelTitle',
-			components: [
-				{content: 'Garnet is a UI library built for wearable devices and is based on Enyo. Garnet supports LG smart watch as well as the emulator provided. Browser-wise, Garnet supports the browser on LG smart watch, Firefox 16, Opera 15, Safari 3.1, Chrome 27 and their higher versions.et Quad-Core Processor, 1080p resolution screen, 13-megapixel rear'}
-			]
-		}
-	],
-	hidePanel: function(inSender, inEvent) {
-		this.fromPanel.triggerHandler('onHide2', {originalEvent: utils.clone(inEvent, true)});
-		return true;
-	},
-	tapOK: function(inSender, inEvent) {
-		this.fromPanel.triggerHandler('onOK', {originalEvent: utils.clone(inEvent, true)});
-		return true;
-	},
-	tapCancel: function(inSender, inEvent) {
-		this.fromPanel.triggerHandler('onCancel', {originalEvent: utils.clone(inEvent, true)});
-		return true;
-	}
-});
 
 var ConfirmBasePanel = kind({
 	name: 'g.sample.ConfirmBasePanel',
 	kind: Panel,
+	events: {
+		onResult: ''
+	},
 	handlers: {
-		onHide2: 'result',
-		onOK: 'result',
-		onCancel: 'result'
+		onOK: 'okHandler',
+		onCancel: 'cancelHandler'
 	},
 	components: [
 		{name: 'button1', kind: Button, classes: 'g-sample-confirm-panel-button', ontap: 'showPanel', content: 'Only text'},
@@ -149,26 +27,104 @@ var ConfirmBasePanel = kind({
 		{name: 'button3', kind: Button, classes: 'g-sample-confirm-panel-button', ontap: 'showPanel', content: 'Icon + Title + Text'},
 		{name: 'button4', kind: Button, classes: 'g-sample-confirm-panel-button', ontap: 'showPanel', content: 'Scroll+Icon+Title+Text'}
 	],
-	showPanel: function(inSender, inEvent) {
-		var name = inSender.name;
-
-		if (name == 'button1' || name == 'button2' || name == 'button3' || name == 'button4') {
-			this.bubbleUp('onPushPanel', {panelName: name, owner: this});
+	popPanels: {
+		button1: {
+			name: 'confirmPanelNoScrollNoIcon',
+			kind: ConfirmPanel,
+			onCancel: 'cancelHandler',
+			onOK: 'okHandler',
+			components: [
+				{
+					kind: PopupPanelScroller,
+					components: [
+						{content: 'All the labels follow guideline.'}
+					]
+				}
+			]
+		},
+		button2: {
+			name: 'confirmPanelWithScrollNoIcon',
+			kind: ConfirmPanel,
+			events: {
+				onOK: ''
+			},
+			buttonComponents: [
+				{name: 'ok', kind: IconButton, ontap: 'okHandler', classes: 'g-ok-image'}
+			],
+			components: [
+				{
+					kind: PopupPanelScroller,
+					components: [
+						{content: 'Garnet is a UI library built for wearable devices and is based on Enyo. Garnet supports LG smart watch'}
+					]
+				}
+			],
+			okHandler: function(inSender, inEvent) {
+				this.doOK();
+			}
+		},
+		button3: {
+			name: 'confirmPanelWithIconNoScroll',
+			kind: ConfirmPanel,
+			events: {
+				onOK: ''
+			},
+			buttonComponents: [
+				{name: 'ok2', kind: IconButton, ontap: 'okHandler', classes: 'g-ok-image'}
+			],
+			components: [
+				{
+					kind: PopupPanelScroller,
+					icon: true,
+					iconSrc: '@../assets/ic_warning.svg',
+					title: true,
+					titleContent: 'test',
+					components: [
+						{content: 'All the labels follow guideline.'}
+					]
+				}
+			],
+			okHandler: function(inSender, inEvent) {
+				this.doOK();
+			}
+		},
+		button4: {
+			name: 'confirmPanelWithIconAndScroll',
+			kind: ConfirmPanel,
+			onCancel: 'cancelHandler',
+			onOK: 'okHandler',
+			components: [
+				{
+					kind: PopupPanelScroller,
+					icon: true,
+					iconSrc: '@../assets/ic_warning.svg',
+					title: true,
+					titleContent: 'ScrollIconTitleTextPanelTitle',
+					components: [
+						{content: 'Garnet is a UI library built for wearable devices and is based on Enyo. Garnet supports LG smart watch as well as the emulator provided. Browser-wise, Garnet supports the browser on LG smart watch, Firefox 16, Opera 15, Safari 3.1, Chrome 27 and their higher versions.et Quad-Core Processor, 1080p resolution screen, 13-megapixel rear'}
+					]
+				}
+			]
 		}
 	},
-	result: function(inSender, inEvent) {
+	showPanel: function(inSender, inEvent) {
 		var
-			name = inEvent.originalEvent.originator.name,
-			msg = '"' + name + '" PopupPanel closed ',
-			type = inEvent.originalEvent.type;
+			name = inSender.name,
+			panel = this.popPanels[name];
 
-		if (type == 'onOK') {
-			msg += 'by OK button';
-		} else if (type == 'onCancel') {
-			msg += 'by Cancel button';
+		if (panel) {
+			this.bubbleUp('onPushPanel', {panel: panel, owner: this});
 		}
-
-		this.bubbleUp((type == 'onOK' || type == 'onCancel') ? 'onPopPanel' : 'onResult', {msg: msg});
+	},
+	cancelHandler: function(inSender, inEvent) {
+		var name = inSender.name;
+		this.bubbleUp('onPopPanel');
+		this.doResult({msg: name + ' is hidden by Cancel button'});
+	},
+	okHandler: function(inSender, inEvent) {
+		var name = inSender.name;
+		this.bubbleUp('onPopPanel');
+		this.doResult({msg: name + ' is hidden by OK button'});
 	}
 });
 
@@ -183,18 +139,7 @@ var PanelManager = kind({
 		{kind: ConfirmBasePanel, classes: 'g-sample-panel'}
 	],
 	pushPanel: function (inSender, inEvent) {
-		var type = {
-			button1: {name: 'confirmPanelNoScrollNoIcon', kind: OneTextPanel},
-			button2: {name: 'confirmPanelWithScrollNoIcon', kind: ScrollTextPanel},
-			button3: {name: 'confirmPanelWithIconNoScroll', kind: IconTitleTextPanel},
-			button4: {name: 'confirmPanelWithIconAndScroll', kind: ScrollIconTitleTextPanel}
-		};
-
-		this.pushFloatingPanel({
-			name: type[inEvent.panelName].name,
-			kind: type[inEvent.panelName].kind,
-			fromPanel: inEvent.owner ? inEvent.owner : this
-		});
+		this.pushFloatingPanel(inEvent.panel, {owner: inEvent.owner});
 	},
 	popPanel: function (inSender, inEvent) {
 		this.popFloatingPanel();

--- a/garnet/src/ContextualPanelSample.js
+++ b/garnet/src/ContextualPanelSample.js
@@ -3,130 +3,94 @@ require('garnet');
 var
 	kind = require('enyo/kind'),
 	Control = require('enyo/Control'),
-	utils = require('enyo/utils');
 
-var
 	Button = require('garnet/Button'),
 	Panel = require('garnet/Panel'),
 	ContextualPanel = require('garnet/ContextualPanel'),
 	PanelManager = require('garnet/PanelManager');
 
-var OneButtonPanel = kind({
-	name: 'g.sample.OneButtonPanel',
-	kind: ContextualPanel,
-	handlers: {
-		onHide: 'hidePanel'
-	},
-	buttonComponents: [
-		{
-			name: 'button1',
-			ontap: 'buttonTap',
-			src: '@../assets/btn_context_delete.svg',
-			title: 'Delete'
-		}
-	],
-	hidePanel: function(inSender, inEvent) {
-		this.fromPanel.triggerHandler('onHide2', {originalEvent: utils.clone(inEvent, true)});
-	},
-	buttonTap: function(inSender, inEvent) {
-		this.fromPanel.triggerHandler('onButtonTap', {originalEvent: {originator: this, title: inEvent.originator.title}});
-	}
-});
-
-var TwoButtonPanel = kind({
-	name: 'g.sample.TwoButtonPanel',
-	kind: ContextualPanel,
-	handlers: {
-		onHide: 'hidePanel'
-	},
-	buttonComponents: [
-		{
-			name: '1st 2 buttons',
-			ontap: 'buttonTap',
-			src: '@../assets/btn_context_edit.svg',
-			title: 'Edit'
-		},
-		{
-			name: '2nd 2 buttons',
-			ontap: 'buttonTap',
-			src: '@../assets/btn_context_delete.svg',
-			disabled: true,
-			title: 'Delete'
-		}
-	],
-	hidePanel: function(inSender, inEvent) {
-		this.fromPanel.triggerHandler('onHide2', {originalEvent: utils.clone(inEvent, true)});
-	},
-	buttonTap: function(inSender, inEvent) {
-		this.fromPanel.triggerHandler('onButtonTap', {originalEvent: {originator: this, title: inEvent.originator.title}});
-	}
-});
-
-var ThreeButtonPanel = kind({
-	name: 'g.sample.ThreeButtonPanel',
-	kind: ContextualPanel,
-	handlers: {
-		onHide: 'hidePanel'
-	},
-	buttonComponents: [
-		{
-			name: '1st 3 buttons',
-			ontap: 'buttonTap',
-			src: '@../assets/btn_context_favorite.svg',
-			title: 'Favorite'
-		},
-		{
-			name: '2nd 3 buttons',
-			ontap: 'buttonTap',
-			src: '@../assets/btn_context_edit.svg',
-			title: 'Edit',
-			disabled: true
-		},
-		{
-			name: '3rd 3 buttons',
-			ontap: 'buttonTap',
-			src: '@../assets/btn_context_delete.svg',
-			title: 'Delete'
-		}
-	],
-	hidePanel: function(inSender, inEvent) {
-		this.fromPanel.triggerHandler('onHide2', {originalEvent: utils.clone(inEvent, true)});
-	},
-	buttonTap: function(inSender, inEvent) {
-		this.fromPanel.triggerHandler('onButtonTap', {originalEvent: {originator: this, title: inEvent.originator.title}});
-	}
-});
-
 var ContextualBasePanel = kind({
 	name: 'g.sample.ContextualBasePanel',
 	kind: Panel,
-	handlers: {
-		onHide2: 'result',
-		onButtonTap: 'result'
+	events: {
+		onResult: ''
 	},
 	components: [
 		{name: 'oneButton', kind: Button, classes: 'g-sample-contextual-panel-button', ontap: 'showPanel', content: 'Click here to show panel!'},
 		{name: 'twoButton', kind: Button, classes: 'g-sample-contextual-panel-button', ontap: 'showPanel', content: 'Click here to show panel!'},
 		{name: 'threeButton', kind: Button, classes: 'g-sample-contextual-panel-button', ontap: 'showPanel', content: 'Click here to show panel!'}
 	],
-	showPanel: function(inSender, inEvent) {
-		var name = inSender.name;
-
-		if (name == 'oneButton' || name == 'twoButton' || name == 'threeButton' ) {
-			this.bubbleUp('onPushPanel', {panelName: name, owner: this});
+	popPanels: {
+		oneButton: {
+			name: 'g.sample.OneButtonPanel',
+			kind: ContextualPanel,
+			buttonComponents: [
+				{
+					name: '1rd Contextual 1st button',
+					ontap: 'tapHandler',
+					src: '@../assets/btn_context_delete.svg',
+					title: 'Delete'
+				}
+			]
+		},
+		twoButton: {
+			name: 'g.sample.TwoButtonPanel',
+			kind: ContextualPanel,
+			buttonComponents: [
+				{
+					name: '2rd Contextual 1st button',
+					ontap: 'tapHandler',
+					src: '@../assets/btn_context_edit.svg',
+					title: 'Edit'
+				},
+				{
+					name: '2nd Contextual 2nd button',
+					ontap: 'tapHandler',
+					src: '@../assets/btn_context_delete.svg',
+					disabled: true,
+					title: 'Delete'
+				}
+			]
+		},
+		threeButton: {
+			name: 'g.sample.ThreeButtonPanel',
+			kind: ContextualPanel,
+			buttonComponents: [
+				{
+					name: '3rd Contextual 1st button',
+					ontap: 'tapHandler',
+					src: '@../assets/btn_context_favorite.svg',
+					title: 'Favorite'
+				},
+				{
+					name: '3nd Contextual 2nd button',
+					ontap: 'tapHandler',
+					src: '@../assets/btn_context_edit.svg',
+					title: 'Edit',
+					disabled: true
+				},
+				{
+					name: '3rd Contextual 3rd button',
+					ontap: 'tapHandler',
+					src: '@../assets/btn_context_delete.svg',
+					title: 'Delete'
+				}
+			]
 		}
 	},
-	result: function(inSender, inEvent) {
+	showPanel: function(inSender, inEvent) {
 		var
-			name = inEvent.originalEvent.originator.name,
-			msg = '"' + name + '" PopupPanel closed ',
-			title = inEvent.originalEvent.title;
+			name = inSender.name,
+			panel = this.popPanels[name];
 
-		if (title) {
-			msg += ('by ' + title + ' button');
+		if (panel) {
+			this.bubbleUp('onPushPanel', {panel: panel, owner: this});
 		}
-
-		this.bubbleUp(title ? 'onPopPanel' : 'onResult', {msg: msg});
+	},
+	tapHandler: function(inSender, inEvent) {
+		var name = inSender.name;
+		this.bubbleUp('onPopPanel');
+		this.doResult({msg: name + ' tapped'});
 	}
 });
 
@@ -138,20 +102,10 @@ var PanelManager = kind({
 		onPopPanel: 'popPanel'
 	},
 	components: [
-		{kind: ContextualBasePanel}
+		{kind: ContextualBasePanel, classes: 'g-sample-panel'}
 	],
 	pushPanel: function (inSender, inEvent) {
-		var type = {
-			oneButton: {name: 'OneButtonPanel', kind: OneButtonPanel},
-			twoButton: {name: 'TwoButtonPanel', kind: TwoButtonPanel},
-			threeButton: {name: 'ThreeButtonPanel', kind: ThreeButtonPanel}
-		};
-
-		this.pushFloatingPanel({
-			name: type[inEvent.panelName].name,
-			kind: type[inEvent.panelName].kind,
-			fromPanel: inEvent.owner ? inEvent.owner : this
-		});
+		this.pushFloatingPanel(inEvent.panel, {owner: inEvent.owner});
 	},
 	popPanel: function (inSender, inEvent) {
 		this.popFloatingPanel();

--- a/garnet/src/FormSample.js
+++ b/garnet/src/FormSample.js
@@ -125,40 +125,6 @@ var Formatter = kind.singleton({
 	}
 });
 
-var SampleTimePickerPanel = kind({
-	name: 'g.sample.TimePickerPanel',
-	kind: TimePickerPanel,
-	valueChanged: kind.inherit(function(sup) {
-		return function() {
-			sup.apply(this, arguments);
-			if (this.fromPanel) {
-				this.fromPanel.triggerHandler('onUpdate', {
-					name: this.name,
-					hour: this.getHourValue(),
-					minute: this.getMinuteValue(),
-					meridiem: this.getMeridiemValue()
-				});
-			}
-		};
-	})
-});
-
-var SampleDatePickerPanel = kind({
-	name: 'g.sample.DatePickerPanel',
-	kind: DatePickerPanel,
-	valueChanged: kind.inherit(function(sup) {
-		return function() {
-			sup.apply(this, arguments);
-			if (this.fromPanel) {
-				this.fromPanel.triggerHandler('onUpdate', {
-					name: this.name,
-					value: this.value
-				});
-			}
-		};
-	})
-});
-
 var CollectionPickerPanel = kind({
 	name: 'g.sample.CollectionPickerPanel',
 	kind: PickerPanel,
@@ -168,17 +134,6 @@ var CollectionPickerPanel = kind({
 		return function() {
 			sup.apply(this, arguments);
 			this.collection = new Collection(data);
-		};
-	}),
-	valueChanged: kind.inherit(function(sup) {
-		return function() {
-			sup.apply(this, arguments);
-			if (this.fromPanel) {
-				this.fromPanel.triggerHandler('onUpdate', {
-					name: this.name,
-					value: this.value
-				});
-			}
 		};
 	})
 });
@@ -198,49 +153,22 @@ var CollectionMultiPickerPanel = kind({
 			this.collection = new Collection(data);
 		};
 	}),
-	valueChanged: kind.inherit(function(sup) {
-		return function() {
-			sup.apply(this, arguments);
-			if (this.fromPanel) {
-				this.fromPanel.triggerHandler('onUpdate', {
-					name: this.name,
-					value: this.value
-				});
-			}
-		};
-	}),
 	popPanel: function() {
-		this.bubbleUp('onPopPanel');
+		this.container.popFloatingPanel();
 	}
-});
-
-var SampleWheelSliderPanel = kind({
-	name: 'g.sample.WheelSliderPanel',
-	kind: WheelSliderPanel,
-	valueChanged: kind.inherit(function(sup) {
-		return function() {
-			sup.apply(this, arguments);
-			if (this.fromPanel) {
-				this.fromPanel.triggerHandler('onUpdate', {
-					name: this.name,
-					value: this.value
-				});
-			}
-		};
-	})
 });
 
 var
 	panels = {
-		timePickerButton:                {name: 'timePicker', kind: SampleTimePickerPanel, meridiemValue: '24'},
-		timePickerButtonWithValue:       {name: 'timePickerWithValue', kind: SampleTimePickerPanel},
-		datePickerButton:                {name: 'datePicker', kind: SampleDatePickerPanel},
-		datePickerButtonWithValue:       {name: 'datePickerWithValue', kind: SampleDatePickerPanel},
+		timePickerButton:                {name: 'timePicker', kind: TimePickerPanel, meridiemValue: '24'},
+		timePickerButtonWithValue:       {name: 'timePickerWithValue', kind: TimePickerPanel},
+		datePickerButton:                {name: 'datePicker', kind: DatePickerPanel},
+		datePickerButtonWithValue:       {name: 'datePickerWithValue', kind: DatePickerPanel},
 		pickerPanelButton:               {name: 'pickerPanel', kind: CollectionPickerPanel, title:true, titleContent: 'PickerTitle', ontap: 'hidePickerPanelPopup'},
 		pickerPanelButtonWithValue:      {name: 'pickerPanelWithValue', kind: CollectionPickerPanel, title:true, titleContent: 'PickerTitle', selectedIndex: 0, ontap: 'hidePickerPanelPopupWithValue'},
 		multiPickerPanelButton:          {name: 'multiPickerPanel', kind: CollectionMultiPickerPanel, title:true, titleContent: 'MultiPickerTitle'},
 		multiPickerPanelButtonWithValue: {name: 'multiPickerPanelWithValue', kind: CollectionMultiPickerPanel, title:true, titleContent: 'MultiPickerTitle', selectedIndex: [0, 1]},
-		wheelSliderPanelButtonWithValue: {name: 'wheelSliderPanelWithValue', kind: SampleWheelSliderPanel, title:true, titleContent: 'WheelSliderTitle'}
+		wheelSliderPanelButtonWithValue: {name: 'wheelSliderPanelWithValue', kind: WheelSliderPanel, title:true, titleContent: 'WheelSliderTitle'}
 	},
 
 	today = new Date(),
@@ -260,9 +188,6 @@ var FormPanel = kind({
 	kind: Panel,
 	events: {
 		onResult: ''
-	},
-	handlers: {
-		onUpdate: 'updateContent'
 	},
 	classes: 'g-sample-panel g-common-width-height-fit g-layout-absolute-wrapper',
 	components: [
@@ -335,7 +260,7 @@ var FormPanel = kind({
 	showPanel: function(inSender, inEvent) {
 		var
 			name = inSender.name,
-			options = {owner: this, fromPanel: this};
+			options = {owner: this, onUpdate: 'updateContent'};
 
 		// initialize default values
 		if (name === 'timePickerButtonWithValue' && !this.$.timePickerWithValue) {
@@ -344,24 +269,24 @@ var FormPanel = kind({
 				minuteValue: defaults.timePickerButtonWithValue.minute,
 				meridiemValue: defaults.timePickerButtonWithValue.meridiem,
 				owner: this,
-				fromPanel: this
+				onUpdate: 'updateContent'
 			};
 		} else if (name === 'datePickerButtonWithValue' && !this.$.datePickerWithValue) {
 			options = {
 				value: defaults.datePickerButtonWithValue,
 				owner: this,
-				fromPanel: this
+				onUpdate: 'updateContent'
 			};
 		} else if (name === 'wheelSliderPanelButtonWithValue' && !this.$.wheelSliderPanelWithValue) {
 			options = {
 				value: defaults.wheelSliderPanelWithValue,
 				owner: this,
-				fromPanel: this
+				onUpdate: 'updateContent'
 			};
 		}
 
 		// push a panel
-		this.bubbleUp('onPushPanel', {panel: panels[name], options: options});
+		this.container.pushFloatingPanel(panels[name], options);
 	},
 	updateContent: function(inSender, inEvent) {
 		var
@@ -411,23 +336,6 @@ var FormPanel = kind({
 	}
 });
 
-var PanelManager = kind({
-	kind: PanelManager,
-	handlers: {
-		onPushPanel: 'pushPanel',
-		onPopPanel: 'popPanel'
-	},
-	components: [
-		{name: 'formPanel', kind: FormPanel}
-	],
-	pushPanel: function (inSender, inEvent) {
-		this.pushFloatingPanel(inEvent.panel, inEvent.options);
-	},
-	popPanel: function (inSender, inEvent) {
-		this.popFloatingPanel();
-	}
-});
-
 module.exports = kind({
 	name: 'g.sample.FormSample',
 	handlers: {
@@ -438,7 +346,9 @@ module.exports = kind({
 		{content: '< Form Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'Form Picker Buttons / Form Buttons / Form Inputs', classes: 'g-sample-subheader'},
-		{kind: PanelManager, classes: 'g-sample-panel-manager'},
+		{kind: PanelManager, classes: 'g-sample-panel-manager', components: [
+			{name: 'formPanel', kind: FormPanel}
+		]},
 
 		{src: '@../assets/btn_command_next.svg', classes: 'g-sample-result', components: [
 			{content: 'Result', classes: 'g-sample-subheader'},

--- a/garnet/src/FormSample.js
+++ b/garnet/src/FormSample.js
@@ -3,6 +3,7 @@ require('garnet');
 var
 	kind               = require('enyo/kind'),
 	Collection         = require('enyo/Collection.js'),
+
 	Title              = require('garnet/Title'),
 	IconButton         = require('garnet/IconButton'),
 	FormButton         = require('garnet/FormButton'),
@@ -11,8 +12,8 @@ var
 	FormLabel          = require('garnet/FormLabel'),
 	FormPickerButton   = require('garnet/FormPickerButton'),
 	FormToolDecorator  = require('garnet/FormToolDecorator'),
-	Panel              = require('garnet/Panel'),
 	Scroller           = require('garnet/Scroller'),
+	Panel              = require('garnet/Panel'),
 	TimePickerPanel    = require('garnet/TimePickerPanel'),
 	DatePickerPanel    = require('garnet/DatePickerPanel'),
 	PickerPanel        = require('garnet/PickerPanel'),

--- a/garnet/src/FormSample.js
+++ b/garnet/src/FormSample.js
@@ -154,7 +154,7 @@ var CollectionMultiPickerPanel = kind({
 		};
 	}),
 	popPanel: function() {
-		this.container.popFloatingPanel();
+		this.bubbleUp('onPopPanel');
 	}
 });
 
@@ -336,6 +336,23 @@ var FormPanel = kind({
 	}
 });
 
+var PanelManager = kind({
+	kind: PanelManager,
+	handlers: {
+		onPushPanel: 'pushPanel',
+		onPopPanel: 'popPanel'
+	},
+	components: [
+		{name: 'formPanel', kind: FormPanel}
+	],
+	pushPanel: function (inSender, inEvent) {
+		this.pushFloatingPanel(inEvent.panel, inEvent.options);
+	},
+	popPanel: function (inSender, inEvent) {
+		this.popFloatingPanel();
+	}
+});
+
 module.exports = kind({
 	name: 'g.sample.FormSample',
 	handlers: {
@@ -346,10 +363,7 @@ module.exports = kind({
 		{content: '< Form Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'Form Picker Buttons / Form Buttons / Form Inputs', classes: 'g-sample-subheader'},
-		{kind: PanelManager, classes: 'g-sample-panel-manager', components: [
-			{name: 'formPanel', kind: FormPanel}
-		]},
-
+		{kind: PanelManager, classes: 'g-sample-panel-manager'},
 		{src: '@../assets/btn_command_next.svg', classes: 'g-sample-result', components: [
 			{content: 'Result', classes: 'g-sample-subheader'},
 			{name: 'result', allowHtml: true, content: 'No button pressed yet.', classes: 'g-sample-description'}

--- a/garnet/src/MultiPickerPanelSample.js
+++ b/garnet/src/MultiPickerPanelSample.js
@@ -8,11 +8,50 @@ var
 	MultiPickerPanel = require('garnet/MultiPickerPanel'),
 	PanelManager = require('garnet/PanelManager');
 
-var Formatter = kind.singleton({
-	/*
-	* From multiPickerPanel.value to FormPickerButton.content
-	*/
-	MultiPickerPanel: function(val, data) {
+var SampleMultiPickerPanel = kind({
+	name: 'g.sample.MultiPickerPanel',
+	kind: MultiPickerPanel,
+	handlers: {
+		onCancel: 'popPanel',
+		onOK: 'popPanel'
+	},
+	title: true,
+	titleContent: 'MultiPickerPanel',
+	create: kind.inherit(function(sup) {
+		return function() {
+			sup.apply(this, arguments);
+			this.collection = new Collection(data);
+		};
+	}),
+	popPanel: function() {
+		this.container.popFloatingPanel();
+	}
+});
+
+var FormPanel = kind({
+	name: 'g.sample.FormPanel',
+	kind: Panel,
+	events: {
+		onResult: ''
+	},
+	components: [
+		{name: 'multiPickerButton', kind: FormPickerButton, classes: 'g-sample-multipicker-panel-button', ontap: 'showPanel', content: 'Click here!'}
+	],
+	initComponents: kind.inherit(function(sup) {
+		return function() {
+			sup.apply(this, arguments);
+			this.$.multiPickerButton.setContent(data[1].item + ', ' + data[2].item);
+		};
+	}),
+	showPanel: function(inSender, inEvent) {
+		this.container.pushFloatingPanel({name: 'multiPickerPanel', kind: SampleMultiPickerPanel, owner: this, selectedIndex: [1, 2], onUpdate: 'updateContent'});
+	},
+	updateContent: function(inSender, inEvent) {
+		var content = this.formattingContent(inEvent.value);
+		this.$.multiPickerButton.setContent(content);
+		this.doResult({msg: content});
+	},
+	formattingContent: function(val, data) {
 		var
 			items = val,
 			names = '',
@@ -39,82 +78,6 @@ var Formatter = kind.singleton({
 	}
 });
 
-var SampleMultiPickerPanel = kind({
-	name: 'g.sample.MultiPickerPanel',
-	kind: MultiPickerPanel,
-	handlers: {
-		onCancel: 'popPanel',
-		onOK: 'popPanel'
-	},
-	title: true,
-	titleContent: 'MultiPickerPanel',
-	create: kind.inherit(function(sup) {
-		return function() {
-			sup.apply(this, arguments);
-			this.collection = new Collection(data);
-		};
-	}),
-	valueChanged: kind.inherit(function(sup) {
-		return function() {
-			sup.apply(this, arguments);
-			if (this.fromPanel) {
-				this.fromPanel.triggerHandler('onUpdate', {
-					name: this.name,
-					value: this.value
-				});
-			}
-		};
-	}),
-	popPanel: function() {
-		this.bubbleUp('onPopPanel');
-	}
-});
-
-var FormPanel = kind({
-	name: 'g.sample.FormPanel',
-	kind: Panel,
-	events: {
-		onResult: ''
-	},
-	handlers: {
-		onUpdate: 'updateContent'
-	},
-	components: [
-		{name: 'multiPickerButton', kind: FormPickerButton, classes: 'g-sample-multipicker-panel-button', ontap: 'showPanel', content: 'Click here!'}
-	],
-	initComponents: kind.inherit(function(sup) {
-		return function() {
-			sup.apply(this, arguments);
-			this.$.multiPickerButton.setContent(data[1].item + ', ' + data[2].item);
-		};
-	}),
-	showPanel: function(inSender, inEvent) {
-		this.bubbleUp('onPushPanel', {panel: {name: 'multiPickerPanel', kind: SampleMultiPickerPanel, owner: this, fromPanel: this, selectedIndex: [1, 2]}});
-	},
-	updateContent: function(inSender, inEvent) {
-		var content = Formatter.MultiPickerPanel(inEvent.value);
-		this.$.multiPickerButton.setContent(content);
-		this.doResult({msg: content});
-	}
-});
-
-var PanelManager = kind({
-	kind: PanelManager,
-	handlers: {
-		onPushPanel: 'pushPanel',
-		onPopPanel: 'popPanel'
-	},
-	components: [
-		{kind: FormPanel, classes: 'g-sample-panel;', onResult: 'result'}
-	],
-	pushPanel: function (inSender, inEvent) {
-		this.pushFloatingPanel(inEvent.panel, inEvent.options);
-	},
-	popPanel: function (inSender, inEvent) {
-		this.popFloatingPanel();
-	}
-});
-
 module.exports = kind({
 	name: 'g.sample.MultiPickerPanelSample',
 	classes: 'enyo-unselectable garnet g-sample',
@@ -122,7 +85,9 @@ module.exports = kind({
 		{content: '< MultiPickerPanel Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'MultiPickerPanel', classes: 'g-sample-subheader'},
-		{kind: PanelManager, classes: 'g-sample-panel-manager'},
+		{kind: PanelManager, classes: 'g-sample-panel-manager', components: [
+			{kind: FormPanel, classes: 'g-sample-panel;', onResult: 'result'}
+		]},
 
 		{src: '@../assets/btn_command_next.svg', classes: 'g-sample-result', components: [
 			{content: 'Result', classes: 'g-sample-subheader'},

--- a/garnet/src/MultiPickerPanelSample.js
+++ b/garnet/src/MultiPickerPanelSample.js
@@ -24,7 +24,7 @@ var SampleMultiPickerPanel = kind({
 		};
 	}),
 	popPanel: function() {
-		this.container.popFloatingPanel();
+		this.bubbleUp('onPopPanel');
 	}
 });
 
@@ -44,7 +44,7 @@ var FormPanel = kind({
 		};
 	}),
 	showPanel: function(inSender, inEvent) {
-		this.container.pushFloatingPanel({name: 'multiPickerPanel', kind: SampleMultiPickerPanel, owner: this, selectedIndex: [1, 2], onUpdate: 'updateContent'});
+		this.bubbleUp('onPushPanel', {panel: {name: 'multiPickerPanel', kind: SampleMultiPickerPanel, owner: this, selectedIndex: [1, 2], onUpdate: 'updateContent'}});
 	},
 	updateContent: function(inSender, inEvent) {
 		var content = this.formattingContent(inEvent.value);
@@ -78,6 +78,23 @@ var FormPanel = kind({
 	}
 });
 
+var PanelManager = kind({
+	kind: PanelManager,
+	handlers: {
+		onPushPanel: 'pushPanel',
+		onPopPanel: 'popPanel'
+	},
+	components: [
+		{kind: FormPanel, classes: 'g-sample-panel;'}
+	],
+	pushPanel: function (inSender, inEvent) {
+		this.pushFloatingPanel(inEvent.panel, inEvent.options);
+	},
+	popPanel: function (inSender, inEvent) {
+		this.popFloatingPanel();
+	}
+});
+
 module.exports = kind({
 	name: 'g.sample.MultiPickerPanelSample',
 	classes: 'enyo-unselectable garnet g-sample',
@@ -85,10 +102,7 @@ module.exports = kind({
 		{content: '< MultiPickerPanel Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'MultiPickerPanel', classes: 'g-sample-subheader'},
-		{kind: PanelManager, classes: 'g-sample-panel-manager', components: [
-			{kind: FormPanel, classes: 'g-sample-panel;', onResult: 'result'}
-		]},
-
+		{kind: PanelManager, classes: 'g-sample-panel-manager', onResult: 'result'},
 		{src: '@../assets/btn_command_next.svg', classes: 'g-sample-result', components: [
 			{content: 'Result', classes: 'g-sample-subheader'},
 			{name: 'result', allowHtml: true, content: 'No button pressed yet.', classes: 'g-sample-description'}

--- a/garnet/src/PickerPanelSample.js
+++ b/garnet/src/PickerPanelSample.js
@@ -38,7 +38,7 @@ var FormPanel = kind({
 		};
 	}),
 	showPanel: function(inSender, inEvent) {
-		this.container.pushFloatingPanel({name: 'pickerPanel', kind: SamplePickerPanel, owner: this, selectedIndex: 2, onUpdate: 'updateContent'});
+		this.bubbleUp('onPushPanel', {panel: {name: 'pickerPanel', kind: SamplePickerPanel, owner: this, selectedIndex: 2, onUpdate: 'updateContent'}});
 	},
 	updateContent: function(inSender, inEvent) {
 		var content = this.formattingContent(inEvent.value);
@@ -61,6 +61,23 @@ var FormPanel = kind({
 	}
 });
 
+var PanelManager = kind({
+	kind: PanelManager,
+	handlers: {
+		onPushPanel: 'pushPanel',
+		onPopPanel: 'popPanel'
+	},
+	components: [
+		{kind: FormPanel, classes: 'g-sample-panel;'}
+	],
+	pushPanel: function (inSender, inEvent) {
+		this.pushFloatingPanel(inEvent.panel, inEvent.options);
+	},
+	popPanel: function (inSender, inEvent) {
+		this.popFloatingPanel();
+	}
+});
+
 module.exports = kind({
 	name: 'g.sample.PickerPanelSample',
 	classes: 'enyo-unselectable garnet g-sample',
@@ -68,9 +85,7 @@ module.exports = kind({
 		{content: '< PickerPanel Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'PickerPanel', classes: 'g-sample-subheader'},
-		{kind: PanelManager, classes: 'g-sample-panel-manager', components: [
-			{kind: FormPanel, classes: 'g-sample-panel', onResult: 'result'}
-		]},
+		{kind: PanelManager, classes: 'g-sample-panel-manager', onResult: 'result'},
 		{src: '@../assets/btn_command_next.svg', classes: 'g-sample-result', components: [
 			{content: 'Result', classes: 'g-sample-subheader'},
 			{name: 'result', allowHtml: true, content: 'No button pressed yet.', classes: 'g-sample-description'}

--- a/garnet/src/PickerPanelSample.js
+++ b/garnet/src/PickerPanelSample.js
@@ -3,17 +3,15 @@ require('garnet');
 var
 	kind = require('enyo/kind'),
 	Collection = require('enyo/Collection.js'),
+
 	FormPickerButton = require('garnet/FormPickerButton'),
 	Panel = require('garnet/Panel'),
 	PickerPanel = require('garnet/PickerPanel'),
 	PanelManager = require('garnet/PanelManager');
 
-
-var SamplePickerPanel = kind({
-	name: 'g.sample.PickerPanel',
+SamplePickerPanel = kind({
+	name: 'g.sample.SamplePickerPanel',
 	kind: PickerPanel,
-	title: true,
-	titleContent: 'PickerTitle',
 	create: kind.inherit(function(sup) {
 		return function() {
 			sup.apply(this, arguments);
@@ -31,6 +29,17 @@ var FormPanel = kind({
 	components: [
 		{name: 'pickerButton', kind: FormPickerButton, classes: 'g-sample-picker-panel-button', ontap: 'showPanel', content: 'Click here!'}
 	],
+	popPanels: {
+		pickerButton: {
+			name: 'pickerPanel',
+			kind: SamplePickerPanel,
+			title: true,
+			titleContent: 'PickerTitle',
+			selectedIndex: 2,
+			onUpdate: 'updateContent'
+
+		}
+	},
 	initComponents: kind.inherit(function(sup) {
 		return function() {
 			sup.apply(this, arguments);
@@ -38,14 +47,20 @@ var FormPanel = kind({
 		};
 	}),
 	showPanel: function(inSender, inEvent) {
-		this.bubbleUp('onPushPanel', {panel: {name: 'pickerPanel', kind: SamplePickerPanel, owner: this, selectedIndex: 2, onUpdate: 'updateContent'}});
+		var
+			name = inSender.name,
+			panel = this.popPanels[name];
+
+		if (panel) {
+			this.bubbleUp('onPushPanel', {panel: panel, owner: this});
+		}
 	},
 	updateContent: function(inSender, inEvent) {
-		var content = this.formattingContent(inEvent.value);
+		var content = this.formattingValueToText(inEvent.value);
 		this.$.pickerButton.setContent(content);
-		this.doResult({msg: content});
+		this.doResult({msg: content + ' tapped'});
 	},
-	formattingContent: function(val, data) {
+	formattingValueToText: function(val, data) {
 		var
 			item = val,
 			name = 'No item';
@@ -68,10 +83,10 @@ var PanelManager = kind({
 		onPopPanel: 'popPanel'
 	},
 	components: [
-		{kind: FormPanel, classes: 'g-sample-panel;'}
+		{kind: FormPanel, classes: 'g-sample-panel'}
 	],
 	pushPanel: function (inSender, inEvent) {
-		this.pushFloatingPanel(inEvent.panel, inEvent.options);
+		this.pushFloatingPanel(inEvent.panel, {owner: inEvent.owner});
 	},
 	popPanel: function (inSender, inEvent) {
 		this.popFloatingPanel();

--- a/garnet/src/PickerPanelSample.js
+++ b/garnet/src/PickerPanelSample.js
@@ -8,11 +8,52 @@ var
 	PickerPanel = require('garnet/PickerPanel'),
 	PanelManager = require('garnet/PanelManager');
 
-var Formatter = kind.singleton({
-	/*
-	* From PickerPanel.value to FormPickerButton.content
-	*/
-	PickerPanel: function(val, data) {
+
+var SamplePickerPanel = kind({
+	name: 'g.sample.PickerPanel',
+	kind: PickerPanel,
+	events: {
+		onUpdate: ''
+	},
+	title: true,
+	titleContent: 'PickerTitle',
+	create: kind.inherit(function(sup) {
+		return function() {
+			sup.apply(this, arguments);
+			this.collection = new Collection(data);
+		};
+	}),
+	deactivate: function(inEvent) {
+		if (!inEvent.dragging) {
+			this.doUpdate({name: this.name, value: this.value});
+		}
+	}
+});
+
+var FormPanel = kind({
+	name: 'g.sample.FormPanel',
+	kind: Panel,
+	events: {
+		onResult: ''
+	},
+	components: [
+		{name: 'pickerButton', kind: FormPickerButton, classes: 'g-sample-picker-panel-button', ontap: 'showPanel', content: 'Click here!'}
+	],
+	initComponents: kind.inherit(function(sup) {
+		return function() {
+			sup.apply(this, arguments);
+			this.$.pickerButton.setContent(data[2].item);
+		};
+	}),
+	showPanel: function(inSender, inEvent) {
+		this.container.pushFloatingPanel({name: 'pickerPanel', kind: PickerPanel, title: true, titleContent: 'PickerTitle', owner: this, onUpdate: 'updateContent'});
+	},
+	updateContent: function(inSender, inEvent) {
+		var content = this.formattingContent(inEvent.value);
+		this.$.pickerButton.setContent(content);
+		this.doResult({msg: content});
+	},
+	formattingContent: function(val, data) {
 		var
 			item = val,
 			name = 'No item';
@@ -28,75 +69,6 @@ var Formatter = kind.singleton({
 	}
 });
 
-var SamplePickerPanel = kind({
-	name: 'g.sample.PickerPanel',
-	kind: PickerPanel,
-	title: true,
-	titleContent: 'PickerTitle',
-	create: kind.inherit(function(sup) {
-		return function() {
-			sup.apply(this, arguments);
-			this.collection = new Collection(data);
-		};
-	}),
-	valueChanged: kind.inherit(function(sup) {
-		return function() {
-			sup.apply(this, arguments);
-			if (this.fromPanel) {
-				this.fromPanel.triggerHandler('onUpdate', {
-					name: this.name,
-					value: this.value
-				});
-			}
-		};
-	})
-});
-
-var FormPanel = kind({
-	name: 'g.sample.FormPanel',
-	kind: Panel,
-	events: {
-		onResult: ''
-	},
-	handlers: {
-		onUpdate: 'updateContent'
-	},
-	components: [
-		{name: 'pickerButton', kind: FormPickerButton, classes: 'g-sample-picker-panel-button', ontap: 'showPanel', content: 'Click here!'}
-	],
-	initComponents: kind.inherit(function(sup) {
-		return function() {
-			sup.apply(this, arguments);
-			this.$.pickerButton.setContent(data[2].item);
-		};
-	}),
-	showPanel: function(inSender, inEvent) {
-		this.bubbleUp('onPushPanel', {panel: {name: 'pickerPanel', kind: SamplePickerPanel, owner: this, fromPanel: this, selectedIndex: 2}});
-	},
-	updateContent: function(inSender, inEvent) {
-		var content = Formatter.PickerPanel(inEvent.value);
-		this.$.pickerButton.setContent(content);
-		this.doResult({msg: content});
-	}
-});
-
-var PanelManager = kind({
-	kind: PanelManager,
-	handlers: {
-		onPushPanel: 'pushPanel',
-		onPopPanel: 'popPanel'
-	},
-	components: [
-		{kind: FormPanel, classes: 'g-sample-panel', onResult: 'result'}
-	],
-	pushPanel: function (inSender, inEvent) {
-		this.pushFloatingPanel(inEvent.panel, inEvent.options);
-	},
-	popPanel: function (inSender, inEvent) {
-		this.popFloatingPanel();
-	}
-});
-
 module.exports = kind({
 	name: 'g.sample.PickerPanelSample',
 	classes: 'enyo-unselectable garnet g-sample',
@@ -104,8 +76,9 @@ module.exports = kind({
 		{content: '< PickerPanel Sample', classes: 'g-sample-header', ontap: 'goBack'},
 
 		{content: 'PickerPanel', classes: 'g-sample-subheader'},
-		{kind: PanelManager, classes: 'g-sample-panel-manager'},
-
+		{kind: PanelManager, classes: 'g-sample-panel-manager', components: [
+			{kind: FormPanel, classes: 'g-sample-panel', onResult: 'result'}
+		]},
 		{src: '@../assets/btn_command_next.svg', classes: 'g-sample-result', components: [
 			{content: 'Result', classes: 'g-sample-subheader'},
 			{name: 'result', allowHtml: true, content: 'No button pressed yet.', classes: 'g-sample-description'}

--- a/garnet/src/PickerPanelSample.js
+++ b/garnet/src/PickerPanelSample.js
@@ -19,7 +19,7 @@ var SamplePickerPanel = kind({
 			sup.apply(this, arguments);
 			this.collection = new Collection(data);
 		};
-	}),
+	})
 });
 
 var FormPanel = kind({

--- a/garnet/src/PickerPanelSample.js
+++ b/garnet/src/PickerPanelSample.js
@@ -12,9 +12,6 @@ var
 var SamplePickerPanel = kind({
 	name: 'g.sample.PickerPanel',
 	kind: PickerPanel,
-	events: {
-		onUpdate: ''
-	},
 	title: true,
 	titleContent: 'PickerTitle',
 	create: kind.inherit(function(sup) {
@@ -23,11 +20,6 @@ var SamplePickerPanel = kind({
 			this.collection = new Collection(data);
 		};
 	}),
-	deactivate: function(inEvent) {
-		if (!inEvent.dragging) {
-			this.doUpdate({name: this.name, value: this.value});
-		}
-	}
 });
 
 var FormPanel = kind({
@@ -46,7 +38,7 @@ var FormPanel = kind({
 		};
 	}),
 	showPanel: function(inSender, inEvent) {
-		this.container.pushFloatingPanel({name: 'pickerPanel', kind: PickerPanel, title: true, titleContent: 'PickerTitle', owner: this, onUpdate: 'updateContent'});
+		this.container.pushFloatingPanel({name: 'pickerPanel', kind: SamplePickerPanel, owner: this, selectedIndex: 2, onUpdate: 'updateContent'});
 	},
 	updateContent: function(inSender, inEvent) {
 		var content = this.formattingContent(inEvent.value);

--- a/garnet/src/PickerPanelSample.js
+++ b/garnet/src/PickerPanelSample.js
@@ -9,7 +9,7 @@ var
 	PickerPanel = require('garnet/PickerPanel'),
 	PanelManager = require('garnet/PanelManager');
 
-SamplePickerPanel = kind({
+var SamplePickerPanel = kind({
 	name: 'g.sample.SamplePickerPanel',
 	kind: PickerPanel,
 	create: kind.inherit(function(sup) {

--- a/garnet/src/ToastPanelSample.js
+++ b/garnet/src/ToastPanelSample.js
@@ -4,27 +4,34 @@ var
 	kind = require('enyo/kind'),
 
 	Button = require('garnet/Button'),
-	ToastPanel = require('garnet/ToastPanel'),
 	Panel = require('garnet/Panel'),
+	ToastPanel = require('garnet/ToastPanel'),
 	PanelManager = require('garnet/PanelManager');
-
-var SampleToast = kind({
-	name: 'toast',
-	kind: ToastPanel,
-	allowHtml: true,
-	duration: 5000,
-	content: 'Toast<br><br>Saved'
-});
 
 var ToastBasePanel = kind({
 	name: 'g.sample.ToastBasePanel',
 	kind: Panel,
 	classes: 'g-layout-absolute-wrapper', // for button
 	components: [
-		{kind: Button, classes: 'g-sample-toast-panel-container g-layout-absolute-center g-layout-absolute-middle', ontap: 'showPanel', content: 'Click here'}
+		{name: 'button', kind: Button, classes: 'g-sample-toast-panel-container g-layout-absolute-center g-layout-absolute-middle', ontap: 'showPanel', content: 'Click here'}
 	],
+	popPanels: {
+		button: {
+			name: 'toast',
+			kind: ToastPanel,
+			allowHtml: true,
+			duration: 5000,
+			content: 'Toast<br><br>Saved'
+		}
+	},
 	showPanel: function(inSender, inEvent) {
-		this.bubbleUp('onPushPanel', {panelName: name, owner: this});
+		var
+			name = inSender.name,
+			panel = this.popPanels[name];
+
+		if (panel) {
+			this.bubbleUp('onPushPanel', {panel: panel, owner: this});
+		}
 	}
 });
 
@@ -35,14 +42,13 @@ var PanelManager = kind({
 		onPushPanel: 'pushPanel'
 	},
 	components: [
-		{kind: ToastBasePanel}
+		{kind: ToastBasePanel, classes: 'g-sample-panel'}
 	],
 	pushPanel: function (inSender, inEvent) {
-		this.pushFloatingPanel({
-			name: 'toast',
-			kind: SampleToast,
-			fromPanel: inEvent.owner ? inEvent.owner : this
-		});
+		this.pushFloatingPanel(inEvent.panel, {owner: inEvent.owner});
+	},
+	popPanel: function (inSender, inEvent) {
+		this.popFloatingPanel();
 	}
 });
 


### PR DESCRIPTION
## Issue

: After pushing popup based panels into garnet/PanelManager, it is hard to handle those panels by the owner panel.
## Fix

: Allow ViewLayout to react to the events and then allow them to bubble normally
So now the samples related with them looks like the samples before.
With this PR, app developers could reduce code modification with popup based panels.

Related Wiki : http://collab.lge.com/main/display/ENYO/151118+Garnet+1.5.0-pre.3+checklist

Enyo-DCO-1.1-Signed-off-by: YB Sung yb.sung@lge.com
