### PR TITLE
ENYO-2754: Remove pressed class for preventing pressed state.

### DIFF
--- a/sunstone/src/GridListSample.js
+++ b/sunstone/src/GridListSample.js
@@ -83,7 +83,7 @@ module.exports = kind({
 		}
 		this.$.list.refresh();
 	},
-	setupReorderComponents: function (inSender, inEvent) {
+	setupReorderComponents: function(inSender, inEvent) {
 		var i = inEvent.index;
 		if (!this.names[i]) {
 			return;
@@ -93,7 +93,7 @@ module.exports = kind({
 		this.$.reorderTile.setCaption(item.name);
 		this.$.reorderTile.setSelected(this.$.list.isSelected(i));
 	},
-	setupItem: function (inSender, inEvent) {
+	setupItem: function(inSender, inEvent) {
 		var i = inEvent.index,
 			item = this.names[i];
 		this.$.tile.setCaption(item.name);
@@ -101,7 +101,7 @@ module.exports = kind({
 		this.$.tile.setSelected(this.$.list.isSelected(i));
 		return true;
 	},
-	pressed: function (inSender, inEvent) {
+	pressed: function(inSender, inEvent) {
 		if (!this.isPressed) {
 			this.$.list.lockRow();
 			this.$.list.prepareRow(inEvent.index);
@@ -109,7 +109,7 @@ module.exports = kind({
 			this.isPressed = true;
 		}
 	},
-	unpressed: function (inSender, inEvent) {
+	unpressed: function(inSender, inEvent) {
 		inSender.removeClass('pressed');
 		this.$.list.lockRow();
 		this.isPressed = false;

--- a/sunstone/src/GridListSample.js
+++ b/sunstone/src/GridListSample.js
@@ -61,29 +61,29 @@ module.exports = kind({
 		var movedItem = utils.clone(this.names[inEvent.reorderFrom]);
 		var lastSelected = this.$.list.getSelection().lastSelected;
 
-		this.names.splice(inEvent.reorderFrom,1);
-		this.names.splice((inEvent.reorderTo),0,movedItem);
+		this.names.splice(inEvent.reorderFrom, 1);
+		this.names.splice(inEvent.reorderTo, 0, movedItem);
 
-		if(this.$.list.isSelected(inEvent.reorderFrom)) { //reorder selected Item
+		if (this.$.list.isSelected(inEvent.reorderFrom)) { //reorder selected Item
 			this.$.list.deselect(inEvent.reorderFrom);
 			this.$.list.select(inEvent.reorderTo);
-		}else if(this.$.list.isSelected(inEvent.reorderTo)) { //reorder to selected Item
+		} else if (this.$.list.isSelected(inEvent.reorderTo)) { //reorder to selected Item
 			this.$.list.deselect(inEvent.reorderTo);
-			if(inEvent.reorderFrom > inEvent.reorderTo) {
-				this.$.list.select(inEvent.reorderTo+1);
-			}else {
-				this.$.list.select(inEvent.reorderTo-1);
+			if (inEvent.reorderFrom > inEvent.reorderTo) {
+				this.$.list.select(inEvent.reorderTo + 1);
+			} else {
+				this.$.list.select(inEvent.reorderTo - 1);
 			}
-		}else { // when selected item is between reorderFrom and reorderTo
-			if(inEvent.reorderFrom < lastSelected && inEvent.reorderTo > lastSelected) {
-				this.$.list.select(lastSelected-1);
-			}else if(inEvent.reorderFrom > lastSelected && inEvent.reorderTo < lastSelected) {
-				this.$.list.select(lastSelected+1);
+		} else { // when selected item is between reorderFrom and reorderTo
+			if (inEvent.reorderFrom < lastSelected && inEvent.reorderTo > lastSelected) {
+				this.$.list.select(lastSelected - 1);
+			} else if (inEvent.reorderFrom > lastSelected && inEvent.reorderTo < lastSelected) {
+				this.$.list.select(lastSelected + 1);
 			}
 		}
 		this.$.list.refresh();
 	},
-	setupReorderComponents: function(inSender, inEvent) {
+	setupReorderComponents: function (inSender, inEvent) {
 		var i = inEvent.index;
 		if (!this.names[i]) {
 			return;
@@ -93,14 +93,15 @@ module.exports = kind({
 		this.$.reorderTile.setCaption(item.name);
 		this.$.reorderTile.setSelected(this.$.list.isSelected(i));
 	},
-	setupItem: function(inSender, inEvent) {
+	setupItem: function (inSender, inEvent) {
 		var i = inEvent.index,
 			item = this.names[i];
 		this.$.tile.setCaption(item.name);
+		this.$.tile.removeClass('pressed'); // For Preventing pressed state when page is generated.
 		this.$.tile.setSelected(this.$.list.isSelected(i));
 		return true;
 	},
-	pressed: function(inSender, inEvent) {
+	pressed: function (inSender, inEvent) {
 		if (!this.isPressed) {
 			this.$.list.lockRow();
 			this.$.list.prepareRow(inEvent.index);
@@ -108,7 +109,7 @@ module.exports = kind({
 			this.isPressed = true;
 		}
 	},
-	unpressed: function(inSender, inEvent) {
+	unpressed: function (inSender, inEvent) {
 		inSender.removeClass('pressed');
 		this.$.list.lockRow();
 		this.isPressed = false;

--- a/sunstone/src/ListSample.js
+++ b/sunstone/src/ListSample.js
@@ -103,6 +103,7 @@ module.exports = kind({
 		var n = this.names[i];
 		// apply selection style if inSender (the list) indicates that this row is selected.
 		this.$.item.addRemoveClass('list-sample-selected', inSender.isSelected(i));
+		this.$.item.removeClass('pressed'); // For Preventing pressed state when page is generated.
 		this.$.name.setContent(n.name);
 		this.$.checkbox.setChecked(n.checked);
 		return true;


### PR DESCRIPTION
In sunstone's GridListSample, remove pressed class in setupItem() for preventing
pressed state when page is re-generated because of reordering.

https://jira2.lgsvl.com/browse/ENYO-2754
Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com
