### PR TITLE
PLAT-13289: Prevent css class conflict

### DIFF
--- a/garnet/src/ArcSample.js
+++ b/garnet/src/ArcSample.js
@@ -36,7 +36,7 @@ var ArcPanel = kind({
 
 module.exports = kind({
 	name: 'g.sample.ArcSample',
-	classes: 'enyo-unselectable garnet g-sample',
+	classes: 'enyo-unselectable garnet g-sample g-sample-arc',
 	components: [
 		{content: '< Arc Sample', classes: 'g-sample-header', ontap: 'goBack'},
 

--- a/garnet/src/ArcSample.less
+++ b/garnet/src/ArcSample.less
@@ -1,11 +1,13 @@
 /* ArcSample */
 
-// Common classes
+.g-sample-arc {
+	// Common classes
 
-.g-sample-arc .g-sample-circle-panel {
-	background-color: #000000;
+	.g-sample-circle-panel {
+		background-color: #000000;
 
-	position: relative;
-	border-radius: 50%;
-	overflow: hidden;
+		position: relative;
+		border-radius: 50%;
+		overflow: hidden;
+	}
 }

--- a/garnet/src/ArcSample.less
+++ b/garnet/src/ArcSample.less
@@ -2,7 +2,7 @@
 
 // Common classes
 
-.g-sample-circle-panel {
+.g-sample-arc .g-sample-circle-panel {
 	background-color: #000000;
 
 	position: relative;

--- a/garnet/src/ArcSample.less
+++ b/garnet/src/ArcSample.less
@@ -1,13 +1,13 @@
 /* ArcSample */
 
 .g-sample-arc {
-	// Common classes
+// Common classes
 
-	.g-sample-circle-panel {
-		background-color: #000000;
+.g-sample-circle-panel {
+	background-color: #000000;
 
-		position: relative;
-		border-radius: 50%;
-		overflow: hidden;
-	}
+	position: relative;
+	border-radius: 50%;
+	overflow: hidden;
+}
 }

--- a/garnet/src/ButtonSample.js
+++ b/garnet/src/ButtonSample.js
@@ -35,7 +35,7 @@ var ButtonPanel = kind({
 
 module.exports = kind({
 	name: 'g.sample.ButtonSample',
-	classes: 'enyo-unselectable garnet g-sample',
+	classes: 'enyo-unselectable garnet g-sample g-sample-button',
 	components: [
 		{content: '< Button Sample', classes: 'g-sample-header', ontap: 'goBack'},
 

--- a/garnet/src/ButtonSample.less
+++ b/garnet/src/ButtonSample.less
@@ -1,40 +1,42 @@
 /* ButtonSample */
 
-// Common classes
+.g-sample-button {
+	// Common classes
 
-.g-sample-button .g-sample-circle-panel {
-	background-color: #000000;
+	.g-sample-circle-panel {
+		background-color: #000000;
 
-	position: relative;
-	border-radius: 50%;
-	overflow: hidden;
-}
-.g-sample-button .g-sample-result {
-	background-color: #EDEDED;
+		position: relative;
+		border-radius: 50%;
+		overflow: hidden;
+	}
+	.g-sample-result {
+		background-color: #EDEDED;
 
-	position: fixed;
-	width: 100%;
-	min-height: 160px;
-	bottom: 0;
-	z-index: 9999;
-	opacity: 0.8;
-}
-.g-sample-button .g-sample-text {
-	display: inline-block;
+		position: fixed;
+		width: 100%;
+		min-height: 160px;
+		bottom: 0;
+		z-index: 9999;
+		opacity: 0.8;
+	}
+	.g-sample-text {
+		display: inline-block;
 
-	font-size: 20px;
-	color: #FFFFFF;
-}
+		font-size: 20px;
+		color: #FFFFFF;
+	}
 
-// Sample specific classes
+	// Sample specific classes
 
-.g-sample-button-container {
-	width: 280px;
-	height: 230px;
-}
-.g-sample-button-disable {
-	width: 100px;
-}
-.g-sample-button-fixed {
-	width: 280px;
+	.g-sample-button-container {
+		width: 280px;
+		height: 230px;
+	}
+	.g-sample-button-disable {
+		width: 100px;
+	}
+	.g-sample-button-fixed {
+		width: 280px;
+	}
 }

--- a/garnet/src/ButtonSample.less
+++ b/garnet/src/ButtonSample.less
@@ -1,42 +1,42 @@
 /* ButtonSample */
 
 .g-sample-button {
-	// Common classes
+// Common classes
 
-	.g-sample-circle-panel {
-		background-color: #000000;
+.g-sample-circle-panel {
+	background-color: #000000;
 
-		position: relative;
-		border-radius: 50%;
-		overflow: hidden;
-	}
-	.g-sample-result {
-		background-color: #EDEDED;
+	position: relative;
+	border-radius: 50%;
+	overflow: hidden;
+}
+.g-sample-result {
+	background-color: #EDEDED;
 
-		position: fixed;
-		width: 100%;
-		min-height: 160px;
-		bottom: 0;
-		z-index: 9999;
-		opacity: 0.8;
-	}
-	.g-sample-text {
-		display: inline-block;
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
+.g-sample-text {
+	display: inline-block;
 
-		font-size: 20px;
-		color: #FFFFFF;
-	}
+	font-size: 20px;
+	color: #FFFFFF;
+}
 
-	// Sample specific classes
+// Sample specific classes
 
-	.g-sample-button-container {
-		width: 280px;
-		height: 230px;
-	}
-	.g-sample-button-disable {
-		width: 100px;
-	}
-	.g-sample-button-fixed {
-		width: 280px;
-	}
+.g-sample-button-container {
+	width: 280px;
+	height: 230px;
+}
+.g-sample-button-disable {
+	width: 100px;
+}
+.g-sample-button-fixed {
+	width: 280px;
+}
 }

--- a/garnet/src/ButtonSample.less
+++ b/garnet/src/ButtonSample.less
@@ -2,14 +2,14 @@
 
 // Common classes
 
-.g-sample-circle-panel {
+.g-sample-button .g-sample-circle-panel {
 	background-color: #000000;
 
 	position: relative;
 	border-radius: 50%;
 	overflow: hidden;
 }
-.g-sample-result {
+.g-sample-button .g-sample-result {
 	background-color: #EDEDED;
 
 	position: fixed;
@@ -19,7 +19,7 @@
 	z-index: 9999;
 	opacity: 0.8;
 }
-.g-sample-text {
+.g-sample-button .g-sample-text {
 	display: inline-block;
 
 	font-size: 20px;

--- a/garnet/src/CheckboxSample.js
+++ b/garnet/src/CheckboxSample.js
@@ -44,7 +44,7 @@ var CheckboxPanel = kind({
 
 module.exports = kind({
 	name: 'g.sample.CheckboxSample',
-	classes: 'enyo-unselectable garnet g-sample',
+	classes: 'enyo-unselectable garnet g-sample g-sample-checkbox',
 	components: [
 		{content: '< Checkbox Sample', classes: 'g-sample-header', ontap: 'goBack'},
 

--- a/garnet/src/CheckboxSample.less
+++ b/garnet/src/CheckboxSample.less
@@ -1,24 +1,26 @@
 /* CheckboxSample */
 
-// Common classes
+.g-sample-checkbox {
+	// Common classes
 
-.g-sample-checkbox .g-sample-circle-panel {
-	background-color: #000000;
+	.g-sample-circle-panel {
+		background-color: #000000;
 
-	position: relative;
-	border-radius: 50%;
-	overflow: hidden;
-}
-.g-sample-checkbox .g-sample-text {
-	display: inline-block;
+		position: relative;
+		border-radius: 50%;
+		overflow: hidden;
+	}
+	.g-sample-text {
+		display: inline-block;
 
-	font-size: 20px;
-	color: #FFFFFF;
-}
+		font-size: 20px;
+		color: #FFFFFF;
+	}
 
-// Sample specific classes
+	// Sample specific classes
 
-.g-sample-checkbox-container {
-	width: 255px;
-	height: 200px;
+	.g-sample-checkbox-container {
+		width: 255px;
+		height: 200px;
+	}
 }

--- a/garnet/src/CheckboxSample.less
+++ b/garnet/src/CheckboxSample.less
@@ -1,26 +1,26 @@
 /* CheckboxSample */
 
 .g-sample-checkbox {
-	// Common classes
+// Common classes
 
-	.g-sample-circle-panel {
-		background-color: #000000;
+.g-sample-circle-panel {
+	background-color: #000000;
 
-		position: relative;
-		border-radius: 50%;
-		overflow: hidden;
-	}
-	.g-sample-text {
-		display: inline-block;
+	position: relative;
+	border-radius: 50%;
+	overflow: hidden;
+}
+.g-sample-text {
+	display: inline-block;
 
-		font-size: 20px;
-		color: #FFFFFF;
-	}
+	font-size: 20px;
+	color: #FFFFFF;
+}
 
-	// Sample specific classes
+// Sample specific classes
 
-	.g-sample-checkbox-container {
-		width: 255px;
-		height: 200px;
-	}
+.g-sample-checkbox-container {
+	width: 255px;
+	height: 200px;
+}
 }

--- a/garnet/src/CheckboxSample.less
+++ b/garnet/src/CheckboxSample.less
@@ -2,14 +2,14 @@
 
 // Common classes
 
-.g-sample-circle-panel {
+.g-sample-checkbox .g-sample-circle-panel {
 	background-color: #000000;
 
 	position: relative;
 	border-radius: 50%;
 	overflow: hidden;
 }
-.g-sample-text {
+.g-sample-checkbox .g-sample-text {
 	display: inline-block;
 
 	font-size: 20px;

--- a/garnet/src/CommandBarSample.js
+++ b/garnet/src/CommandBarSample.js
@@ -99,7 +99,7 @@ module.exports = kind({
 	handlers: {
 		onResult: 'result'
 	},
-	classes: 'enyo-unselectable garnet g-sample',
+	classes: 'enyo-unselectable garnet g-sample g-sample-commandbar',
 	components: [
 		{content: '< CommandBar Sample', classes: 'g-sample-header', ontap: 'goBack'},
 

--- a/garnet/src/CommandBarSample.less
+++ b/garnet/src/CommandBarSample.less
@@ -1,39 +1,39 @@
 /* CommandBarSample */
 
 .g-sample-commandbar {
-	// Common classes
+// Common classes
 
-	.g-sample-panels {
-		position: relative;
-		height: 100%;
-	}
-	.g-sample-panel-margin {
-		background-color: #000000;
+.g-sample-panels {
+	position: relative;
+	height: 100%;
+}
+.g-sample-panel-margin {
+	background-color: #000000;
 
-		position: relative;
-		display: inline-block;
-		margin-right: 10px;
-		overflow: hidden;
-	}
-	.g-sample-result {
-		background-color: #EDEDED;
+	position: relative;
+	display: inline-block;
+	margin-right: 10px;
+	overflow: hidden;
+}
+.g-sample-result {
+	background-color: #EDEDED;
 
-		position: fixed;
-		width: 100%;
-		min-height: 160px;
-		bottom: 0;
-		z-index: 9999;
-		opacity: 0.8;
-	}
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
 
-	// Sample specific classes
+// Sample specific classes
 
-	.g-sample-commandbar-content {
-		width: 200px;
-		margin: auto;
-		padding-top: 60px;
-	}
-	.g-sample-commandbar-button {
-		margin: 20px 0 116px;
-	}
+.g-sample-commandbar-content {
+	width: 200px;
+	margin: auto;
+	padding-top: 60px;
+}
+.g-sample-commandbar-button {
+	margin: 20px 0 116px;
+}
 }

--- a/garnet/src/CommandBarSample.less
+++ b/garnet/src/CommandBarSample.less
@@ -1,37 +1,39 @@
 /* CommandBarSample */
 
-// Common classes
+.g-sample-commandbar {
+	// Common classes
 
-.g-sample-commandbar .g-sample-panels {
-	position: relative;
-	height: 100%;
-}
-.g-sample-commandbar .g-sample-panel-margin {
-	background-color: #000000;
+	.g-sample-panels {
+		position: relative;
+		height: 100%;
+	}
+	.g-sample-panel-margin {
+		background-color: #000000;
 
-	position: relative;
-	display: inline-block;
-	margin-right: 10px;
-	overflow: hidden;
-}
-.g-sample-commandbar .g-sample-result {
-	background-color: #EDEDED;
+		position: relative;
+		display: inline-block;
+		margin-right: 10px;
+		overflow: hidden;
+	}
+	.g-sample-result {
+		background-color: #EDEDED;
 
-	position: fixed;
-	width: 100%;
-	min-height: 160px;
-	bottom: 0;
-	z-index: 9999;
-	opacity: 0.8;
-}
+		position: fixed;
+		width: 100%;
+		min-height: 160px;
+		bottom: 0;
+		z-index: 9999;
+		opacity: 0.8;
+	}
 
-// Sample specific classes
+	// Sample specific classes
 
-.g-sample-commandbar-content {
-	width: 200px;
-	margin: auto;
-	padding-top: 60px;
-}
-.g-sample-commandbar-button {
-	margin: 20px 0 116px;
+	.g-sample-commandbar-content {
+		width: 200px;
+		margin: auto;
+		padding-top: 60px;
+	}
+	.g-sample-commandbar-button {
+		margin: 20px 0 116px;
+	}
 }

--- a/garnet/src/CommandBarSample.less
+++ b/garnet/src/CommandBarSample.less
@@ -2,11 +2,11 @@
 
 // Common classes
 
-.g-sample-panels {
+.g-sample-commandbar .g-sample-panels {
 	position: relative;
 	height: 100%;
 }
-.g-sample-panel-margin {
+.g-sample-commandbar .g-sample-panel-margin {
 	background-color: #000000;
 
 	position: relative;
@@ -14,7 +14,7 @@
 	margin-right: 10px;
 	overflow: hidden;
 }
-.g-sample-result {
+.g-sample-commandbar .g-sample-result {
 	background-color: #EDEDED;
 
 	position: fixed;

--- a/garnet/src/ConfirmPanelSample.js
+++ b/garnet/src/ConfirmPanelSample.js
@@ -147,7 +147,7 @@ var PanelManager = kind({
 module.exports = kind({
 	name: 'g.sample.ConfirmPanelSample',
 	kind: Control,
-	classes: 'enyo-unselectable enyo-fit garnet g-sample',
+	classes: 'enyo-unselectable enyo-fit garnet g-sample g-sample-confirm-panel',
 	handlers: {
 		onResult: "result",
 		onPopPanel: "result"

--- a/garnet/src/ConfirmPanelSample.less
+++ b/garnet/src/ConfirmPanelSample.less
@@ -1,38 +1,38 @@
 /* ConfirmPanelSample */
 
 .g-sample-confirm-panel {
-	// Common classes
+// Common classes
 
-	.g-sample-panel {
-		background-color: #000000;
+.g-sample-panel {
+	background-color: #000000;
 
-		position: relative;
-		overflow: hidden;
-	}
-	.g-sample-panel-manager {
-		position: relative;
-		display: inline-block;
-		width: 320px;
-		height: 320px;
-	}
-	.g-sample-result {
-		background-color: #EDEDED;
+	position: relative;
+	overflow: hidden;
+}
+.g-sample-panel-manager {
+	position: relative;
+	display: inline-block;
+	width: 320px;
+	height: 320px;
+}
+.g-sample-result {
+	background-color: #EDEDED;
 
-		position: fixed;
-		width: 100%;
-		min-height: 160px;
-		bottom: 0;
-		z-index: 9999;
-		opacity: 0.8;
-	}
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
 
-	// Sample specific classes
+// Sample specific classes
 
-	.g-sample-confirm-panel-button {
-		width:310px;
-		margin:5px;
-	}
-	.g-sample-confirm-panel-button:first-child {
-		margin:20px 5px 5px;
-	}
+.g-sample-confirm-panel-button {
+	width:310px;
+	margin:5px;
+}
+.g-sample-confirm-panel-button:first-child {
+	margin:20px 5px 5px;
+}
 }

--- a/garnet/src/ConfirmPanelSample.less
+++ b/garnet/src/ConfirmPanelSample.less
@@ -2,18 +2,19 @@
 
 // Common classes
 
-.g-sample-panel {
+.g-sample-confirm-panel .g-sample-panel {
 	background-color: #000000;
 
 	position: relative;
 	overflow: hidden;
-}.g-sample-panel-manager {
+}
+.g-sample-confirm-panel .g-sample-panel-manager {
 	position: relative;
 	display: inline-block;
 	width: 320px;
 	height: 320px;
 }
-.g-sample-result {
+.g-sample-confirm-panel .g-sample-result {
 	background-color: #EDEDED;
 
 	position: fixed;

--- a/garnet/src/ConfirmPanelSample.less
+++ b/garnet/src/ConfirmPanelSample.less
@@ -1,36 +1,38 @@
 /* ConfirmPanelSample */
 
-// Common classes
+.g-sample-confirm-panel {
+	// Common classes
 
-.g-sample-confirm-panel .g-sample-panel {
-	background-color: #000000;
+	.g-sample-panel {
+		background-color: #000000;
 
-	position: relative;
-	overflow: hidden;
-}
-.g-sample-confirm-panel .g-sample-panel-manager {
-	position: relative;
-	display: inline-block;
-	width: 320px;
-	height: 320px;
-}
-.g-sample-confirm-panel .g-sample-result {
-	background-color: #EDEDED;
+		position: relative;
+		overflow: hidden;
+	}
+	.g-sample-panel-manager {
+		position: relative;
+		display: inline-block;
+		width: 320px;
+		height: 320px;
+	}
+	.g-sample-result {
+		background-color: #EDEDED;
 
-	position: fixed;
-	width: 100%;
-	min-height: 160px;
-	bottom: 0;
-	z-index: 9999;
-	opacity: 0.8;
-}
+		position: fixed;
+		width: 100%;
+		min-height: 160px;
+		bottom: 0;
+		z-index: 9999;
+		opacity: 0.8;
+	}
 
-// Sample specific classes
+	// Sample specific classes
 
-.g-sample-confirm-panel-button {
-	width:310px;
-	margin:5px;
-}
-.g-sample-confirm-panel-button:first-child {
-	margin:20px 5px 5px;
+	.g-sample-confirm-panel-button {
+		width:310px;
+		margin:5px;
+	}
+	.g-sample-confirm-panel-button:first-child {
+		margin:20px 5px 5px;
+	}
 }

--- a/garnet/src/ContextualPanelSample.js
+++ b/garnet/src/ContextualPanelSample.js
@@ -117,7 +117,7 @@ module.exports = kind({
 		onResult: "result",
 		onPopPanel: "result"
 	},
-	classes: 'enyo-unselectable enyo-fit garnet g-sample',
+	classes: 'enyo-unselectable enyo-fit garnet g-sample g-sample-contextual-panel',
 	components: [
 		{content: '< ContextualPanel Sample', classes: 'g-sample-header', ontap: 'goBack'},
 

--- a/garnet/src/ContextualPanelSample.less
+++ b/garnet/src/ContextualPanelSample.less
@@ -1,32 +1,32 @@
 /* ContextualPanelSample */
 
 .g-sample-contextual-panel {
-	// Common classes
+// Common classes
 
-	.g-sample-panel-manager {
-		position: relative;
-		display: inline-block;
-		width: 320px;
-		height: 320px;
-	}
-	.g-sample-result {
-		background-color: #EDEDED;
+.g-sample-panel-manager {
+	position: relative;
+	display: inline-block;
+	width: 320px;
+	height: 320px;
+}
+.g-sample-result {
+	background-color: #EDEDED;
 
-		position: fixed;
-		width: 100%;
-		min-height: 160px;
-		bottom: 0;
-		z-index: 9999;
-		opacity: 0.8;
-	}
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
 
-	// Sample specific classes
+// Sample specific classes
 
-	.g-sample-contextual-panel-button {
-		width:310px;
-		margin:5px;
-	}
-	.g-sample-contextual-panel-button:first-child {
-		margin:55px 5px 5px;
-	}
+.g-sample-contextual-panel-button {
+	width:310px;
+	margin:5px;
+}
+.g-sample-contextual-panel-button:first-child {
+	margin:55px 5px 5px;
+}
 }

--- a/garnet/src/ContextualPanelSample.less
+++ b/garnet/src/ContextualPanelSample.less
@@ -1,30 +1,32 @@
 /* ContextualPanelSample */
 
-// Common classes
+.g-sample-contextual-panel {
+	// Common classes
 
-.g-sample-contextual-panel .g-sample-panel-manager {
-	position: relative;
-	display: inline-block;
-	width: 320px;
-	height: 320px;
-}
-.g-sample-contextual-panel .g-sample-result {
-	background-color: #EDEDED;
+	.g-sample-panel-manager {
+		position: relative;
+		display: inline-block;
+		width: 320px;
+		height: 320px;
+	}
+	.g-sample-result {
+		background-color: #EDEDED;
 
-	position: fixed;
-	width: 100%;
-	min-height: 160px;
-	bottom: 0;
-	z-index: 9999;
-	opacity: 0.8;
-}
+		position: fixed;
+		width: 100%;
+		min-height: 160px;
+		bottom: 0;
+		z-index: 9999;
+		opacity: 0.8;
+	}
 
-// Sample specific classes
+	// Sample specific classes
 
-.g-sample-contextual-panel-button {
-	width:310px;
-	margin:5px;
-}
-.g-sample-contextual-panel-button:first-child {
-	margin:55px 5px 5px;
+	.g-sample-contextual-panel-button {
+		width:310px;
+		margin:5px;
+	}
+	.g-sample-contextual-panel-button:first-child {
+		margin:55px 5px 5px;
+	}
 }

--- a/garnet/src/ContextualPanelSample.less
+++ b/garnet/src/ContextualPanelSample.less
@@ -2,13 +2,13 @@
 
 // Common classes
 
-.g-sample-panel-manager {
+.g-sample-contextual-panel .g-sample-panel-manager {
 	position: relative;
 	display: inline-block;
 	width: 320px;
 	height: 320px;
 }
-.g-sample-result {
+.g-sample-contextual-panel .g-sample-result {
 	background-color: #EDEDED;
 
 	position: fixed;

--- a/garnet/src/DataGridListSample.js
+++ b/garnet/src/DataGridListSample.js
@@ -142,7 +142,7 @@ var DataGridListCirclePanel = kind({
 
 var DataGridListSample = module.exports = kind({
 	name: 'g.sample.DataGridListSample',
-	classes: 'enyo-unselectable garnet g-sample',
+	classes: 'enyo-unselectable garnet g-sample g-sample-datagridlist',
 	components: [
 		{
 			content: '< Data Grid List Sample',

--- a/garnet/src/DataGridListSample.less
+++ b/garnet/src/DataGridListSample.less
@@ -1,97 +1,99 @@
 /* DataGridListSample */
 
-// Common classes
+.g-sample-datagridlist {
+	// Common classes
 
-.g-sample-datagridlist .g-sample-panel-margin {
-	background-color: #000000;
+	.g-sample-panel-margin {
+		background-color: #000000;
 
-	position: relative;
-	display: inline-block;
-	margin-right: 10px;
-	overflow: hidden;
-}
+		position: relative;
+		display: inline-block;
+		margin-right: 10px;
+		overflow: hidden;
+	}
 
-// Sample specific classes
+	// Sample specific classes
 
-.g-sample-datagridlist-panel {
-	background-color: #000000;
+	.g-sample-datagridlist-panel {
+		background-color: #000000;
 
-	width: 232px;
-	height: 320px;
-	margin: auto;
-}
-.g-sample-datagridlist-imageitem {
-	width: 127px;
-	height: 127px;
+		width: 232px;
+		height: 320px;
+		margin: auto;
+	}
+	.g-sample-datagridlist-imageitem {
+		width: 127px;
+		height: 127px;
 
-	text-align: center;
+		text-align: center;
 
-	cursor: pointer;
-}
-.g-sample-datagridlist-imageitem img {
-	background-size: contain;
+		cursor: pointer;
+	}
+	.g-sample-datagridlist-imageitem img {
+		background-size: contain;
 
-	width: 107px;
-	height: 107px;
-}
-.g-sample-datagridlist-circle-imageitem img {
-	background-size: contain;
+		width: 107px;
+		height: 107px;
+	}
+	.g-sample-datagridlist-circle-imageitem img {
+		background-size: contain;
 
-	width: 82px;
-	height: 82px;
-	border-radius: 100%;
-	margin-top: 0.8px;
-}
-.g-sample-datagridlist-imageitem .caption{
-	width: 0;
-	height: 0;
-	overflow: hidden;
-}
-.g-sample-datagridlist-circle-imageitem .caption{
-	width: 92px;
-	height: 20px;
-	margin-top: 0;
-	margin-left: 15px;
-	margin-right: 15px;
+		width: 82px;
+		height: 82px;
+		border-radius: 100%;
+		margin-top: 0.8px;
+	}
+	.g-sample-datagridlist-imageitem .caption{
+		width: 0;
+		height: 0;
+		overflow: hidden;
+	}
+	.g-sample-datagridlist-circle-imageitem .caption{
+		width: 92px;
+		height: 20px;
+		margin-top: 0;
+		margin-left: 15px;
+		margin-right: 15px;
 
-	font-size: 18px;
-	color: #FAFAFA;
+		font-size: 18px;
+		color: #FAFAFA;
 
-	-webkit-mask-image: -webkit-linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
-	-webkit-mask-image: linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
-}
-.g-sample-datagridlist-imageitem.disabled {
-	opacity: 0.4;
+		-webkit-mask-image: -webkit-linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
+		-webkit-mask-image: linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
+	}
+	.g-sample-datagridlist-imageitem.disabled {
+		opacity: 0.4;
 
-	filter: alpha(opacity=40);
-}
+		filter: alpha(opacity=40);
+	}
 
-/* GridList Imageitem */
-.selection-enabled .g-sample-datagridlist-imageitem.g-selection-overlay-support.selected .g-icon-button {
-	background-position: 0 -325.8px;
+	/* GridList Imageitem */
+	.selection-enabled .g-sample-datagridlist-imageitem.g-selection-overlay-support.selected .g-icon-button {
+		background-position: 0 -325.8px;
 
-	margin-top: 0;
-	margin-left: 5px;
-	margin-right: 15px;
-}
-.g-sample-datagridlist-imageitem .g-selection-overlay-support-scrim .g-selection-overlay-support-checkbox {
-	position: absolute;
-	width: 107px;
-	height: 107px;
-	margin-top: 0;
-	margin-left: 0;
-}
-.selection-enabled .g-sample-datagridlist-circle-imageitem.g-selection-overlay-support.selected .g-icon-button {
-	background-position: 0 -331px;
+		margin-top: 0;
+		margin-left: 5px;
+		margin-right: 15px;
+	}
+	.g-sample-datagridlist-imageitem .g-selection-overlay-support-scrim .g-selection-overlay-support-checkbox {
+		position: absolute;
+		width: 107px;
+		height: 107px;
+		margin-top: 0;
+		margin-left: 0;
+	}
+	.selection-enabled .g-sample-datagridlist-circle-imageitem.g-selection-overlay-support.selected .g-icon-button {
+		background-position: 0 -331px;
 
-	margin-top: 0;
-	margin-left: 5px;
-	margin-right: 0;
-}
-.g-sample-datagridlist-circle-imageitem .g-selection-overlay-support-scrim .g-selection-overlay-support-checkbox {
-	position: absolute;
-	width: 107px;
-	height: 88px;
-	margin-top: 0;
-	margin-left: 0;
+		margin-top: 0;
+		margin-left: 5px;
+		margin-right: 0;
+	}
+	.g-sample-datagridlist-circle-imageitem .g-selection-overlay-support-scrim .g-selection-overlay-support-checkbox {
+		position: absolute;
+		width: 107px;
+		height: 88px;
+		margin-top: 0;
+		margin-left: 0;
+	}
 }

--- a/garnet/src/DataGridListSample.less
+++ b/garnet/src/DataGridListSample.less
@@ -1,99 +1,99 @@
 /* DataGridListSample */
 
 .g-sample-datagridlist {
-	// Common classes
+// Common classes
 
-	.g-sample-panel-margin {
-		background-color: #000000;
+.g-sample-panel-margin {
+	background-color: #000000;
 
-		position: relative;
-		display: inline-block;
-		margin-right: 10px;
-		overflow: hidden;
-	}
+	position: relative;
+	display: inline-block;
+	margin-right: 10px;
+	overflow: hidden;
+}
 
-	// Sample specific classes
+// Sample specific classes
 
-	.g-sample-datagridlist-panel {
-		background-color: #000000;
+.g-sample-datagridlist-panel {
+	background-color: #000000;
 
-		width: 232px;
-		height: 320px;
-		margin: auto;
-	}
-	.g-sample-datagridlist-imageitem {
-		width: 127px;
-		height: 127px;
+	width: 232px;
+	height: 320px;
+	margin: auto;
+}
+.g-sample-datagridlist-imageitem {
+	width: 127px;
+	height: 127px;
 
-		text-align: center;
+	text-align: center;
 
-		cursor: pointer;
-	}
-	.g-sample-datagridlist-imageitem img {
-		background-size: contain;
+	cursor: pointer;
+}
+.g-sample-datagridlist-imageitem img {
+	background-size: contain;
 
-		width: 107px;
-		height: 107px;
-	}
-	.g-sample-datagridlist-circle-imageitem img {
-		background-size: contain;
+	width: 107px;
+	height: 107px;
+}
+.g-sample-datagridlist-circle-imageitem img {
+	background-size: contain;
 
-		width: 82px;
-		height: 82px;
-		border-radius: 100%;
-		margin-top: 0.8px;
-	}
-	.g-sample-datagridlist-imageitem .caption{
-		width: 0;
-		height: 0;
-		overflow: hidden;
-	}
-	.g-sample-datagridlist-circle-imageitem .caption{
-		width: 92px;
-		height: 20px;
-		margin-top: 0;
-		margin-left: 15px;
-		margin-right: 15px;
+	width: 82px;
+	height: 82px;
+	border-radius: 100%;
+	margin-top: 0.8px;
+}
+.g-sample-datagridlist-imageitem .caption{
+	width: 0;
+	height: 0;
+	overflow: hidden;
+}
+.g-sample-datagridlist-circle-imageitem .caption{
+	width: 92px;
+	height: 20px;
+	margin-top: 0;
+	margin-left: 15px;
+	margin-right: 15px;
 
-		font-size: 18px;
-		color: #FAFAFA;
+	font-size: 18px;
+	color: #FAFAFA;
 
-		-webkit-mask-image: -webkit-linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
-		-webkit-mask-image: linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
-	}
-	.g-sample-datagridlist-imageitem.disabled {
-		opacity: 0.4;
+	-webkit-mask-image: -webkit-linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
+	-webkit-mask-image: linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
+}
+.g-sample-datagridlist-imageitem.disabled {
+	opacity: 0.4;
 
-		filter: alpha(opacity=40);
-	}
+	filter: alpha(opacity=40);
+}
 
-	/* GridList Imageitem */
-	.selection-enabled .g-sample-datagridlist-imageitem.g-selection-overlay-support.selected .g-icon-button {
-		background-position: 0 -325.8px;
+/* GridList Imageitem */
+.selection-enabled .g-sample-datagridlist-imageitem.g-selection-overlay-support.selected .g-icon-button {
+	background-position: 0 -325.8px;
 
-		margin-top: 0;
-		margin-left: 5px;
-		margin-right: 15px;
-	}
-	.g-sample-datagridlist-imageitem .g-selection-overlay-support-scrim .g-selection-overlay-support-checkbox {
-		position: absolute;
-		width: 107px;
-		height: 107px;
-		margin-top: 0;
-		margin-left: 0;
-	}
-	.selection-enabled .g-sample-datagridlist-circle-imageitem.g-selection-overlay-support.selected .g-icon-button {
-		background-position: 0 -331px;
+	margin-top: 0;
+	margin-left: 5px;
+	margin-right: 15px;
+}
+.g-sample-datagridlist-imageitem .g-selection-overlay-support-scrim .g-selection-overlay-support-checkbox {
+	position: absolute;
+	width: 107px;
+	height: 107px;
+	margin-top: 0;
+	margin-left: 0;
+}
+.selection-enabled .g-sample-datagridlist-circle-imageitem.g-selection-overlay-support.selected .g-icon-button {
+	background-position: 0 -331px;
 
-		margin-top: 0;
-		margin-left: 5px;
-		margin-right: 0;
-	}
-	.g-sample-datagridlist-circle-imageitem .g-selection-overlay-support-scrim .g-selection-overlay-support-checkbox {
-		position: absolute;
-		width: 107px;
-		height: 88px;
-		margin-top: 0;
-		margin-left: 0;
-	}
+	margin-top: 0;
+	margin-left: 5px;
+	margin-right: 0;
+}
+.g-sample-datagridlist-circle-imageitem .g-selection-overlay-support-scrim .g-selection-overlay-support-checkbox {
+	position: absolute;
+	width: 107px;
+	height: 88px;
+	margin-top: 0;
+	margin-left: 0;
+}
 }

--- a/garnet/src/DataGridListSample.less
+++ b/garnet/src/DataGridListSample.less
@@ -2,7 +2,7 @@
 
 // Common classes
 
-.g-sample-panel-margin {
+.g-sample-datagridlist .g-sample-panel-margin {
 	background-color: #000000;
 
 	position: relative;

--- a/garnet/src/DataGridListwithCardsSample.js
+++ b/garnet/src/DataGridListwithCardsSample.js
@@ -131,7 +131,7 @@ var DataGridListCardsCirclePanel = kind({
 
 module.exports = kind({
 	name: 'g.sample.DataGridListwithCardsSample',
-	classes: 'enyo-unselectable garnet g-sample',
+	classes: 'enyo-unselectable garnet g-sample g-sample-datagridlist-cards',
 	components: [
 		{content: '< Data Grid List with Cards Sample', classes: 'g-sample-header', ontap: 'goBack'},
 

--- a/garnet/src/DataGridListwithCardsSample.less
+++ b/garnet/src/DataGridListwithCardsSample.less
@@ -1,90 +1,90 @@
 /* DataGridListwithCardsSample */
 
 .g-sample-datagridlist-cards {
-	// Common classes
+// Common classes
 
-	.g-sample-panel-margin {
-		background-color: #000000;
+.g-sample-panel-margin {
+	background-color: #000000;
 
-		position: relative;
-		display: inline-block;
-		margin-right: 10px;
-		overflow: hidden;
-	}
-	.g-sample-panel-margin {
-		background-color: #000000;
+	position: relative;
+	display: inline-block;
+	margin-right: 10px;
+	overflow: hidden;
+}
+.g-sample-panel-margin {
+	background-color: #000000;
 
-		position: relative;
-		display: inline-block;
-		margin-right: 10px;
-		overflow: hidden;
-	}
-	.g-sample-circle-panel-margin {
-		background-color: #000000;
+	position: relative;
+	display: inline-block;
+	margin-right: 10px;
+	overflow: hidden;
+}
+.g-sample-circle-panel-margin {
+	background-color: #000000;
 
-		position: relative;
-		display: inline-block;
-		border-radius: 50%;
-		margin-right: 10px;
-		overflow: hidden;
-	}
+	position: relative;
+	display: inline-block;
+	border-radius: 50%;
+	margin-right: 10px;
+	overflow: hidden;
+}
 
-	// Sample specific classes
+// Sample specific classes
 
-	.g-sample-datagridlist-panel-card {
-		background-color: #000000;
+.g-sample-datagridlist-panel-card {
+	background-color: #000000;
 
-		width: 212px;
-		height: 320px;
-		padding-top: 6px;
-		margin: auto;
-	}
-	.g-sample-datagridlist-cards-imageitem.g-selection-overlay-support.item{
-		width: 212px;
-		height: 212px;
+	width: 212px;
+	height: 320px;
+	padding-top: 6px;
+	margin: auto;
+}
+.g-sample-datagridlist-cards-imageitem.g-selection-overlay-support.item{
+	width: 212px;
+	height: 212px;
 
-		text-align: center;
+	text-align: center;
 
-		cursor: pointer;
-	}
-	.g-sample-datagridlist-cards-imageitem.g-selection-overlay-support.item img {
-		width: 212px;
-		height: 212px;
-		margin-top: 0.8px;
-	}
-	.g-sample-datagridlist-cards-circle-imageitem.g-selection-overlay-support.item{
-		width: 212px;
-		height: 212px;
+	cursor: pointer;
+}
+.g-sample-datagridlist-cards-imageitem.g-selection-overlay-support.item img {
+	width: 212px;
+	height: 212px;
+	margin-top: 0.8px;
+}
+.g-sample-datagridlist-cards-circle-imageitem.g-selection-overlay-support.item{
+	width: 212px;
+	height: 212px;
 
-		text-align: center;
+	text-align: center;
 
-		cursor: pointer;
-	}
-	.g-sample-datagridlist-cards-circle-imageitem.g-selection-overlay-support.item img {
-		width: 212px;
-		height: 212px;
-		border-radius: 100%;
-	}
-	.g-sample-datagridlist-cards-circle-imageitem .caption{
-		width: 106px;
-		height: 22px;
-		margin-left: 54px;
-		margin-top: -3px;
+	cursor: pointer;
+}
+.g-sample-datagridlist-cards-circle-imageitem.g-selection-overlay-support.item img {
+	width: 212px;
+	height: 212px;
+	border-radius: 100%;
+}
+.g-sample-datagridlist-cards-circle-imageitem .caption{
+	width: 106px;
+	height: 22px;
+	margin-left: 54px;
+	margin-top: -3px;
 
-		font-size: 22px;
-		color: #FAFAFA;
+	font-size: 22px;
+	color: #FAFAFA;
 
-		-webkit-mask-image: -webkit-linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
-		-webkit-mask-image: linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
-	}
+	-webkit-mask-image: -webkit-linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
+	-webkit-mask-image: linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
+}
 
-	/* GridList Imageitem */
-	.selection-enabled .g-sample-datagridlist-cards-imageitem.g-selection-overlay-support.selected .g-icon-button {
-		background-position: 0 -96px;
-	}
-	.g-sample-datagridlist-cards-imageitem .g-selection-overlay-support-scrim .g-selection-overlay-support-checkbox {
-		position: absolute;
-		margin-top: 0;
-		margin-left: 0;
-	}
+/* GridList Imageitem */
+.selection-enabled .g-sample-datagridlist-cards-imageitem.g-selection-overlay-support.selected .g-icon-button {
+	background-position: 0 -96px;
+}
+.g-sample-datagridlist-cards-imageitem .g-selection-overlay-support-scrim .g-selection-overlay-support-checkbox {
+	position: absolute;
+	margin-top: 0;
+	margin-left: 0;
+}
 }

--- a/garnet/src/DataGridListwithCardsSample.less
+++ b/garnet/src/DataGridListwithCardsSample.less
@@ -2,7 +2,7 @@
 
 // Common classes
 
-.g-sample-panel-margin {
+.g-sample-datagridlist-cards .g-sample-panel-margin {
 	background-color: #000000;
 
 	position: relative;
@@ -10,7 +10,7 @@
 	margin-right: 10px;
 	overflow: hidden;
 }
-.g-sample-panel-margin {
+.g-sample-datagridlist-cards .g-sample-panel-margin {
 	background-color: #000000;
 
 	position: relative;

--- a/garnet/src/DataGridListwithCardsSample.less
+++ b/garnet/src/DataGridListwithCardsSample.less
@@ -1,79 +1,90 @@
 /* DataGridListwithCardsSample */
 
-// Common classes
+.g-sample-datagridlist-cards {
+	// Common classes
 
-.g-sample-datagridlist-cards .g-sample-panel-margin {
-	background-color: #000000;
+	.g-sample-panel-margin {
+		background-color: #000000;
 
-	position: relative;
-	display: inline-block;
-	margin-right: 10px;
-	overflow: hidden;
-}
-.g-sample-datagridlist-cards .g-sample-panel-margin {
-	background-color: #000000;
+		position: relative;
+		display: inline-block;
+		margin-right: 10px;
+		overflow: hidden;
+	}
+	.g-sample-panel-margin {
+		background-color: #000000;
 
-	position: relative;
-	display: inline-block;
-	margin-right: 10px;
-	overflow: hidden;
-}
+		position: relative;
+		display: inline-block;
+		margin-right: 10px;
+		overflow: hidden;
+	}
+	.g-sample-circle-panel-margin {
+		background-color: #000000;
 
-// Sample specific classes
+		position: relative;
+		display: inline-block;
+		border-radius: 50%;
+		margin-right: 10px;
+		overflow: hidden;
+	}
 
-.g-sample-datagridlist-panel-card {
-	background-color: #000000;
+	// Sample specific classes
 
-	width: 212px;
-	height: 320px;
-	padding-top: 6px;
-	margin: auto;
-}
-.g-sample-datagridlist-cards-imageitem.g-selection-overlay-support.item{
-	width: 212px;
-	height: 212px;
+	.g-sample-datagridlist-panel-card {
+		background-color: #000000;
 
-	text-align: center;
+		width: 212px;
+		height: 320px;
+		padding-top: 6px;
+		margin: auto;
+	}
+	.g-sample-datagridlist-cards-imageitem.g-selection-overlay-support.item{
+		width: 212px;
+		height: 212px;
 
-	cursor: pointer;
-}
-.g-sample-datagridlist-cards-imageitem.g-selection-overlay-support.item img {
-	width: 212px;
-	height: 212px;
-	margin-top: 0.8px;
-}
-.g-sample-datagridlist-cards-circle-imageitem.g-selection-overlay-support.item{
-	width: 212px;
-	height: 212px;
+		text-align: center;
 
-	text-align: center;
+		cursor: pointer;
+	}
+	.g-sample-datagridlist-cards-imageitem.g-selection-overlay-support.item img {
+		width: 212px;
+		height: 212px;
+		margin-top: 0.8px;
+	}
+	.g-sample-datagridlist-cards-circle-imageitem.g-selection-overlay-support.item{
+		width: 212px;
+		height: 212px;
 
-	cursor: pointer;
-}
-.g-sample-datagridlist-cards-circle-imageitem.g-selection-overlay-support.item img {
-	width: 212px;
-	height: 212px;
-	border-radius: 100%;
-}
-.g-sample-datagridlist-cards-circle-imageitem .caption{
-	width: 106px;
-	height: 22px;
-	margin-left: 54px;
-	margin-top: -3px;
+		text-align: center;
 
-	font-size: 22px;
-	color: #FAFAFA;
+		cursor: pointer;
+	}
+	.g-sample-datagridlist-cards-circle-imageitem.g-selection-overlay-support.item img {
+		width: 212px;
+		height: 212px;
+		border-radius: 100%;
+	}
+	.g-sample-datagridlist-cards-circle-imageitem .caption{
+		width: 106px;
+		height: 22px;
+		margin-left: 54px;
+		margin-top: -3px;
 
-	-webkit-mask-image: -webkit-linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
-	-webkit-mask-image: linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
-}
+		font-size: 22px;
+		color: #FAFAFA;
 
-/* GridList Imageitem */
-.selection-enabled .g-sample-datagridlist-cards-imageitem.g-selection-overlay-support.selected .g-icon-button {
-	background-position: 0 -96px;
-}
-.g-sample-datagridlist-cards-imageitem .g-selection-overlay-support-scrim .g-selection-overlay-support-checkbox {
-	position: absolute;
-	margin-top: 0;
-	margin-left: 0;
+		-webkit-mask-image: -webkit-linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
+		-webkit-mask-image: linear-gradient(right, rgba(0, 0, 0, 0), #FFFFFF 28px, #FFFFFF);
+	}
+
+	/* GridList Imageitem */
+	.selection-enabled .g-sample-datagridlist-cards-imageitem.g-selection-overlay-support.selected .g-icon-button {
+		background-position: 0 -96px;
+	}
+	.g-sample-datagridlist-cards-imageitem .g-selection-overlay-support-scrim .g-selection-overlay-support-checkbox {
+		position: absolute;
+		margin-top: 0;
+		margin-left: 0;
+	}
 }

--- a/garnet/src/DataListSample.js
+++ b/garnet/src/DataListSample.js
@@ -65,7 +65,7 @@ var DataListPanel = kind({
 
 var DataListSample = module.exports = kind({
 	name: 'g.sample.DataListSample',
-	classes: 'enyo-unselectable garnet g-sample',
+	classes: 'enyo-unselectable garnet g-sample g-sample-datalist',
 	components: [
 		{content: '< Data List Sample', classes: 'g-sample-header', ontap: 'goBack'},
 

--- a/garnet/src/DataListSample.less
+++ b/garnet/src/DataListSample.less
@@ -1,57 +1,57 @@
 /* DataListSample */
 
 .g-sample-datalist {
-	// Common classes
+// Common classes
 
-	.g-sample-panel {
-		background-color: #000000;
+.g-sample-panel {
+	background-color: #000000;
 
-		position: relative;
-		overflow: hidden;
-	}
+	position: relative;
+	overflow: hidden;
+}
 
-	// Sample specific classes
+// Sample specific classes
 
-	.g-sample-datalist-footer {
-		border-top: 3px solid #202328;
-	}
-	.g-sample-datalist-footer > .g-button {
-		width: 122px;
-		height: 60px;
-		margin: 10px 99px 9px;
-	}
-	.g-sample-datalist-item {
-		position: relative;
-		height: 134px;
-		overflow: hidden;
+.g-sample-datalist-footer {
+	border-top: 3px solid #202328;
+}
+.g-sample-datalist-footer > .g-button {
+	width: 122px;
+	height: 60px;
+	margin: 10px 99px 9px;
+}
+.g-sample-datalist-item {
+	position: relative;
+	height: 134px;
+	overflow: hidden;
 
-		cursor: pointer;
-	}
-	.g-sample-datalist-item-icon {
-		position: absolute;
-		width: 60px;
-		height: 60px;
-		margin: auto 0;
-		top: 0;
-		bottom: 0;
-		left: 38px;
-	}
-	.g-sample-datalist-item-title {
-		width: 170px;
-		height: 47px;
-		margin: 16px 0 0 112px;
+	cursor: pointer;
+}
+.g-sample-datalist-item-icon {
+	position: absolute;
+	width: 60px;
+	height: 60px;
+	margin: auto 0;
+	top: 0;
+	bottom: 0;
+	left: 38px;
+}
+.g-sample-datalist-item-title {
+	width: 170px;
+	height: 47px;
+	margin: 16px 0 0 112px;
 
-		color: #FFFFFF;
-		text-align: center;
-		font-size: 40px;
-	}
-	.g-sample-datalist-item-genre {
-		width: 170px;
-		height: 30px;
-		margin: 4px 0 0 112px;
+	color: #FFFFFF;
+	text-align: center;
+	font-size: 40px;
+}
+.g-sample-datalist-item-genre {
+	width: 170px;
+	height: 30px;
+	margin: 4px 0 0 112px;
 
-		color: #AFAFAF;
-		text-align: center;
-		font-size: 26px;
-	}
+	color: #AFAFAF;
+	text-align: center;
+	font-size: 26px;
+}
 }

--- a/garnet/src/DataListSample.less
+++ b/garnet/src/DataListSample.less
@@ -1,55 +1,57 @@
 /* DataListSample */
 
-// Common classes
+.g-sample-datalist {
+	// Common classes
 
-.g-sample-datalist .g-sample-panel {
-	background-color: #000000;
+	.g-sample-panel {
+		background-color: #000000;
 
-	position: relative;
-	overflow: hidden;
-}
+		position: relative;
+		overflow: hidden;
+	}
 
-// Sample specific classes
+	// Sample specific classes
 
-.g-sample-datalist-footer {
-	border-top: 3px solid #202328;
-}
-.g-sample-datalist-footer > .g-button {
-	width: 122px;
-	height: 60px;
-	margin: 10px 99px 9px;
-}
-.g-sample-datalist-item {
-	position: relative;
-	height: 134px;
-	overflow: hidden;
+	.g-sample-datalist-footer {
+		border-top: 3px solid #202328;
+	}
+	.g-sample-datalist-footer > .g-button {
+		width: 122px;
+		height: 60px;
+		margin: 10px 99px 9px;
+	}
+	.g-sample-datalist-item {
+		position: relative;
+		height: 134px;
+		overflow: hidden;
 
-	cursor: pointer;
-}
-.g-sample-datalist-item-icon {
-	position: absolute;
-	width: 60px;
-	height: 60px;
-	margin: auto 0;
-	top: 0;
-	bottom: 0;
-	left: 38px;
-}
-.g-sample-datalist-item-title {
-	width: 170px;
-	height: 47px;
-	margin: 16px 0 0 112px;
+		cursor: pointer;
+	}
+	.g-sample-datalist-item-icon {
+		position: absolute;
+		width: 60px;
+		height: 60px;
+		margin: auto 0;
+		top: 0;
+		bottom: 0;
+		left: 38px;
+	}
+	.g-sample-datalist-item-title {
+		width: 170px;
+		height: 47px;
+		margin: 16px 0 0 112px;
 
-	color: #FFFFFF;
-	text-align: center;
-	font-size: 40px;
-}
-.g-sample-datalist-item-genre {
-	width: 170px;
-	height: 30px;
-	margin: 4px 0 0 112px;
+		color: #FFFFFF;
+		text-align: center;
+		font-size: 40px;
+	}
+	.g-sample-datalist-item-genre {
+		width: 170px;
+		height: 30px;
+		margin: 4px 0 0 112px;
 
-	color: #AFAFAF;
-	text-align: center;
-	font-size: 26px;
+		color: #AFAFAF;
+		text-align: center;
+		font-size: 26px;
+	}
 }

--- a/garnet/src/DataListSample.less
+++ b/garnet/src/DataListSample.less
@@ -2,7 +2,7 @@
 
 // Common classes
 
-.g-sample-panel {
+.g-sample-datalist .g-sample-panel {
 	background-color: #000000;
 
 	position: relative;

--- a/garnet/src/DataListwithCardsSample.js
+++ b/garnet/src/DataListwithCardsSample.js
@@ -71,7 +71,7 @@ var DataListSmallCardsPanel = kind({
 
 module.exports = kind({
 	name: 'g.sample.DataListwithCardsSample',
-	classes: 'enyo-unselectable garnet g-sample',
+	classes: 'enyo-unselectable garnet g-sample g-sample-datalist-cards',
 	components: [
 		{content: '< Data List with Cards Sample', classes: 'g-sample-header', ontap: 'goBack'},
 

--- a/garnet/src/DataListwithCardsSample.less
+++ b/garnet/src/DataListwithCardsSample.less
@@ -1,67 +1,69 @@
 /* DataListwithCardsSample */
 
-// Common classes
+.g-sample-datalist-cards {
+	// Common classes
 
-.g-sample-datalist-cards .g-sample-panel-margin {
-	background-color: #000000;
+	.g-sample-panel-margin {
+		background-color: #000000;
 
-	position: relative;
-	display: inline-block;
-	margin-right: 10px;
-	overflow: hidden;
-}
-.g-sample-datalist-cards .g-sample-circle-panel-margin {
-	background-color: #000000;
+		position: relative;
+		display: inline-block;
+		margin-right: 10px;
+		overflow: hidden;
+	}
+	.g-sample-circle-panel-margin {
+		background-color: #000000;
 
-	position: relative;
-	display: inline-block;
-	border-radius: 50%;
-	margin-right: 10px;
-	overflow: hidden;
-}
-.g-sample-datalist-cards .g-sample-panels {
-	position: relative;
-	height: 100%;
-}
+		position: relative;
+		display: inline-block;
+		border-radius: 50%;
+		margin-right: 10px;
+		overflow: hidden;
+	}
+	.g-sample-panels {
+		position: relative;
+		height: 100%;
+	}
 
-// Sample specific classes
+	// Sample specific classes
 
-.g-sample-datalist-cards-list {
-	width: 240px;
-	height: 320px;
-	margin-left: 40px;
-}
-.g-sample-datalist-cards-list-header {
-	height: 70px;
-}
-.g-sample-datalist-cards-list-footer {
-	height: 34px;
-}
-.g-sample-datalist-cards-item {
-	height: 320px;
+	.g-sample-datalist-cards-list {
+		width: 240px;
+		height: 320px;
+		margin-left: 40px;
+	}
+	.g-sample-datalist-cards-list-header {
+		height: 70px;
+	}
+	.g-sample-datalist-cards-list-footer {
+		height: 34px;
+	}
+	.g-sample-datalist-cards-item {
+		height: 320px;
 
-	line-height: 320px;
-}
+		line-height: 320px;
+	}
 
-.g-sample-datalist-smallcards-item {
-	width: 240px;
-}
+	.g-sample-datalist-smallcards-item {
+		width: 240px;
+	}
 
-.g-sample-datalist-smallcards-item img {
-	display: block;
-	width: 184px;
-	height: 184px;
-	border-radius: 100%;
-	margin-left: auto;
-	margin-right: auto;
-	margin-top: 0.3px;
-}
+	.g-sample-datalist-smallcards-item img {
+		display: block;
+		width: 184px;
+		height: 184px;
+		border-radius: 100%;
+		margin-left: auto;
+		margin-right: auto;
+		margin-top: 0.3px;
+	}
 
-.g-sample-datalist-smallcards-title {
-	width: 240px;
-	height: 24px;
-	margin-bottom: 8px;
+	.g-sample-datalist-smallcards-title {
+		width: 240px;
+		height: 24px;
+		margin-bottom: 8px;
 
-	font-size: 24px;
-	text-align: center;
+		font-size: 24px;
+		text-align: center;
+	}
 }

--- a/garnet/src/DataListwithCardsSample.less
+++ b/garnet/src/DataListwithCardsSample.less
@@ -2,7 +2,7 @@
 
 // Common classes
 
-.g-sample-panel-margin {
+.g-sample-datalist-cards .g-sample-panel-margin {
 	background-color: #000000;
 
 	position: relative;
@@ -10,7 +10,7 @@
 	margin-right: 10px;
 	overflow: hidden;
 }
-.g-sample-circle-panel-margin {
+.g-sample-datalist-cards .g-sample-circle-panel-margin {
 	background-color: #000000;
 
 	position: relative;
@@ -19,7 +19,7 @@
 	margin-right: 10px;
 	overflow: hidden;
 }
-.g-sample-panels {
+.g-sample-datalist-cards .g-sample-panels {
 	position: relative;
 	height: 100%;
 }
@@ -61,7 +61,7 @@
 	width: 240px;
 	height: 24px;
 	margin-bottom: 8px;
-	
+
 	font-size: 24px;
 	text-align: center;
 }

--- a/garnet/src/DataListwithCardsSample.less
+++ b/garnet/src/DataListwithCardsSample.less
@@ -1,69 +1,69 @@
 /* DataListwithCardsSample */
 
 .g-sample-datalist-cards {
-	// Common classes
+// Common classes
 
-	.g-sample-panel-margin {
-		background-color: #000000;
+.g-sample-panel-margin {
+	background-color: #000000;
 
-		position: relative;
-		display: inline-block;
-		margin-right: 10px;
-		overflow: hidden;
-	}
-	.g-sample-circle-panel-margin {
-		background-color: #000000;
+	position: relative;
+	display: inline-block;
+	margin-right: 10px;
+	overflow: hidden;
+}
+.g-sample-circle-panel-margin {
+	background-color: #000000;
 
-		position: relative;
-		display: inline-block;
-		border-radius: 50%;
-		margin-right: 10px;
-		overflow: hidden;
-	}
-	.g-sample-panels {
-		position: relative;
-		height: 100%;
-	}
+	position: relative;
+	display: inline-block;
+	border-radius: 50%;
+	margin-right: 10px;
+	overflow: hidden;
+}
+.g-sample-panels {
+	position: relative;
+	height: 100%;
+}
 
-	// Sample specific classes
+// Sample specific classes
 
-	.g-sample-datalist-cards-list {
-		width: 240px;
-		height: 320px;
-		margin-left: 40px;
-	}
-	.g-sample-datalist-cards-list-header {
-		height: 70px;
-	}
-	.g-sample-datalist-cards-list-footer {
-		height: 34px;
-	}
-	.g-sample-datalist-cards-item {
-		height: 320px;
+.g-sample-datalist-cards-list {
+	width: 240px;
+	height: 320px;
+	margin-left: 40px;
+}
+.g-sample-datalist-cards-list-header {
+	height: 70px;
+}
+.g-sample-datalist-cards-list-footer {
+	height: 34px;
+}
+.g-sample-datalist-cards-item {
+	height: 320px;
 
-		line-height: 320px;
-	}
+	line-height: 320px;
+}
 
-	.g-sample-datalist-smallcards-item {
-		width: 240px;
-	}
+.g-sample-datalist-smallcards-item {
+	width: 240px;
+}
 
-	.g-sample-datalist-smallcards-item img {
-		display: block;
-		width: 184px;
-		height: 184px;
-		border-radius: 100%;
-		margin-left: auto;
-		margin-right: auto;
-		margin-top: 0.3px;
-	}
+.g-sample-datalist-smallcards-item img {
+	display: block;
+	width: 184px;
+	height: 184px;
+	border-radius: 100%;
+	margin-left: auto;
+	margin-right: auto;
+	margin-top: 0.3px;
+}
 
-	.g-sample-datalist-smallcards-title {
-		width: 240px;
-		height: 24px;
-		margin-bottom: 8px;
+.g-sample-datalist-smallcards-title {
+	width: 240px;
+	height: 24px;
+	margin-bottom: 8px;
 
-		font-size: 24px;
-		text-align: center;
-	}
+	font-size: 24px;
+	text-align: center;
+}
 }

--- a/garnet/src/DataListwithCheckboxesSample.js
+++ b/garnet/src/DataListwithCheckboxesSample.js
@@ -116,7 +116,7 @@ var CheckableDataListPanel = kind({
 
 module.exports = kind({
 	name: 'g.sample.DataListwithCheckboxesSample',
-	classes: 'enyo-unselectable garnet g-sample',
+	classes: 'enyo-unselectable garnet g-sample g-sample-datalist-checkboxes',
 	components: [
 		{content: '< Data List with Checkboxes Sample', classes: 'g-sample-header', ontap: 'goBack'},
 

--- a/garnet/src/DataListwithCheckboxesSample.less
+++ b/garnet/src/DataListwithCheckboxesSample.less
@@ -1,60 +1,60 @@
 /* DataListwithCheckboxesSample */
 
 .g-sample-datalist-checkboxes {
-	// Common classes
+// Common classes
 
-	.g-sample-panel {
-		background-color: #000000;
+.g-sample-panel {
+	background-color: #000000;
 
-		position: relative;
-		overflow: hidden;
-	}
-	.g-sample-result {
-		background-color: #EDEDED;
+	position: relative;
+	overflow: hidden;
+}
+.g-sample-result {
+	background-color: #EDEDED;
 
-		position: fixed;
-		width: 100%;
-		min-height: 160px;
-		bottom: 0;
-		z-index: 9999;
-		opacity: 0.8;
-	}
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
 
-	// Sample specific classes
+// Sample specific classes
 
-	/* Checkbox Item */
-	.g-sample-datalist-checkboxes-checkbox-item {
-		position: relative; /* Do not omit this. It's critical */
-		height: 134px;
-		overflow: hidden;
+/* Checkbox Item */
+.g-sample-datalist-checkboxes-checkbox-item {
+	position: relative; /* Do not omit this. It's critical */
+	height: 134px;
+	overflow: hidden;
 
-		line-height: 134px;
+	line-height: 134px;
 
-		cursor: pointer;
-	}
-	.g-sample-datalist-checkboxes-checkbox-item .checkbox-item-title {
-		width: 170px;
-		height: 134px;
-		margin: 0 38px 0 112px;
+	cursor: pointer;
+}
+.g-sample-datalist-checkboxes-checkbox-item .checkbox-item-title {
+	width: 170px;
+	height: 134px;
+	margin: 0 38px 0 112px;
 
-		color: #FFFFFF;
-		text-align: center;
-		font-size: 40px;
-	}
-	.g-sample-datalist-checkboxes-checkbox-item.disabled {
-		opacity: 0.4;
+	color: #FFFFFF;
+	text-align: center;
+	font-size: 40px;
+}
+.g-sample-datalist-checkboxes-checkbox-item.disabled {
+	opacity: 0.4;
 
-		filter: alpha(opacity=40);
-	}
-	/* This for always showing checkbox */
-	.g-selection-overlay-support-scrim {
-		display: inline;
-	}
-	.g-selection-overlay-support-scrim .g-icon-button {
-		margin-left: 0;
-		background-size: 100%;
-	}
-	.g-sample-datalist-checkboxes-checkbox-item.pressed-effect .g-selection-overlay-support-scrim .g-icon-button {
-		background-position: 0 -60px;
-	}
+	filter: alpha(opacity=40);
+}
+/* This for always showing checkbox */
+.g-selection-overlay-support-scrim {
+	display: inline;
+}
+.g-selection-overlay-support-scrim .g-icon-button {
+	margin-left: 0;
+	background-size: 100%;
+}
+.g-sample-datalist-checkboxes-checkbox-item.pressed-effect .g-selection-overlay-support-scrim .g-icon-button {
+	background-position: 0 -60px;
+}
 }

--- a/garnet/src/DataListwithCheckboxesSample.less
+++ b/garnet/src/DataListwithCheckboxesSample.less
@@ -2,13 +2,13 @@
 
 // Common classes
 
-.g-sample-panel {
+.g-sample-datalist-checkboxes .g-sample-panel {
 	background-color: #000000;
 
 	position: relative;
 	overflow: hidden;
 }
-.g-sample-result {
+.g-sample-datalist-checkboxes .g-sample-result {
 	background-color: #EDEDED;
 
 	position: fixed;

--- a/garnet/src/DataListwithCheckboxesSample.less
+++ b/garnet/src/DataListwithCheckboxesSample.less
@@ -1,58 +1,60 @@
 /* DataListwithCheckboxesSample */
 
-// Common classes
+.g-sample-datalist-checkboxes {
+	// Common classes
 
-.g-sample-datalist-checkboxes .g-sample-panel {
-	background-color: #000000;
+	.g-sample-panel {
+		background-color: #000000;
 
-	position: relative;
-	overflow: hidden;
-}
-.g-sample-datalist-checkboxes .g-sample-result {
-	background-color: #EDEDED;
+		position: relative;
+		overflow: hidden;
+	}
+	.g-sample-result {
+		background-color: #EDEDED;
 
-	position: fixed;
-	width: 100%;
-	min-height: 160px;
-	bottom: 0;
-	z-index: 9999;
-	opacity: 0.8;
-}
+		position: fixed;
+		width: 100%;
+		min-height: 160px;
+		bottom: 0;
+		z-index: 9999;
+		opacity: 0.8;
+	}
 
-// Sample specific classes
+	// Sample specific classes
 
-/* Checkbox Item */
-.g-sample-datalist-checkboxes-checkbox-item {
-	position: relative; /* Do not omit this. It's critical */
-	height: 134px;
-	overflow: hidden;
+	/* Checkbox Item */
+	.g-sample-datalist-checkboxes-checkbox-item {
+		position: relative; /* Do not omit this. It's critical */
+		height: 134px;
+		overflow: hidden;
 
-	line-height: 134px;
+		line-height: 134px;
 
-	cursor: pointer;
-}
-.g-sample-datalist-checkboxes-checkbox-item .checkbox-item-title {
-	width: 170px;
-	height: 134px;
-	margin: 0 38px 0 112px;
+		cursor: pointer;
+	}
+	.g-sample-datalist-checkboxes-checkbox-item .checkbox-item-title {
+		width: 170px;
+		height: 134px;
+		margin: 0 38px 0 112px;
 
-	color: #FFFFFF;
-	text-align: center;
-	font-size: 40px;
-}
-.g-sample-datalist-checkboxes-checkbox-item.disabled {
-	opacity: 0.4;
+		color: #FFFFFF;
+		text-align: center;
+		font-size: 40px;
+	}
+	.g-sample-datalist-checkboxes-checkbox-item.disabled {
+		opacity: 0.4;
 
-	filter: alpha(opacity=40);
-}
-/* This for always showing checkbox */
-.g-selection-overlay-support-scrim {
-	display: inline;
-}
-.g-selection-overlay-support-scrim .g-icon-button {
-	margin-left: 0;
-	background-size: 100%;
-}
-.g-sample-datalist-checkboxes-checkbox-item.pressed-effect .g-selection-overlay-support-scrim .g-icon-button {
-	background-position: 0 -60px;
+		filter: alpha(opacity=40);
+	}
+	/* This for always showing checkbox */
+	.g-selection-overlay-support-scrim {
+		display: inline;
+	}
+	.g-selection-overlay-support-scrim .g-icon-button {
+		margin-left: 0;
+		background-size: 100%;
+	}
+	.g-sample-datalist-checkboxes-checkbox-item.pressed-effect .g-selection-overlay-support-scrim .g-icon-button {
+		background-position: 0 -60px;
+	}
 }

--- a/garnet/src/DataListwithIconBadgeSample.js
+++ b/garnet/src/DataListwithIconBadgeSample.js
@@ -78,7 +78,7 @@ var IconBadgeDataListPanel = kind({
 
 module.exports = kind({
 	name: 'g.sample.DataListwithIconBadgeSample',
-	classes: 'enyo-unselectable garnet g-sample',
+	classes: 'enyo-unselectable garnet g-sample g-datalist-iconbadge',
 	components: [
 		{content: '< Data List with Icon Badge Sample', classes: 'g-sample-header', ontap: 'goBack'},
 

--- a/garnet/src/DataListwithIconBadgeSample.less
+++ b/garnet/src/DataListwithIconBadgeSample.less
@@ -1,57 +1,58 @@
 /* DataListwithIconBadgeSample */
 
+.g-datalist-iconbadge {
+	// Common classes
 
-// Common classes
+	.g-sample-panel {
+		background-color: #000000;
 
-.g-datalist-iconbadge .g-sample-panel {
-	background-color: #000000;
+		position: relative;
+		overflow: hidden;
+	}
 
-	position: relative;
-	overflow: hidden;
-}
+	// Sample specific classes
 
-// Sample specific classes
+	.g-datalist-iconbadge-item {
+		position: relative;
+		height: 134px;
+		overflow: hidden;
 
-.g-datalist-iconbadge-item {
-	position: relative;
-	height: 134px;
-	overflow: hidden;
+		cursor: pointer;
+	}
+	.g-datalist-iconbadge-item .icon-badge-item-icon {
+		position: absolute;
+		width: 60px;
+		height: 60px;
+		margin: auto 0;
+		top: 0;
+		bottom: 0;
+		left: 38px;
+	}
+	.g-datalist-iconbadge-item .icon-badge-item-new-icon {
+		position: absolute;
+		width: 16px;
+		height: 16px;
+		top: 0;
+		right: 0;
+	}
+	.g-datalist-iconbadge-item .icon-badge-item-info-icon {
+		position: absolute;
+		width: 16px;
+		height: 16px;
+		bottom: 0;
+		right: 0;
+	}
+	.g-datalist-iconbadge-item .icon-badge-item-title {
+		position: absolute;
+		width: 170px;
+		height: 47px;
+		top: 50%;
+		left: 112px;
 
-	cursor: pointer;
-}
-.g-datalist-iconbadge-item .icon-badge-item-icon {
-	position: absolute;
-	width: 60px;
-	height: 60px;
-	margin: auto 0;
-	top: 0;
-	bottom: 0;
-	left: 38px;
-}
-.g-datalist-iconbadge-item .icon-badge-item-new-icon {
-	position: absolute;
-	width: 16px;
-	height: 16px;
-	top: 0;
-	right: 0;
-}
-.g-datalist-iconbadge-item .icon-badge-item-info-icon {
-	position: absolute;
-	width: 16px;
-	height: 16px;
-	bottom: 0;
-	right: 0;
-}
-.g-datalist-iconbadge-item .icon-badge-item-title {
-	position: absolute;
-	width: 170px;
-	height: 47px;
-	top: 50%;
-	left: 112px;
+		transform: translateY(-50%);
 
-	transform: translateY(-50%);
-
-	color: #FFFFFF;
-	text-align: center;
-	font-size: 40px;
+		color: #FFFFFF;
+		text-align: center;
+		font-size: 40px;
+	}
 }

--- a/garnet/src/DataListwithIconBadgeSample.less
+++ b/garnet/src/DataListwithIconBadgeSample.less
@@ -3,7 +3,7 @@
 
 // Common classes
 
-.g-sample-panel {
+.g-datalist-iconbadge .g-sample-panel {
 	background-color: #000000;
 
 	position: relative;

--- a/garnet/src/DataListwithIconBadgeSample.less
+++ b/garnet/src/DataListwithIconBadgeSample.less
@@ -1,58 +1,58 @@
 /* DataListwithIconBadgeSample */
 
 .g-datalist-iconbadge {
-	// Common classes
+// Common classes
 
-	.g-sample-panel {
-		background-color: #000000;
+.g-sample-panel {
+	background-color: #000000;
 
-		position: relative;
-		overflow: hidden;
-	}
+	position: relative;
+	overflow: hidden;
+}
 
-	// Sample specific classes
+// Sample specific classes
 
-	.g-datalist-iconbadge-item {
-		position: relative;
-		height: 134px;
-		overflow: hidden;
+.g-datalist-iconbadge-item {
+	position: relative;
+	height: 134px;
+	overflow: hidden;
 
-		cursor: pointer;
-	}
-	.g-datalist-iconbadge-item .icon-badge-item-icon {
-		position: absolute;
-		width: 60px;
-		height: 60px;
-		margin: auto 0;
-		top: 0;
-		bottom: 0;
-		left: 38px;
-	}
-	.g-datalist-iconbadge-item .icon-badge-item-new-icon {
-		position: absolute;
-		width: 16px;
-		height: 16px;
-		top: 0;
-		right: 0;
-	}
-	.g-datalist-iconbadge-item .icon-badge-item-info-icon {
-		position: absolute;
-		width: 16px;
-		height: 16px;
-		bottom: 0;
-		right: 0;
-	}
-	.g-datalist-iconbadge-item .icon-badge-item-title {
-		position: absolute;
-		width: 170px;
-		height: 47px;
-		top: 50%;
-		left: 112px;
+	cursor: pointer;
+}
+.g-datalist-iconbadge-item .icon-badge-item-icon {
+	position: absolute;
+	width: 60px;
+	height: 60px;
+	margin: auto 0;
+	top: 0;
+	bottom: 0;
+	left: 38px;
+}
+.g-datalist-iconbadge-item .icon-badge-item-new-icon {
+	position: absolute;
+	width: 16px;
+	height: 16px;
+	top: 0;
+	right: 0;
+}
+.g-datalist-iconbadge-item .icon-badge-item-info-icon {
+	position: absolute;
+	width: 16px;
+	height: 16px;
+	bottom: 0;
+	right: 0;
+}
+.g-datalist-iconbadge-item .icon-badge-item-title {
+	position: absolute;
+	width: 170px;
+	height: 47px;
+	top: 50%;
+	left: 112px;
 
-		transform: translateY(-50%);
+	transform: translateY(-50%);
 
-		color: #FFFFFF;
-		text-align: center;
-		font-size: 40px;
-	}
+	color: #FFFFFF;
+	text-align: center;
+	font-size: 40px;
+}
 }

--- a/garnet/src/DataListwithRadioButtonsSample.js
+++ b/garnet/src/DataListwithRadioButtonsSample.js
@@ -107,7 +107,7 @@ var RadioDataListPanel = kind({
 
 module.exports = kind({
 	name: 'g.sample.DataListwithRadioButtonsSample',
-	classes: 'enyo-unselectable garnet g-sample',
+	classes: 'enyo-unselectable garnet g-sample g-sample-datalist-radiobuttons',
 	components: [
 		{content: '< DataList with Radio Buttons Sample', classes: 'g-sample-header', ontap: 'goBack'},
 

--- a/garnet/src/DataListwithRadioButtonsSample.less
+++ b/garnet/src/DataListwithRadioButtonsSample.less
@@ -2,13 +2,13 @@
 
 // Common classes
 
-.g-sample-panel {
+.g-sample-datalist-radiobuttons .g-sample-panel {
 	background-color: #000000;
 
 	position: relative;
 	overflow: hidden;
 }
-.g-sample-result {
+.g-sample-datalist-radiobuttons .g-sample-result {
 	background-color: #EDEDED;
 
 	position: fixed;

--- a/garnet/src/DataListwithRadioButtonsSample.less
+++ b/garnet/src/DataListwithRadioButtonsSample.less
@@ -1,70 +1,70 @@
 /* DataListwithRadioButtonsSample */
 
 .g-sample-datalist-radiobuttons {
-	// Common classes
+// Common classes
 
-	.g-sample-panel {
-		background-color: #000000;
+.g-sample-panel {
+	background-color: #000000;
 
-		position: relative;
-		overflow: hidden;
-	}
-	.g-sample-result {
-		background-color: #EDEDED;
+	position: relative;
+	overflow: hidden;
+}
+.g-sample-result {
+	background-color: #EDEDED;
 
-		position: fixed;
-		width: 100%;
-		min-height: 160px;
-		bottom: 0;
-		z-index: 9999;
-		opacity: 0.8;
-	}
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
 
-	// Sample specific classes
+// Sample specific classes
 
-	/* RadioButton Item */
-	.g-sample-datalist-radiobuttons-item {
-		position: relative; /* Do not omit this. It's critical */
-		height: 134px;
-		overflow: hidden;
+/* RadioButton Item */
+.g-sample-datalist-radiobuttons-item {
+	position: relative; /* Do not omit this. It's critical */
+	height: 134px;
+	overflow: hidden;
 
-		line-height: 134px;
+	line-height: 134px;
 
-		cursor: pointer;
-	}
-	.g-sample-datalist-radiobuttons-item .radiobutton-item-title {
-		width: 170px;
-		height: 134px;
-		margin: 0 112px 0 38px;
+	cursor: pointer;
+}
+.g-sample-datalist-radiobuttons-item .radiobutton-item-title {
+	width: 170px;
+	height: 134px;
+	margin: 0 112px 0 38px;
 
-		color: #FFFFFF;
-		text-align: center;
-		font-size: 40px;
-	}
-	.g-sample-datalist-radiobuttons-item.disabled {
-		opacity: 0.4;
+	color: #FFFFFF;
+	text-align: center;
+	font-size: 40px;
+}
+.g-sample-datalist-radiobuttons-item.disabled {
+	opacity: 0.4;
 
-		filter: alpha(opacity=40);
-	}
-	/* This for always showing radiobutton */
-	.g-selection-overlay-support-scrim {
-		display: inline;
-	}
-	/* This is to make radiobutton to draw image based on 'active' attribute not 'selected' */
-	.enyo-data-list .active {
-		overflow: inherit;
-	}
-	.g-selection-overlay-support-scrim .g-icon-button {
-		margin-left: 0;
-		background-size: 100%;
-	}
-	.g-selection-overlay-support.selected .g-icon-button {
-		background-position: 0 -180px;
-	}
-	.g-selection-overlay-support.active .g-icon-button {
-		background-position: 0 -180px;
-	}
-	.g-sample-datalist-radiobuttons-item.pressed-effect .g-selection-overlay-support-scrim .g-icon-button {
-		background-position: 0 -60px;
-	}
+	filter: alpha(opacity=40);
+}
+/* This for always showing radiobutton */
+.g-selection-overlay-support-scrim {
+	display: inline;
+}
+/* This is to make radiobutton to draw image based on 'active' attribute not 'selected' */
+.enyo-data-list .active {
+	overflow: inherit;
+}
+.g-selection-overlay-support-scrim .g-icon-button {
+	margin-left: 0;
+	background-size: 100%;
+}
+.g-selection-overlay-support.selected .g-icon-button {
+	background-position: 0 -180px;
+}
+.g-selection-overlay-support.active .g-icon-button {
+	background-position: 0 -180px;
+}
+.g-sample-datalist-radiobuttons-item.pressed-effect .g-selection-overlay-support-scrim .g-icon-button {
+	background-position: 0 -60px;
+}
 }

--- a/garnet/src/DataListwithRadioButtonsSample.less
+++ b/garnet/src/DataListwithRadioButtonsSample.less
@@ -1,68 +1,70 @@
 /* DataListwithRadioButtonsSample */
 
-// Common classes
+.g-sample-datalist-radiobuttons {
+	// Common classes
 
-.g-sample-datalist-radiobuttons .g-sample-panel {
-	background-color: #000000;
+	.g-sample-panel {
+		background-color: #000000;
 
-	position: relative;
-	overflow: hidden;
-}
-.g-sample-datalist-radiobuttons .g-sample-result {
-	background-color: #EDEDED;
+		position: relative;
+		overflow: hidden;
+	}
+	.g-sample-result {
+		background-color: #EDEDED;
 
-	position: fixed;
-	width: 100%;
-	min-height: 160px;
-	bottom: 0;
-	z-index: 9999;
-	opacity: 0.8;
-}
+		position: fixed;
+		width: 100%;
+		min-height: 160px;
+		bottom: 0;
+		z-index: 9999;
+		opacity: 0.8;
+	}
 
-// Sample specific classes
+	// Sample specific classes
 
-/* RadioButton Item */
-.g-sample-datalist-radiobuttons-item {
-	position: relative; /* Do not omit this. It's critical */
-	height: 134px;
-	overflow: hidden;
+	/* RadioButton Item */
+	.g-sample-datalist-radiobuttons-item {
+		position: relative; /* Do not omit this. It's critical */
+		height: 134px;
+		overflow: hidden;
 
-	line-height: 134px;
+		line-height: 134px;
 
-	cursor: pointer;
-}
-.g-sample-datalist-radiobuttons-item .radiobutton-item-title {
-	width: 170px;
-	height: 134px;
-	margin: 0 112px 0 38px;
+		cursor: pointer;
+	}
+	.g-sample-datalist-radiobuttons-item .radiobutton-item-title {
+		width: 170px;
+		height: 134px;
+		margin: 0 112px 0 38px;
 
-	color: #FFFFFF;
-	text-align: center;
-	font-size: 40px;
-}
-.g-sample-datalist-radiobuttons-item.disabled {
-	opacity: 0.4;
+		color: #FFFFFF;
+		text-align: center;
+		font-size: 40px;
+	}
+	.g-sample-datalist-radiobuttons-item.disabled {
+		opacity: 0.4;
 
-	filter: alpha(opacity=40);
-}
-/* This for always showing radiobutton */
-.g-selection-overlay-support-scrim {
-	display: inline;
-}
-/* This is to make radiobutton to draw image based on 'active' attribute not 'selected' */
-.enyo-data-list .active {
-	overflow: inherit;
-}
-.g-selection-overlay-support-scrim .g-icon-button {
-	margin-left: 0;
-	background-size: 100%;
-}
-.g-selection-overlay-support.selected .g-icon-button {
-	background-position: 0 -180px;
-}
-.g-selection-overlay-support.active .g-icon-button {
-	background-position: 0 -180px;
-}
-.g-sample-datalist-radiobuttons-item.pressed-effect .g-selection-overlay-support-scrim .g-icon-button {
-	background-position: 0 -60px;
+		filter: alpha(opacity=40);
+	}
+	/* This for always showing radiobutton */
+	.g-selection-overlay-support-scrim {
+		display: inline;
+	}
+	/* This is to make radiobutton to draw image based on 'active' attribute not 'selected' */
+	.enyo-data-list .active {
+		overflow: inherit;
+	}
+	.g-selection-overlay-support-scrim .g-icon-button {
+		margin-left: 0;
+		background-size: 100%;
+	}
+	.g-selection-overlay-support.selected .g-icon-button {
+		background-position: 0 -180px;
+	}
+	.g-selection-overlay-support.active .g-icon-button {
+		background-position: 0 -180px;
+	}
+	.g-sample-datalist-radiobuttons-item.pressed-effect .g-selection-overlay-support-scrim .g-icon-button {
+		background-position: 0 -60px;
+	}
 }

--- a/garnet/src/DatePickerPanelSample.js
+++ b/garnet/src/DatePickerPanelSample.js
@@ -13,7 +13,7 @@ var SampleDatePickerPanel = kind({
 
 module.exports = kind({
 	name: 'g.sample.DatePickerPanelSample',
-	classes: 'enyo-unselectable garnet g-sample',
+	classes: 'enyo-unselectable garnet g-sample g-sample-date-picker-panel',
 	components: [
 		{content: '< Date Picker Panel Sample', classes: 'g-sample-header', ontap: 'goBack'},
 

--- a/garnet/src/DatePickerPanelSample.less
+++ b/garnet/src/DatePickerPanelSample.less
@@ -1,20 +1,22 @@
 /* DatePickerPanelSample */
 
-// Common classes
+.g-sample-date-picker-panel {
+	// Common classes
 
-.g-sample-date-picker-panel .g-sample-panel {
-	background-color: #000000;
+	.g-sample-panel {
+		background-color: #000000;
 
-	position: relative;
-	overflow: hidden;
-}
-.g-sample-date-picker-panel .g-sample-result {
-	background-color: #EDEDED;
+		position: relative;
+		overflow: hidden;
+	}
+	.g-sample-result {
+		background-color: #EDEDED;
 
-	position: fixed;
-	width: 100%;
-	min-height: 160px;
-	bottom: 0;
-	z-index: 9999;
-	opacity: 0.8;
+		position: fixed;
+		width: 100%;
+		min-height: 160px;
+		bottom: 0;
+		z-index: 9999;
+		opacity: 0.8;
+	}
 }

--- a/garnet/src/DatePickerPanelSample.less
+++ b/garnet/src/DatePickerPanelSample.less
@@ -1,22 +1,22 @@
 /* DatePickerPanelSample */
 
 .g-sample-date-picker-panel {
-	// Common classes
+// Common classes
 
-	.g-sample-panel {
-		background-color: #000000;
+.g-sample-panel {
+	background-color: #000000;
 
-		position: relative;
-		overflow: hidden;
-	}
-	.g-sample-result {
-		background-color: #EDEDED;
+	position: relative;
+	overflow: hidden;
+}
+.g-sample-result {
+	background-color: #EDEDED;
 
-		position: fixed;
-		width: 100%;
-		min-height: 160px;
-		bottom: 0;
-		z-index: 9999;
-		opacity: 0.8;
-	}
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
 }

--- a/garnet/src/DatePickerPanelSample.less
+++ b/garnet/src/DatePickerPanelSample.less
@@ -2,13 +2,13 @@
 
 // Common classes
 
-.g-sample-panel {
+.g-sample-date-picker-panel .g-sample-panel {
 	background-color: #000000;
 
 	position: relative;
 	overflow: hidden;
 }
-.g-sample-result {
+.g-sample-date-picker-panel .g-sample-result {
 	background-color: #EDEDED;
 
 	position: fixed;

--- a/garnet/src/FormSample.js
+++ b/garnet/src/FormSample.js
@@ -383,7 +383,7 @@ module.exports = kind({
 	handlers: {
 		onResult: 'result'
 	},
-	classes: 'enyo-unselectable garnet g-sample',
+	classes: 'enyo-unselectable garnet g-sample g-sample-form',
 	components: [
 		{content: '< Form Sample', classes: 'g-sample-header', ontap: 'goBack'},
 

--- a/garnet/src/FormSample.less
+++ b/garnet/src/FormSample.less
@@ -1,47 +1,47 @@
 /* FormSample */
 
 .g-sample-form {
-	// Common classes
+// Common classes
 
-	.g-sample-panel-manager {
-		position: relative;
-		display: inline-block;
-		width: 320px;
-		height: 320px;
-	}
-	.g-sample-result {
-		background-color: #EDEDED;
+.g-sample-panel-manager {
+	position: relative;
+	display: inline-block;
+	width: 320px;
+	height: 320px;
+}
+.g-sample-result {
+	background-color: #EDEDED;
 
-		position: fixed;
-		width: 100%;
-		min-height: 160px;
-		bottom: 0;
-		z-index: 9999;
-		opacity: 0.8;
-	}
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
 
-	// Sample specific classes
+// Sample specific classes
 
-	.g-sample-form-title {
-		position: relative;
-	}
+.g-sample-form-title {
+	position: relative;
+}
 
-	.g-sample-form-button1 {
-		width: 118px;
-		margin-right: 4px;
+.g-sample-form-button1 {
+	width: 118px;
+	margin-right: 4px;
 
-		font-size: 20px;
-	}
-	.g-sample-form-button2 {
-		width: 120px;
+	font-size: 20px;
+}
+.g-sample-form-button2 {
+	width: 120px;
 
-		font-size: 20px;
-	}
-	.g-sample-form-input {
-		width: 185px;
-		margin-right: 6px;
-	}
-	.g-sample-form-footer {
-		height: 100px;
-	}
+	font-size: 20px;
+}
+.g-sample-form-input {
+	width: 185px;
+	margin-right: 6px;
+}
+.g-sample-form-footer {
+	height: 100px;
+}
 }

--- a/garnet/src/FormSample.less
+++ b/garnet/src/FormSample.less
@@ -2,13 +2,13 @@
 
 // Common classes
 
-.g-sample-panel-manager {
+.g-sample-form .g-sample-panel-manager {
 	position: relative;
 	display: inline-block;
 	width: 320px;
 	height: 320px;
 }
-.g-sample-result {
+.g-sample-form .g-sample-result {
 	background-color: #EDEDED;
 
 	position: fixed;

--- a/garnet/src/FormSample.less
+++ b/garnet/src/FormSample.less
@@ -1,45 +1,47 @@
 /* FormSample */
 
-// Common classes
+.g-sample-form {
+	// Common classes
 
-.g-sample-form .g-sample-panel-manager {
-	position: relative;
-	display: inline-block;
-	width: 320px;
-	height: 320px;
-}
-.g-sample-form .g-sample-result {
-	background-color: #EDEDED;
+	.g-sample-panel-manager {
+		position: relative;
+		display: inline-block;
+		width: 320px;
+		height: 320px;
+	}
+	.g-sample-result {
+		background-color: #EDEDED;
 
-	position: fixed;
-	width: 100%;
-	min-height: 160px;
-	bottom: 0;
-	z-index: 9999;
-	opacity: 0.8;
-}
+		position: fixed;
+		width: 100%;
+		min-height: 160px;
+		bottom: 0;
+		z-index: 9999;
+		opacity: 0.8;
+	}
 
-// Sample specific classes
+	// Sample specific classes
 
-.g-sample-form-title {
-	position: relative;
-}
+	.g-sample-form-title {
+		position: relative;
+	}
 
-.g-sample-form-button1 {
-	width: 118px;
-	margin-right: 4px;
+	.g-sample-form-button1 {
+		width: 118px;
+		margin-right: 4px;
 
-	font-size: 20px;
-}
-.g-sample-form-button2 {
-	width: 120px;
+		font-size: 20px;
+	}
+	.g-sample-form-button2 {
+		width: 120px;
 
-	font-size: 20px;
-}
-.g-sample-form-input {
-	width: 185px;
-	margin-right: 6px;
-}
-.g-sample-form-footer {
-	height: 100px;
+		font-size: 20px;
+	}
+	.g-sample-form-input {
+		width: 185px;
+		margin-right: 6px;
+	}
+	.g-sample-form-footer {
+		height: 100px;
+	}
 }

--- a/garnet/src/IconButtonSample.js
+++ b/garnet/src/IconButtonSample.js
@@ -41,7 +41,7 @@ var IconButtonPanel = kind({
 
 module.exports = kind({
 	name: 'g.sample.IconButtonSample',
-	classes: 'enyo-unselectable garnet g-sample',
+	classes: 'enyo-unselectable garnet g-sample g-sample-icon-button',
 	components: [
 		{content: '< Icon Button Sample', classes: 'g-sample-header', ontap: 'goBack'},
 

--- a/garnet/src/IconButtonSample.less
+++ b/garnet/src/IconButtonSample.less
@@ -1,36 +1,36 @@
 /* IconButtonSample */
 
 .g-sample-icon-button {
-	// Common classes
+// Common classes
 
-	.g-sample-circle-panel {
-		background-color: #000000;
+.g-sample-circle-panel {
+	background-color: #000000;
 
-		position: relative;
-		border-radius: 50%;
-		overflow: hidden;
-	}
-	.g-sample-result {
-		background-color: #EDEDED;
+	position: relative;
+	border-radius: 50%;
+	overflow: hidden;
+}
+.g-sample-result {
+	background-color: #EDEDED;
 
-		position: fixed;
-		width: 100%;
-		min-height: 160px;
-		bottom: 0;
-		z-index: 9999;
-		opacity: 0.8;
-	}
-	.g-sample-text {
-		display: inline-block;
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
+.g-sample-text {
+	display: inline-block;
 
-		font-size: 20px;
-		color: #FFFFFF;
-	}
+	font-size: 20px;
+	color: #FFFFFF;
+}
 
-	// Sample specific classes
+// Sample specific classes
 
-	.g-sample-icon-button-container {
-		width: 255px;
-		height: 230px;
-	}
+.g-sample-icon-button-container {
+	width: 255px;
+	height: 230px;
+}
 }

--- a/garnet/src/IconButtonSample.less
+++ b/garnet/src/IconButtonSample.less
@@ -1,34 +1,36 @@
 /* IconButtonSample */
 
-// Common classes
+.g-sample-icon-button {
+	// Common classes
 
-.g-sample-icon-button .g-sample-circle-panel {
-	background-color: #000000;
+	.g-sample-circle-panel {
+		background-color: #000000;
 
-	position: relative;
-	border-radius: 50%;
-	overflow: hidden;
-}
-.g-sample-icon-button .g-sample-result {
-	background-color: #EDEDED;
+		position: relative;
+		border-radius: 50%;
+		overflow: hidden;
+	}
+	.g-sample-result {
+		background-color: #EDEDED;
 
-	position: fixed;
-	width: 100%;
-	min-height: 160px;
-	bottom: 0;
-	z-index: 9999;
-	opacity: 0.8;
-}
-.g-sample-icon-button .g-sample-text {
-	display: inline-block;
+		position: fixed;
+		width: 100%;
+		min-height: 160px;
+		bottom: 0;
+		z-index: 9999;
+		opacity: 0.8;
+	}
+	.g-sample-text {
+		display: inline-block;
 
-	font-size: 20px;
-	color: #FFFFFF;
-}
+		font-size: 20px;
+		color: #FFFFFF;
+	}
 
-// Sample specific classes
+	// Sample specific classes
 
-.g-sample-icon-button-container {
-	width: 255px;
-	height: 230px;
+	.g-sample-icon-button-container {
+		width: 255px;
+		height: 230px;
+	}
 }

--- a/garnet/src/IconButtonSample.less
+++ b/garnet/src/IconButtonSample.less
@@ -2,14 +2,14 @@
 
 // Common classes
 
-.g-sample-circle-panel {
+.g-sample-icon-button .g-sample-circle-panel {
 	background-color: #000000;
 
 	position: relative;
 	border-radius: 50%;
 	overflow: hidden;
 }
-.g-sample-result {
+.g-sample-icon-button .g-sample-result {
 	background-color: #EDEDED;
 
 	position: fixed;
@@ -19,7 +19,7 @@
 	z-index: 9999;
 	opacity: 0.8;
 }
-.g-sample-text {
+.g-sample-icon-button .g-sample-text {
 	display: inline-block;
 
 	font-size: 20px;

--- a/garnet/src/IconSample.less
+++ b/garnet/src/IconSample.less
@@ -2,14 +2,14 @@
 
 // Common classes
 
-.g-sample-circle-panel {
+.g-sample-icon .g-sample-circle-panel {
 	background-color: #000000;
 
 	position: relative;
 	border-radius: 50%;
 	overflow: hidden;
 }
-.g-sample-text {
+.g-sample-icon .g-sample-text {
 	display: inline-block;
 
 	font-size: 20px;
@@ -30,6 +30,6 @@
 	height: 22px;
 }
 .g-sample-icon-container {
-	width: 255px; 
+	width: 255px;
 	height: 230px;
 }

--- a/garnet/src/IconSample.less
+++ b/garnet/src/IconSample.less
@@ -1,35 +1,37 @@
 /* IconSample */
 
-// Common classes
+.g-sample-icon {
+	// Common classes
 
-.g-sample-icon .g-sample-circle-panel {
-	background-color: #000000;
+	.g-sample-circle-panel {
+		background-color: #000000;
 
-	position: relative;
-	border-radius: 50%;
-	overflow: hidden;
-}
-.g-sample-icon .g-sample-text {
-	display: inline-block;
+		position: relative;
+		border-radius: 50%;
+		overflow: hidden;
+	}
+	.g-sample-text {
+		display: inline-block;
 
-	font-size: 20px;
-	color: #FFFFFF;
-}
+		font-size: 20px;
+		color: #FFFFFF;
+	}
 
-// Sample specific classes
+	// Sample specific classes
 
-.g-sample .g-sample-icon .g-icon {
-	margin-right: 10px;
-}
-.g-sample .g-sample-icon .g-sample-button-warning {
-	background-repeat: no-repeat;
-	background-size: 22px 22px;
-	background-color: black;
+	.g-sample .g-sample-icon .g-icon {
+		margin-right: 10px;
+	}
+	.g-sample .g-sample-icon .g-sample-button-warning {
+		background-repeat: no-repeat;
+		background-size: 22px 22px;
+		background-color: black;
 
-	width: 22px;
-	height: 22px;
-}
-.g-sample-icon-container {
-	width: 255px;
-	height: 230px;
+		width: 22px;
+		height: 22px;
+	}
+	.g-sample-icon-container {
+		width: 255px;
+		height: 230px;
+	}
 }

--- a/garnet/src/IconSample.less
+++ b/garnet/src/IconSample.less
@@ -1,37 +1,37 @@
 /* IconSample */
 
 .g-sample-icon {
-	// Common classes
+// Common classes
 
-	.g-sample-circle-panel {
-		background-color: #000000;
+.g-sample-circle-panel {
+	background-color: #000000;
 
-		position: relative;
-		border-radius: 50%;
-		overflow: hidden;
-	}
-	.g-sample-text {
-		display: inline-block;
+	position: relative;
+	border-radius: 50%;
+	overflow: hidden;
+}
+.g-sample-text {
+	display: inline-block;
 
-		font-size: 20px;
-		color: #FFFFFF;
-	}
+	font-size: 20px;
+	color: #FFFFFF;
+}
 
-	// Sample specific classes
+// Sample specific classes
 
-	.g-sample .g-sample-icon .g-icon {
-		margin-right: 10px;
-	}
-	.g-sample .g-sample-icon .g-sample-button-warning {
-		background-repeat: no-repeat;
-		background-size: 22px 22px;
-		background-color: black;
+.g-sample .g-sample-icon .g-icon {
+	margin-right: 10px;
+}
+.g-sample .g-sample-icon .g-sample-button-warning {
+	background-repeat: no-repeat;
+	background-size: 22px 22px;
+	background-color: black;
 
-		width: 22px;
-		height: 22px;
-	}
-	.g-sample-icon-container {
-		width: 255px;
-		height: 230px;
-	}
+	width: 22px;
+	height: 22px;
+}
+.g-sample-icon-container {
+	width: 255px;
+	height: 230px;
+}
 }

--- a/garnet/src/MultiPickerPanelSample.js
+++ b/garnet/src/MultiPickerPanelSample.js
@@ -111,7 +111,7 @@ var PanelManager = kind({
 
 module.exports = kind({
 	name: 'g.sample.MultiPickerPanelSample',
-	classes: 'enyo-unselectable garnet g-sample',
+	classes: 'enyo-unselectable garnet g-sample g-sample-multipicker-panel',
 	components: [
 		{content: '< MultiPickerPanel Sample', classes: 'g-sample-header', ontap: 'goBack'},
 

--- a/garnet/src/MultiPickerPanelSample.less
+++ b/garnet/src/MultiPickerPanelSample.less
@@ -1,28 +1,28 @@
 /* MultiPickerPanelSample */
 
 .g-sample-multipicker-panel {
-	// Common classes
+// Common classes
 
-	.g-sample-panel-manager {
-		position: relative;
-		display: inline-block;
-		width: 320px;
-		height: 320px;
-	}
-	.g-sample-result {
-		background-color: #EDEDED;
+.g-sample-panel-manager {
+	position: relative;
+	display: inline-block;
+	width: 320px;
+	height: 320px;
+}
+.g-sample-result {
+	background-color: #EDEDED;
 
-		position: fixed;
-		width: 100%;
-		min-height: 160px;
-		bottom: 0;
-		z-index: 9999;
-		opacity: 0.8;
-	}
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
 
-	// Sample specific classes
+// Sample specific classes
 
-	.g-sample-multipicker-panel-button {
-		top: 130px;
-	}
+.g-sample-multipicker-panel-button {
+	top: 130px;
+}
 }

--- a/garnet/src/MultiPickerPanelSample.less
+++ b/garnet/src/MultiPickerPanelSample.less
@@ -1,26 +1,28 @@
 /* MultiPickerPanelSample */
 
-// Common classes
+.g-sample-multipicker-panel {
+	// Common classes
 
-.g-sample-multipicker-panel .g-sample-panel-manager {
-	position: relative;
-	display: inline-block;
-	width: 320px;
-	height: 320px;
-}
-.g-sample-multipicker-panel .g-sample-result {
-	background-color: #EDEDED;
+	.g-sample-panel-manager {
+		position: relative;
+		display: inline-block;
+		width: 320px;
+		height: 320px;
+	}
+	.g-sample-result {
+		background-color: #EDEDED;
 
-	position: fixed;
-	width: 100%;
-	min-height: 160px;
-	bottom: 0;
-	z-index: 9999;
-	opacity: 0.8;
-}
+		position: fixed;
+		width: 100%;
+		min-height: 160px;
+		bottom: 0;
+		z-index: 9999;
+		opacity: 0.8;
+	}
 
-// Sample specific classes
+	// Sample specific classes
 
-.g-sample-multipicker-panel-button {
-	top: 130px;
+	.g-sample-multipicker-panel-button {
+		top: 130px;
+	}
 }

--- a/garnet/src/MultiPickerPanelSample.less
+++ b/garnet/src/MultiPickerPanelSample.less
@@ -2,13 +2,13 @@
 
 // Common classes
 
-.g-sample-panel-manager {
+.g-sample-multipicker-panel .g-sample-panel-manager {
 	position: relative;
 	display: inline-block;
 	width: 320px;
 	height: 320px;
 }
-.g-sample-result {
+.g-sample-multipicker-panel .g-sample-result {
 	background-color: #EDEDED;
 
 	position: fixed;

--- a/garnet/src/PickerPanelSample.js
+++ b/garnet/src/PickerPanelSample.js
@@ -94,7 +94,7 @@ var PanelManager = kind({
 
 module.exports = kind({
 	name: 'g.sample.PickerPanelSample',
-	classes: 'enyo-unselectable garnet g-sample',
+	classes: 'enyo-unselectable garnet g-sample g-sample-picker-panel',
 	components: [
 		{content: '< PickerPanel Sample', classes: 'g-sample-header', ontap: 'goBack'},
 

--- a/garnet/src/PickerPanelSample.less
+++ b/garnet/src/PickerPanelSample.less
@@ -1,34 +1,34 @@
 /* PickerPanelSample */
 
 .g-sample-picker-panel {
-	// Common classes
+// Common classes
 
-	.g-sample-panel {
-		background-color: #000000;
+.g-sample-panel {
+	background-color: #000000;
 
-		position: relative;
-		overflow: hidden;
-	}
-	.g-sample-panel-manager {
-		position: relative;
-		display: inline-block;
-		width: 320px;
-		height: 320px;
-	}
-	.g-sample-result {
-		background-color: #EDEDED;
+	position: relative;
+	overflow: hidden;
+}
+.g-sample-panel-manager {
+	position: relative;
+	display: inline-block;
+	width: 320px;
+	height: 320px;
+}
+.g-sample-result {
+	background-color: #EDEDED;
 
-		position: fixed;
-		width: 100%;
-		min-height: 160px;
-		bottom: 0;
-		z-index: 9999;
-		opacity: 0.8;
-	}
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
 
-	// Sample specific classes
+// Sample specific classes
 
-	.g-sample-picker-panel-button {
-		top: 130px;
-	}
+.g-sample-picker-panel-button {
+	top: 130px;
+}
 }

--- a/garnet/src/PickerPanelSample.less
+++ b/garnet/src/PickerPanelSample.less
@@ -2,19 +2,19 @@
 
 // Common classes
 
-.g-sample-panel {
+.g-sample-picker-panel .g-sample-panel {
 	background-color: #000000;
 
 	position: relative;
 	overflow: hidden;
 }
-.g-sample-panel-manager {
+.g-sample-picker-panel .g-sample-panel-manager {
 	position: relative;
 	display: inline-block;
 	width: 320px;
 	height: 320px;
 }
-.g-sample-result {
+.g-sample-picker-panel .g-sample-result {
 	background-color: #EDEDED;
 
 	position: fixed;

--- a/garnet/src/PickerPanelSample.less
+++ b/garnet/src/PickerPanelSample.less
@@ -1,32 +1,34 @@
 /* PickerPanelSample */
 
-// Common classes
+.g-sample-picker-panel {
+	// Common classes
 
-.g-sample-picker-panel .g-sample-panel {
-	background-color: #000000;
+	.g-sample-panel {
+		background-color: #000000;
 
-	position: relative;
-	overflow: hidden;
-}
-.g-sample-picker-panel .g-sample-panel-manager {
-	position: relative;
-	display: inline-block;
-	width: 320px;
-	height: 320px;
-}
-.g-sample-picker-panel .g-sample-result {
-	background-color: #EDEDED;
+		position: relative;
+		overflow: hidden;
+	}
+	.g-sample-panel-manager {
+		position: relative;
+		display: inline-block;
+		width: 320px;
+		height: 320px;
+	}
+	.g-sample-result {
+		background-color: #EDEDED;
 
-	position: fixed;
-	width: 100%;
-	min-height: 160px;
-	bottom: 0;
-	z-index: 9999;
-	opacity: 0.8;
-}
+		position: fixed;
+		width: 100%;
+		min-height: 160px;
+		bottom: 0;
+		z-index: 9999;
+		opacity: 0.8;
+	}
 
-// Sample specific classes
+	// Sample specific classes
 
-.g-sample-picker-panel-button {
-	top: 130px;
+	.g-sample-picker-panel-button {
+		top: 130px;
+	}
 }

--- a/garnet/src/PreventTapOnDragSample.js
+++ b/garnet/src/PreventTapOnDragSample.js
@@ -4,7 +4,7 @@ var kind = require('enyo/kind');
 
 module.exports = kind({
 	name: 'g.sample.PreventTapOnDragSample',
-	classes: 'enyo-unselectable garnet g-sample',
+	classes: 'enyo-unselectable garnet g-sample g-sample-prevent-tap-on-drag',
 	components: [
 		{content: '< Prevent Tap On Drag Sample', classes: 'g-sample-header', ontap: 'goBack'},
 

--- a/garnet/src/ProgressBarSample.js
+++ b/garnet/src/ProgressBarSample.js
@@ -47,7 +47,7 @@ var ProgressBarPanel = kind({
 
 module.exports = kind({
 	name: 'g.sample.ProgressBarSample',
-	classes: 'enyo-unselectable garnet g-sample',
+	classes: 'enyo-unselectable garnet g-sample g-sample-progressbar',
 	components: [
 		{content: '< Progress Bar Sample', classes: 'g-sample-header', ontap: 'goBack'},
 

--- a/garnet/src/ProgressBarSample.less
+++ b/garnet/src/ProgressBarSample.less
@@ -1,44 +1,44 @@
 /* ProgressBarSample */
 
 .g-sample-progressbar {
-	// Common classes
+// Common classes
 
-	.g-sample-circle-panel {
-		background-color: #000000;
+.g-sample-circle-panel {
+	background-color: #000000;
 
-		position: relative;
-		border-radius: 50%;
-		overflow: hidden;
-	}
+	position: relative;
+	border-radius: 50%;
+	overflow: hidden;
+}
 
-	// Sample specific classes
+// Sample specific classes
 
-	.g-sample-progressbar-header {
-		width: 100%;
-		height: 50px;
-	}
-	.g-sample-progressbar-progressbar1 {
-		margin: 10px 18px 12px;
-	}
-	.g-sample-progressbar-progressbar2 {
-		margin: 10px 18px 12px;
-	}
-	.g-sample-probressbar-tooldecorator {
-		text-align: center;
-	}
-	.g-sample-form-input {
-		width: 150px;
-		margin-right: 10px;
-	}
-	.g-sample-form-value {
-		width: 80px;
-	}
-	.g-sample-form-button-minus {
-		width: 70px;
-		margin: 0 4px 0 45px;
-	}
-	.g-sample-form-button-plus {
-		width: 70px;
-		margin-right: 45px;
-	}
+.g-sample-progressbar-header {
+	width: 100%;
+	height: 50px;
+}
+.g-sample-progressbar-progressbar1 {
+	margin: 10px 18px 12px;
+}
+.g-sample-progressbar-progressbar2 {
+	margin: 10px 18px 12px;
+}
+.g-sample-probressbar-tooldecorator {
+	text-align: center;
+}
+.g-sample-form-input {
+	width: 150px;
+	margin-right: 10px;
+}
+.g-sample-form-value {
+	width: 80px;
+}
+.g-sample-form-button-minus {
+	width: 70px;
+	margin: 0 4px 0 45px;
+}
+.g-sample-form-button-plus {
+	width: 70px;
+	margin-right: 45px;
+}
 }

--- a/garnet/src/ProgressBarSample.less
+++ b/garnet/src/ProgressBarSample.less
@@ -2,7 +2,7 @@
 
 // Common classes
 
-.g-sample-circle-panel {
+.g-sample-progressbar .g-sample-circle-panel {
 	background-color: #000000;
 
 	position: relative;

--- a/garnet/src/ProgressBarSample.less
+++ b/garnet/src/ProgressBarSample.less
@@ -1,42 +1,44 @@
 /* ProgressBarSample */
 
-// Common classes
+.g-sample-progressbar {
+	// Common classes
 
-.g-sample-progressbar .g-sample-circle-panel {
-	background-color: #000000;
+	.g-sample-circle-panel {
+		background-color: #000000;
 
-	position: relative;
-	border-radius: 50%;
-	overflow: hidden;
-}
+		position: relative;
+		border-radius: 50%;
+		overflow: hidden;
+	}
 
-// Sample specific classes
+	// Sample specific classes
 
-.g-sample-progressbar-header {
-	width: 100%;
-	height: 50px;
-}
-.g-sample-progressbar-progressbar1 {
-	margin: 10px 18px 12px;
-}
-.g-sample-progressbar-progressbar2 {
-	margin: 10px 18px 12px;
-}
-.g-sample-probressbar-tooldecorator {
-	text-align: center;
-}
-.g-sample-form-input {
-	width: 150px;
-	margin-right: 10px;
-}
-.g-sample-form-value {
-	width: 80px;
-}
-.g-sample-form-button-minus {
-	width: 70px;
-	margin: 0 4px 0 45px;
-}
-.g-sample-form-button-plus {
-	width: 70px;
-	margin-right: 45px;
+	.g-sample-progressbar-header {
+		width: 100%;
+		height: 50px;
+	}
+	.g-sample-progressbar-progressbar1 {
+		margin: 10px 18px 12px;
+	}
+	.g-sample-progressbar-progressbar2 {
+		margin: 10px 18px 12px;
+	}
+	.g-sample-probressbar-tooldecorator {
+		text-align: center;
+	}
+	.g-sample-form-input {
+		width: 150px;
+		margin-right: 10px;
+	}
+	.g-sample-form-value {
+		width: 80px;
+	}
+	.g-sample-form-button-minus {
+		width: 70px;
+		margin: 0 4px 0 45px;
+	}
+	.g-sample-form-button-plus {
+		width: 70px;
+		margin-right: 45px;
+	}
 }

--- a/garnet/src/SpinnerSample.js
+++ b/garnet/src/SpinnerSample.js
@@ -25,7 +25,7 @@ var TextSpinnerPanel = kind({
 
 module.exports = kind({
 	name: 'g.sample.SpinnerSample',
-	classes: 'enyo-unselectable garnet g-sample',
+	classes: 'enyo-unselectable garnet g-sample g-sample-spinner',
 	components: [
 		{content: '< Spinner Sample', classes: 'g-sample-header', ontap: 'goBack'},
 

--- a/garnet/src/SpinnerSample.less
+++ b/garnet/src/SpinnerSample.less
@@ -1,32 +1,32 @@
 /* SpinnerSample */
 
 .g-sample-spinner {
-	// Common classes
+// Common classes
 
-	.g-sample-circle-panel-margin {
-		background-color: #000000;
+.g-sample-circle-panel-margin {
+	background-color: #000000;
 
-		position: relative;
-		display: inline-block;
-		border-radius: 50%;
-		margin-right: 10px;
-		overflow: hidden;
-	}
-	.g-sample-panels {
-		position: relative;
-		height: 100%;
-	}
+	position: relative;
+	display: inline-block;
+	border-radius: 50%;
+	margin-right: 10px;
+	overflow: hidden;
+}
+.g-sample-panels {
+	position: relative;
+	height: 100%;
+}
 
-	// Sample specific classes
+// Sample specific classes
 
-	.g-sample-spinner-container {
-		width: 244px;
-		height: 110px;
-	}
-	.g-sample-spinner-width {
-		width: 100%
-	}
-	.g-sample-spinner-text-spinner {
-		position: absolute;
-	}
+.g-sample-spinner-container {
+	width: 244px;
+	height: 110px;
+}
+.g-sample-spinner-width {
+	width: 100%
+}
+.g-sample-spinner-text-spinner {
+	position: absolute;
+}
 }

--- a/garnet/src/SpinnerSample.less
+++ b/garnet/src/SpinnerSample.less
@@ -1,30 +1,32 @@
 /* SpinnerSample */
 
-// Common classes
+.g-sample-spinner {
+	// Common classes
 
-.g-sample-spinner .g-sample-circle-panel-margin {
-	background-color: #000000;
+	.g-sample-circle-panel-margin {
+		background-color: #000000;
 
-	position: relative;
-	display: inline-block;
-	border-radius: 50%;
-	margin-right: 10px;
-	overflow: hidden;
-}
-.g-sample-spinner .g-sample-panels {
-	position: relative;
-	height: 100%;
-}
+		position: relative;
+		display: inline-block;
+		border-radius: 50%;
+		margin-right: 10px;
+		overflow: hidden;
+	}
+	.g-sample-panels {
+		position: relative;
+		height: 100%;
+	}
 
-// Sample specific classes
+	// Sample specific classes
 
-.g-sample-spinner-container {
-	width: 244px;
-	height: 110px;
-}
-.g-sample-spinner-width {
-	width: 100%
-}
-.g-sample-spinner-text-spinner {
-	position: absolute;
+	.g-sample-spinner-container {
+		width: 244px;
+		height: 110px;
+	}
+	.g-sample-spinner-width {
+		width: 100%
+	}
+	.g-sample-spinner-text-spinner {
+		position: absolute;
+	}
 }

--- a/garnet/src/SpinnerSample.less
+++ b/garnet/src/SpinnerSample.less
@@ -2,7 +2,7 @@
 
 // Common classes
 
-.g-sample-circle-panel-margin {
+.g-sample-spinner .g-sample-circle-panel-margin {
 	background-color: #000000;
 
 	position: relative;
@@ -11,7 +11,7 @@
 	margin-right: 10px;
 	overflow: hidden;
 }
-.g-sample-panels {
+.g-sample-spinner .g-sample-panels {
 	position: relative;
 	height: 100%;
 }

--- a/garnet/src/TimePickerPanelSample.js
+++ b/garnet/src/TimePickerPanelSample.js
@@ -25,7 +25,7 @@ module.exports = kind({
 	handlers: {
 		onResult: 'result'
 	},
-	classes: 'enyo-unselectable garnet g-sample',
+	classes: 'enyo-unselectable garnet g-sample g-sample-time-picker-panel',
 	components: [
 		{content: '< Time Picker Panel Sample', classes: 'g-sample-header', ontap: 'goBack'},
 

--- a/garnet/src/TimePickerPanelSample.less
+++ b/garnet/src/TimePickerPanelSample.less
@@ -1,25 +1,27 @@
 /* TimePickerPanelSample */
 
-// Common classes
+.g-sample-time-picker-panel {
+	// Common classes
 
-.g-sample-time-picker-panel .g-sample-panels {
-	position: relative;
-	height: 100%;
-}
-.g-sample-time-picker-panel .g-sample-panel-margin {
-	background-color: #000000;
+	.g-sample-panels {
+		position: relative;
+		height: 100%;
+	}
+	.g-sample-panel-margin {
+		background-color: #000000;
 
-	position: relative;
-	display: inline-block;
-	margin-right: 10px;
-	overflow: hidden;
-}
-.g-sample-time-picker-panel .g-sample-result {
-	background-color: #EDEDED;
-	position: fixed;
-	width: 100%;
-	min-height: 160px;
-	bottom: 0;
-	z-index: 9999;
-	opacity: 0.8;
+		position: relative;
+		display: inline-block;
+		margin-right: 10px;
+		overflow: hidden;
+	}
+	.g-sample-result {
+		background-color: #EDEDED;
+		position: fixed;
+		width: 100%;
+		min-height: 160px;
+		bottom: 0;
+		z-index: 9999;
+		opacity: 0.8;
+	}
 }

--- a/garnet/src/TimePickerPanelSample.less
+++ b/garnet/src/TimePickerPanelSample.less
@@ -1,27 +1,27 @@
 /* TimePickerPanelSample */
 
 .g-sample-time-picker-panel {
-	// Common classes
+// Common classes
 
-	.g-sample-panels {
-		position: relative;
-		height: 100%;
-	}
-	.g-sample-panel-margin {
-		background-color: #000000;
+.g-sample-panels {
+	position: relative;
+	height: 100%;
+}
+.g-sample-panel-margin {
+	background-color: #000000;
 
-		position: relative;
-		display: inline-block;
-		margin-right: 10px;
-		overflow: hidden;
-	}
-	.g-sample-result {
-		background-color: #EDEDED;
-		position: fixed;
-		width: 100%;
-		min-height: 160px;
-		bottom: 0;
-		z-index: 9999;
-		opacity: 0.8;
-	}
+	position: relative;
+	display: inline-block;
+	margin-right: 10px;
+	overflow: hidden;
+}
+.g-sample-result {
+	background-color: #EDEDED;
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
 }

--- a/garnet/src/TimePickerPanelSample.less
+++ b/garnet/src/TimePickerPanelSample.less
@@ -2,11 +2,11 @@
 
 // Common classes
 
-.g-sample-panels {
+.g-sample-time-picker-panel .g-sample-panels {
 	position: relative;
 	height: 100%;
 }
-.g-sample-panel-margin {
+.g-sample-time-picker-panel .g-sample-panel-margin {
 	background-color: #000000;
 
 	position: relative;
@@ -14,7 +14,7 @@
 	margin-right: 10px;
 	overflow: hidden;
 }
-.g-sample-result {
+.g-sample-time-picker-panel .g-sample-result {
 	background-color: #EDEDED;
 	position: fixed;
 	width: 100%;

--- a/garnet/src/TitleSample.js
+++ b/garnet/src/TitleSample.js
@@ -41,7 +41,7 @@ var TitlePanel = kind({
 
 module.exports = kind({
 	name: 'g.sample.TitleSample',
-	classes: 'enyo-unselectable garnet g-sample',
+	classes: 'enyo-unselectable garnet g-sample g-sample-title',
 	components: [
 		{content: '< Title ( + BodyText ) Sample', classes: 'g-sample-header', ontap: 'goBack'},
 

--- a/garnet/src/TitleSample.less
+++ b/garnet/src/TitleSample.less
@@ -1,31 +1,33 @@
 /* TitleSample */
 
-// Common classes
+.g-sample-title {
+	// Common classes
 
-.g-sample-title .g-sample-panel {
-	background-color: #000000;
+	.g-sample-panel {
+		background-color: #000000;
 
-	position: relative;
-	overflow: hidden;
-}
-.g-sample-title .g-sample-result {
-	background-color: #EDEDED;
+		position: relative;
+		overflow: hidden;
+	}
+	.g-sample-result {
+		background-color: #EDEDED;
 
-	position: fixed;
-	width: 100%;
-	min-height: 160px;
-	bottom: 0;
-	z-index: 9999;
-	opacity: 0.8;
-}
+		position: fixed;
+		width: 100%;
+		min-height: 160px;
+		bottom: 0;
+		z-index: 9999;
+		opacity: 0.8;
+	}
 
-// Sample specific classes
+	// Sample specific classes
 
-.g-sample-title-content {
-	width: 200px;
-	margin: auto;
-	padding-top: 90px;
-}
-.g-sample-title-button {
-	margin: 20px 0 70px;
+	.g-sample-title-content {
+		width: 200px;
+		margin: auto;
+		padding-top: 90px;
+	}
+	.g-sample-title-button {
+		margin: 20px 0 70px;
+	}
 }

--- a/garnet/src/TitleSample.less
+++ b/garnet/src/TitleSample.less
@@ -1,33 +1,33 @@
 /* TitleSample */
 
 .g-sample-title {
-	// Common classes
+// Common classes
 
-	.g-sample-panel {
-		background-color: #000000;
+.g-sample-panel {
+	background-color: #000000;
 
-		position: relative;
-		overflow: hidden;
-	}
-	.g-sample-result {
-		background-color: #EDEDED;
+	position: relative;
+	overflow: hidden;
+}
+.g-sample-result {
+	background-color: #EDEDED;
 
-		position: fixed;
-		width: 100%;
-		min-height: 160px;
-		bottom: 0;
-		z-index: 9999;
-		opacity: 0.8;
-	}
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
 
-	// Sample specific classes
+// Sample specific classes
 
-	.g-sample-title-content {
-		width: 200px;
-		margin: auto;
-		padding-top: 90px;
-	}
-	.g-sample-title-button {
-		margin: 20px 0 70px;
-	}
+.g-sample-title-content {
+	width: 200px;
+	margin: auto;
+	padding-top: 90px;
+}
+.g-sample-title-button {
+	margin: 20px 0 70px;
+}
 }

--- a/garnet/src/TitleSample.less
+++ b/garnet/src/TitleSample.less
@@ -2,13 +2,13 @@
 
 // Common classes
 
-.g-sample-panel {
+.g-sample-title .g-sample-panel {
 	background-color: #000000;
 
 	position: relative;
 	overflow: hidden;
 }
-.g-sample-result {
+.g-sample-title .g-sample-result {
 	background-color: #EDEDED;
 
 	position: fixed;

--- a/garnet/src/ToastPanelSample.js
+++ b/garnet/src/ToastPanelSample.js
@@ -53,7 +53,7 @@ var PanelManager = kind({
 
 module.exports = kind({
 	name: 'g.sample.ToastPanelSample',
-	classes: 'enyo-unselectable garnet g-sample',
+	classes: 'enyo-unselectable garnet g-sample g-sample-toast-panel',
 	components: [
 		{content: '< Toast Panel Sample', classes: 'g-sample-header', ontap: 'goBack'},
 

--- a/garnet/src/ToastPanelSample.less
+++ b/garnet/src/ToastPanelSample.less
@@ -2,7 +2,7 @@
 
 // Common classes
 
-.g-sample-panel-manager {
+.g-sample-toast-panel .g-sample-panel-manager {
 	position: relative;
 	display: inline-block;
 	width: 320px;

--- a/garnet/src/ToastPanelSample.less
+++ b/garnet/src/ToastPanelSample.less
@@ -1,20 +1,20 @@
 /* ToastPanelSample */
 
 .g-sample-toast-panel {
-	// Common classes
+// Common classes
 
-	.g-sample-panel-manager {
-		position: relative;
-		display: inline-block;
-		width: 320px;
-		height: 320px;
-	}
+.g-sample-panel-manager {
+	position: relative;
+	display: inline-block;
+	width: 320px;
+	height: 320px;
+}
 
-	// Sample specific classes
+// Sample specific classes
 
-	.g-sample-toast-panel-container {
-		position: absolute;
-		width: 310px;
-		margin: auto;
-	}
+.g-sample-toast-panel-container {
+	position: absolute;
+	width: 310px;
+	margin: auto;
+}
 }

--- a/garnet/src/ToastPanelSample.less
+++ b/garnet/src/ToastPanelSample.less
@@ -1,18 +1,20 @@
 /* ToastPanelSample */
 
-// Common classes
+.g-sample-toast-panel {
+	// Common classes
 
-.g-sample-toast-panel .g-sample-panel-manager {
-	position: relative;
-	display: inline-block;
-	width: 320px;
-	height: 320px;
-}
+	.g-sample-panel-manager {
+		position: relative;
+		display: inline-block;
+		width: 320px;
+		height: 320px;
+	}
 
-// Sample specific classes
+	// Sample specific classes
 
-.g-sample-toast-panel-container {
-	position: absolute;
-	width: 310px;
-	margin: auto;
+	.g-sample-toast-panel-container {
+		position: absolute;
+		width: 310px;
+		margin: auto;
+	}
 }

--- a/garnet/src/ToggleButtonSample.js
+++ b/garnet/src/ToggleButtonSample.js
@@ -34,7 +34,7 @@ var ToggleButtonPanel = kind({
 
 module.exports = kind({
 	name: 'g.sample.ToggleButtonSample',
-	classes: 'enyo-unselectable garnet g-sample',
+	classes: 'enyo-unselectable garnet g-sample g-sample-toggle-button',
 	components: [
 		{content: '< Toggle Button Sample', classes: 'g-sample-header', ontap: 'goBack'},
 

--- a/garnet/src/ToggleButtonSample.less
+++ b/garnet/src/ToggleButtonSample.less
@@ -1,34 +1,34 @@
 /* ToggleButtonSample */
 
 .g-sample-toggle-button {
-	// Common classes
+// Common classes
 
-	.g-sample-circle-panel {
-		background-color: #000000;
-		position: relative;
-		border-radius: 50%;
-		overflow: hidden;
-	}
-	.g-sample-result {
-		background-color: #EDEDED;
-		position: fixed;
-		width: 100%;
-		min-height: 160px;
-		bottom: 0;
-		z-index: 9999;
-		opacity: 0.8;
-	}
-	.g-sample-text {
-		display: inline-block;
+.g-sample-circle-panel {
+	background-color: #000000;
+	position: relative;
+	border-radius: 50%;
+	overflow: hidden;
+}
+.g-sample-result {
+	background-color: #EDEDED;
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
+.g-sample-text {
+	display: inline-block;
 
-		font-size: 20px;
-		color: #FFFFFF;
-	}
+	font-size: 20px;
+	color: #FFFFFF;
+}
 
-	// Sample specific classes
+// Sample specific classes
 
-	.g-sample-toggle-button-container {
-		width: 280px;
-		height: 230px;
-	}
+.g-sample-toggle-button-container {
+	width: 280px;
+	height: 230px;
+}
 }

--- a/garnet/src/ToggleButtonSample.less
+++ b/garnet/src/ToggleButtonSample.less
@@ -1,32 +1,34 @@
 /* ToggleButtonSample */
 
-// Common classes
+.g-sample-toggle-button {
+	// Common classes
 
-.g-sample-toggle-button .g-sample-circle-panel {
-	background-color: #000000;
-	position: relative;
-	border-radius: 50%;
-	overflow: hidden;
-}
-.g-sample-toggle-button .g-sample-result {
-	background-color: #EDEDED;
-	position: fixed;
-	width: 100%;
-	min-height: 160px;
-	bottom: 0;
-	z-index: 9999;
-	opacity: 0.8;
-}
-.g-sample-toggle-button .g-sample-text {
-	display: inline-block;
+	.g-sample-circle-panel {
+		background-color: #000000;
+		position: relative;
+		border-radius: 50%;
+		overflow: hidden;
+	}
+	.g-sample-result {
+		background-color: #EDEDED;
+		position: fixed;
+		width: 100%;
+		min-height: 160px;
+		bottom: 0;
+		z-index: 9999;
+		opacity: 0.8;
+	}
+	.g-sample-text {
+		display: inline-block;
 
-	font-size: 20px;
-	color: #FFFFFF;
-}
+		font-size: 20px;
+		color: #FFFFFF;
+	}
 
-// Sample specific classes
+	// Sample specific classes
 
-.g-sample-toggle-button-container {
-	width: 280px;
-	height: 230px;
+	.g-sample-toggle-button-container {
+		width: 280px;
+		height: 230px;
+	}
 }

--- a/garnet/src/ToggleButtonSample.less
+++ b/garnet/src/ToggleButtonSample.less
@@ -2,13 +2,13 @@
 
 // Common classes
 
-.g-sample-circle-panel {
+.g-sample-toggle-button .g-sample-circle-panel {
 	background-color: #000000;
 	position: relative;
 	border-radius: 50%;
 	overflow: hidden;
 }
-.g-sample-result {
+.g-sample-toggle-button .g-sample-result {
 	background-color: #EDEDED;
 	position: fixed;
 	width: 100%;
@@ -17,7 +17,7 @@
 	z-index: 9999;
 	opacity: 0.8;
 }
-.g-sample-text {
+.g-sample-toggle-button .g-sample-text {
 	display: inline-block;
 
 	font-size: 20px;

--- a/garnet/src/ToggleIconButtonSample.js
+++ b/garnet/src/ToggleIconButtonSample.js
@@ -58,7 +58,7 @@ var ToggleIconButtonPanel = kind({
 
 module.exports = kind({
 	name: 'g.sample.ToggleIconButtonSample',
-	classes: 'enyo-unselectable garnet g-sample',
+	classes: 'enyo-unselectable garnet g-sample g-sample-toggle-icon-button',
 	components: [
 		{content: '< Toggle Icon Button Sample', classes: 'g-sample-header', ontap: 'goBack'},
 

--- a/garnet/src/ToggleIconButtonSample.less
+++ b/garnet/src/ToggleIconButtonSample.less
@@ -1,53 +1,53 @@
 /* ToggleIconButtonSample */
 
 .g-sample-toggle-icon-button {
-	// Common classes
+// Common classes
 
-	.g-sample-circle-panel {
-		background-color: #000000;
+.g-sample-circle-panel {
+	background-color: #000000;
 
-		position: relative;
-		border-radius: 50%;
-		overflow: hidden;
-	}
-	.g-sample-result {
-		background-color: #EDEDED;
-		position: fixed;
-		width: 100%;
-		min-height: 160px;
-		bottom: 0;
-		z-index: 9999;
-		opacity: 0.8;
-	}
+	position: relative;
+	border-radius: 50%;
+	overflow: hidden;
+}
+.g-sample-result {
+	background-color: #EDEDED;
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
 
-	// Sample specific classes
+// Sample specific classes
 
-	.g-sample .g-toggle-icon-button {
-		margin-right: 2px;
-	}
-	.g-sample-toggle-icon-button-size {
-		background-size: 60px 360px, 60px 120px;
+.g-sample .g-toggle-icon-button {
+	margin-right: 2px;
+}
+.g-sample-toggle-icon-button-size {
+	background-size: 60px 360px, 60px 120px;
 
-		width: 60px;
-		height: 60px;
-	}
-	.g-sample-toggle-icon-button-container {
-		width: 280px;
-		height: 230px;
-	}
-	.g-sample-toggle-icon-button-text {
-		display: inline-block;
-		margin-left: 10px;
-		margin-right: 10px;
+	width: 60px;
+	height: 60px;
+}
+.g-sample-toggle-icon-button-container {
+	width: 280px;
+	height: 230px;
+}
+.g-sample-toggle-icon-button-text {
+	display: inline-block;
+	margin-left: 10px;
+	margin-right: 10px;
 
-		font-size: 20px;
-		color: #FFFFFF;
-	}
-	.g-sample-toggle-icon-button-group-text {
-		display: inline-block;
-		margin-right: 10px;
+	font-size: 20px;
+	color: #FFFFFF;
+}
+.g-sample-toggle-icon-button-group-text {
+	display: inline-block;
+	margin-right: 10px;
 
-		font-size: 20px;
-		color: #FFFFFF;
-	}
+	font-size: 20px;
+	color: #FFFFFF;
+}
 }

--- a/garnet/src/ToggleIconButtonSample.less
+++ b/garnet/src/ToggleIconButtonSample.less
@@ -2,14 +2,14 @@
 
 // Common classes
 
-.g-sample-circle-panel {
+.g-sample-toggle-icon-button .g-sample-circle-panel {
 	background-color: #000000;
 
 	position: relative;
 	border-radius: 50%;
 	overflow: hidden;
 }
-.g-sample-result {
+.g-sample-toggle-icon-button .g-sample-result {
 	background-color: #EDEDED;
 	position: fixed;
 	width: 100%;

--- a/garnet/src/ToggleIconButtonSample.less
+++ b/garnet/src/ToggleIconButtonSample.less
@@ -1,51 +1,53 @@
 /* ToggleIconButtonSample */
 
-// Common classes
+.g-sample-toggle-icon-button {
+	// Common classes
 
-.g-sample-toggle-icon-button .g-sample-circle-panel {
-	background-color: #000000;
+	.g-sample-circle-panel {
+		background-color: #000000;
 
-	position: relative;
-	border-radius: 50%;
-	overflow: hidden;
-}
-.g-sample-toggle-icon-button .g-sample-result {
-	background-color: #EDEDED;
-	position: fixed;
-	width: 100%;
-	min-height: 160px;
-	bottom: 0;
-	z-index: 9999;
-	opacity: 0.8;
-}
+		position: relative;
+		border-radius: 50%;
+		overflow: hidden;
+	}
+	.g-sample-result {
+		background-color: #EDEDED;
+		position: fixed;
+		width: 100%;
+		min-height: 160px;
+		bottom: 0;
+		z-index: 9999;
+		opacity: 0.8;
+	}
 
-// Sample specific classes
+	// Sample specific classes
 
-.g-sample .g-toggle-icon-button {
-	margin-right: 2px;
-}
-.g-sample-toggle-icon-button-size {
-	background-size: 60px 360px, 60px 120px;
+	.g-sample .g-toggle-icon-button {
+		margin-right: 2px;
+	}
+	.g-sample-toggle-icon-button-size {
+		background-size: 60px 360px, 60px 120px;
 
-	width: 60px;
-	height: 60px;
-}
-.g-sample-toggle-icon-button-container {
-	width: 280px;
-	height: 230px;
-}
-.g-sample-toggle-icon-button-text {
-	display: inline-block;
-	margin-left: 10px;
-	margin-right: 10px;
+		width: 60px;
+		height: 60px;
+	}
+	.g-sample-toggle-icon-button-container {
+		width: 280px;
+		height: 230px;
+	}
+	.g-sample-toggle-icon-button-text {
+		display: inline-block;
+		margin-left: 10px;
+		margin-right: 10px;
 
-	font-size: 20px;
-	color: #FFFFFF;
-}
-.g-sample-toggle-icon-button-group-text {
-	display: inline-block;
-	margin-right: 10px;
+		font-size: 20px;
+		color: #FFFFFF;
+	}
+	.g-sample-toggle-icon-button-group-text {
+		display: inline-block;
+		margin-right: 10px;
 
-	font-size: 20px;
-	color: #FFFFFF;
+		font-size: 20px;
+		color: #FFFFFF;
+	}
 }

--- a/garnet/src/WheelSliderPanelSample.js
+++ b/garnet/src/WheelSliderPanelSample.js
@@ -42,7 +42,7 @@ var WheelSliderPanelBrightness = kind({
 
 var WheelSliderPanelSample = module.exports = kind({
 	name: 'g.sample.WheelSliderPanelSample',
-	classes: 'enyo-unselectable garnet g-sample',
+	classes: 'enyo-unselectable garnet g-sample g-sample-wheelslider-panel',
 	components: [
 		{content: '< Wheel Slider Panel Sample', classes: 'g-sample-header', ontap: 'goBack'},
 

--- a/garnet/src/WheelSliderPanelSample.less
+++ b/garnet/src/WheelSliderPanelSample.less
@@ -2,20 +2,20 @@
 
 // Common classes
 
-.g-sample-panel {
+.g-sample-wheelslider-panel .g-sample-panel {
 	background-color: #000000;
 
 	position: relative;
 	overflow: hidden;
 }
-.g-sample-circle-panel {
+.g-sample-wheelslider-panel .g-sample-circle-panel {
 	background-color: #000000;
 
 	position: relative;
 	border-radius: 50%;
 	overflow: hidden;
 }
-.g-sample-result {
+.g-sample-wheelslider-panel .g-sample-result {
 	background-color: #EDEDED;
 
 	position: fixed;
@@ -25,7 +25,7 @@
 	z-index: 9999;
 	opacity: 0.8;
 }
-.g-sample-pointer-events-none {
+.g-sample-wheelslider-panel .g-sample-pointer-events-none {
 	pointer-events: none;
 }
 

--- a/garnet/src/WheelSliderPanelSample.less
+++ b/garnet/src/WheelSliderPanelSample.less
@@ -1,57 +1,59 @@
 /* WheelSliderPanelSample */
 
-// Common classes
+.g-sample-wheelslider-panel {
+	// Common classes
 
-.g-sample-wheelslider-panel .g-sample-panel {
-	background-color: #000000;
+	.g-sample-panel {
+		background-color: #000000;
 
-	position: relative;
-	overflow: hidden;
-}
-.g-sample-wheelslider-panel .g-sample-circle-panel {
-	background-color: #000000;
+		position: relative;
+		overflow: hidden;
+	}
+	.g-sample-circle-panel {
+		background-color: #000000;
 
-	position: relative;
-	border-radius: 50%;
-	overflow: hidden;
-}
-.g-sample-wheelslider-panel .g-sample-result {
-	background-color: #EDEDED;
+		position: relative;
+		border-radius: 50%;
+		overflow: hidden;
+	}
+	.g-sample-result {
+		background-color: #EDEDED;
 
-	position: fixed;
-	width: 100%;
-	min-height: 160px;
-	bottom: 0;
-	z-index: 9999;
-	opacity: 0.8;
-}
-.g-sample-wheelslider-panel .g-sample-pointer-events-none {
-	pointer-events: none;
-}
+		position: fixed;
+		width: 100%;
+		min-height: 160px;
+		bottom: 0;
+		z-index: 9999;
+		opacity: 0.8;
+	}
+	.g-sample-pointer-events-none {
+		pointer-events: none;
+	}
 
-// Sample specific classes
+	// Sample specific classes
 
-.g-sample-wheelslider-panel-value {
-	display: block;
-	width: 60%;
-	height: 99px;
-	margin-top: 85px;
-	margin-left: 20%;
+	.g-sample-wheelslider-panel-value {
+		display: block;
+		width: 60%;
+		height: 99px;
+		margin-top: 85px;
+		margin-left: 20%;
 
-	text-align: center;
-	font-weight: 400;
-	font-size: 100px;
+		text-align: center;
+		font-weight: 400;
+		font-size: 100px;
 
-	pointer-events: auto;
-}
-.g-sample-wheelslider-panel-text {
-	display: block;
-	width: 80%;
-	margin-left: 10%;
+		pointer-events: auto;
+	}
+	.g-sample-wheelslider-panel-text {
+		display: block;
+		width: 80%;
+		margin-left: 10%;
 
-	text-align: center;
-	font-weight: 800;
-	font-size: 22px;
+		text-align: center;
+		font-weight: 800;
+		font-size: 22px;
 
-	pointer-events: auto;
+		pointer-events: auto;
+	}
 }

--- a/garnet/src/WheelSliderPanelSample.less
+++ b/garnet/src/WheelSliderPanelSample.less
@@ -1,59 +1,59 @@
 /* WheelSliderPanelSample */
 
 .g-sample-wheelslider-panel {
-	// Common classes
+// Common classes
 
-	.g-sample-panel {
-		background-color: #000000;
+.g-sample-panel {
+	background-color: #000000;
 
-		position: relative;
-		overflow: hidden;
-	}
-	.g-sample-circle-panel {
-		background-color: #000000;
+	position: relative;
+	overflow: hidden;
+}
+.g-sample-circle-panel {
+	background-color: #000000;
 
-		position: relative;
-		border-radius: 50%;
-		overflow: hidden;
-	}
-	.g-sample-result {
-		background-color: #EDEDED;
+	position: relative;
+	border-radius: 50%;
+	overflow: hidden;
+}
+.g-sample-result {
+	background-color: #EDEDED;
 
-		position: fixed;
-		width: 100%;
-		min-height: 160px;
-		bottom: 0;
-		z-index: 9999;
-		opacity: 0.8;
-	}
-	.g-sample-pointer-events-none {
-		pointer-events: none;
-	}
+	position: fixed;
+	width: 100%;
+	min-height: 160px;
+	bottom: 0;
+	z-index: 9999;
+	opacity: 0.8;
+}
+.g-sample-pointer-events-none {
+	pointer-events: none;
+}
 
-	// Sample specific classes
+// Sample specific classes
 
-	.g-sample-wheelslider-panel-value {
-		display: block;
-		width: 60%;
-		height: 99px;
-		margin-top: 85px;
-		margin-left: 20%;
+.g-sample-wheelslider-panel-value {
+	display: block;
+	width: 60%;
+	height: 99px;
+	margin-top: 85px;
+	margin-left: 20%;
 
-		text-align: center;
-		font-weight: 400;
-		font-size: 100px;
+	text-align: center;
+	font-weight: 400;
+	font-size: 100px;
 
-		pointer-events: auto;
-	}
-	.g-sample-wheelslider-panel-text {
-		display: block;
-		width: 80%;
-		margin-left: 10%;
+	pointer-events: auto;
+}
+.g-sample-wheelslider-panel-text {
+	display: block;
+	width: 80%;
+	margin-left: 10%;
 
-		text-align: center;
-		font-weight: 800;
-		font-size: 22px;
+	text-align: center;
+	font-weight: 800;
+	font-size: 22px;
 
-		pointer-events: auto;
-	}
+	pointer-events: auto;
+}
 }


### PR DESCRIPTION
## Issue

: There are several same classes in garnet samples. So it's hard to debug the samples with an inspector.
## Fix

: Added each sample specific class and defined the same classes with it.

Before

```
.g-sample-panel {
}
```

After

```
.g-sample-arc 
.g-sample-panel {
}
}
```

Enyo-DCO-1.1-Signed-off-by: YB Sung yb.sung@lge.com
