### PR TITLE
ENYO-2998: Fix call to start job.

### DIFF
--- a/src/enyo-samples/src/PopupSample/PopupSample.js
+++ b/src/enyo-samples/src/PopupSample/PopupSample.js
@@ -91,7 +91,7 @@ module.exports = kind({
 		var p = this.$[sender.popup];
 		if (p) {
 			p.setShowing(true);
-			job.job('autoHidePopup', function() {
+			job('autoHidePopup', function() {
 				p.hide();
 			}, 2000);
 		}


### PR DESCRIPTION
### Issue

The auto-hide popup would not auto-hide.
### Fix

The call to start the job was using the wrong syntax and has been corrected.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
