### PR TITLE
ENYO-2987: Lazily-load different library samples.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,6 +2,7 @@
     "globals": {
       "global": false,
       "require": false,
+      "request": false,
       "exports": true,
       "module": true,
       "module.exports": true,

--- a/index.js
+++ b/index.js
@@ -7,8 +7,19 @@ var
 	strawman = require('./src');
 
 ready(function () {
+
 	var names = window.document.location.search.substring(1).split('&'),
 		name = names[0],
 		Sample = strawman.samples[name] || strawman.List;
-	new Sample().renderInto(document.body);
+
+	if (request.isRequest(Sample)) {
+		//check to see if the sample is wrapped in
+		//request instead of being required into the build
+
+		Sample.then(function(res){
+			new res().renderInto(document.body);
+		});
+	} else {
+		new Sample().renderInto(document.body);
+	}
 });

--- a/src/index.js
+++ b/src/index.js
@@ -6,14 +6,14 @@ var
 
 var
 	samples = {
-		Enyo: require('./enyo-samples'),
-		Moonstone: require('./moonstone-samples'), //router blocking
-		Layout: require('./layout-samples'),
-		Spotlight: require('./spotlight-samples'),
-		iLib: require('./enyo-ilib-samples'),
-		Onyx: require('./onyx-samples'),
-		Canvas: require('./canvas-samples'),
-		Svg: require('./svg-samples')
+		Enyo: request('./enyo-samples'),
+		Moonstone: request('./moonstone-samples'), //router blocking
+		Layout: request('./layout-samples'),
+		Spotlight: request('./spotlight-samples'),
+		iLib: request('./enyo-ilib-samples'),
+		Onyx: request('./onyx-samples'),
+		Canvas: request('./canvas-samples'),
+		Svg: request('./svg-samples')
 	};
 
 var


### PR DESCRIPTION
### Issue

To better simulate real-world scenarios and to prevent cross-contamination, different library's sample sets should be lazily-loaded.
### Fix

Utilized some of the work from https://github.com/enyojs/enyo-strawman/pull/100 and converted the existing library samples from `require` to `request`. Although we are lazily-loading all of the samples now, kept logic for checking if the sample set is to be requested vs. already-required, in case we want to `require` other sample sets in the future.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
