### PR TITLE
ENYO-2897: Garnet: Fixed the bug that the 'body' style in garnet sample affects enyo samples

### DIFF
--- a/garnet/css/all.less
+++ b/garnet/css/all.less
@@ -2,20 +2,18 @@
 
 // PC
 @media all and (min-width: 800px) {
-
-body {
-	background-color: #EDEDED;
-}
-hr {
-	border-width: 1px 0px 0px 0px;
-	border-color: #EDEDED;
-	margin: 0;
-}
-table {
-	margin-bottom: 30px;
-}
 .g-sample {
-	margin: 20px 10px 10px;;
+	background-color: #EDEDED;
+	padding: 20px 10px 10px;
+
+	hr {
+		border-width: 1px 0px 0px 0px;
+		border-color: #EDEDED;
+		margin: 0;
+	}
+	table {
+		margin-bottom: 30px;
+	}
 }
 .g-sample .g-sample-header {
 	margin-bottom: 40px;
@@ -57,32 +55,32 @@ table {
 .g-sample .g-panel {
 	background-color: #000000;
 }
-
 }
 
 // 320
 @media all and (max-width: 799px) {
-
-body {
-	background-color: #000000;
-}
-body .enyo-scroller {
-	overflow-y: hidden !important;
-	overflow-x: hidden !important;
-}
-hr {
-	border-width: 1px 0px 0px 0px;
-	border-color: #EDEDED;
-	margin: 0;
-}
-table {
-	margin-bottom: 30px;
-}
 .g-sample {
+	background-color: #000000;
+
 	position: relative;
 	width: 320px;
 	height: 320px;
 	overflow: hidden;
+
+	transform: scale3d(1, 1, 1);
+
+	.enyo-scroller {
+		overflow-y: hidden !important;
+		overflow-x: hidden !important;
+	}
+	hr {
+		border-width: 1px 0px 0px 0px;
+		border-color: #EDEDED;
+		margin: 0;
+	}
+	table {
+		margin-bottom: 30px;
+	}
 }
 .g-sample .g-sample-header {
 	position: absolute;
@@ -121,5 +119,4 @@ table {
 .g-sample .g-panel {
 	background-color: #000000;
 }
-
 }


### PR DESCRIPTION
## Issue

: The css styles related with Garnet samples affects enyo samples.
## Fix

:Wrapped body, hr, table tag css style with .g-sample class so that the styles in all.less of garnet sample couldn't be included in other library samples.

https://jira2.lgsvl.com/browse/ENYO-2897
Enyo-DCO-1.1-Signed-off-by: YB Sung yb.sung@lge.com
