### PR TITLE
ENYO-2988: Add tabIndex for reading value content

### DIFF
--- a/garnet/src/WheelSliderPanelSample.js
+++ b/garnet/src/WheelSliderPanelSample.js
@@ -16,7 +16,8 @@ var WheelSliderPanelBrightness = kind({
 	value: 50,
 	components: [
 		{classes: 'g-sample-pointer-events-none', components: [
-			{name: 'sampleValue', content: '', classes: 'g-sample-wheelslider-panel-value'},
+			// Accessibility : Add tabIndex for reading value, which is zero.
+			{name: 'sampleValue', tabIndex: -1, content: '', classes: 'g-sample-wheelslider-panel-value'},
 			{content: 'Brightness', classes: 'g-sample-wheelslider-panel-text'}
 		]}
 	],


### PR DESCRIPTION
Add tabIndex: -1 for reading value, which is zero.

Enyo accessibilitySupport adds tabindex if component is focusable, but
if binding value is zero (not String), its content is boolean false.
Then, accessibilitySupport removes tabindex because component is not focusable.

If accessibilityLive is true, screen reader reads content without focus, but
its precondition is that component should be focusable.

https://jira2.lgsvl.com/browse/ENYO-2988
Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com
