### PR TITLE
ENYO-2875: Move ToastPopup prior to fittableRows's fit control

### DIFF
--- a/sunstone/src/PatternSample_Profile.js
+++ b/sunstone/src/PatternSample_Profile.js
@@ -72,7 +72,8 @@ module.exports = kind({
 	classes: 'enyo-unselectable enyo-fit',
 	components: [
 		{kind: Header, title: 'Profile & goal', showBackButton: true, onBackButtonTapped: 'buttonTapped'},
-		{kind: Scroller, fit: true, style: 'height: 100%;', horizontal: 'hidden', components: [
+		{name: 'toastpopup', kind: ToastPopup, showDuration: 2000, content: 'key pressed!'},
+		{kind: Scroller, fit: true, horizontal: 'hidden', components: [
 			{classes: 'general-index', content: 'PROFILE'},
 			{classes: 'profile-label', content: 'Gender'},
 			{name: 'gender', style: 'margin: 0 16px;', kind: ContextualButton, content: 'Test', components: [
@@ -168,8 +169,7 @@ module.exports = kind({
 				{content: 'Stemp : 6500 steps'},
 				{content: 'Distance : 5.51 km'}
 			]}
-		]},
-		{name: 'toastpopup', kind: ToastPopup, showDuration: 2000, content: 'key pressed!'}
+		]}
 	],
 	rendered: kind.inherit(function (sup) {
 		return function() {


### PR DESCRIPTION
Move ToastPopup prior to fit child component in Pattern's profile sample.

If viewport size is changed, reflow is called in FittableRows layout.
The reflow calculates fit component size considering last child component position.
However, fit component(= Scroller) should not consider last child component position,
because ToastPopup is hidden after 2 seconds.
We moved ToastPopup prior to fit component for preventing this.

https://jira2.lgsvl.com/browse/ENYO-2875
Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com
