### PR TITLE
ENYO-3023: Fix for unscrollable list.

### DIFF
--- a/src/layout-samples/src/PanelsFlickrSample/PanelsFlickrSample.js
+++ b/src/layout-samples/src/PanelsFlickrSample/PanelsFlickrSample.js
@@ -74,7 +74,7 @@ module.exports = kind({
 	classes: 'panels-sample-flickr-panels enyo-unselectable enyo-fit',
 	arrangerKind: CollapsingArranger,
 	components: [
-		{kind: FittableRows, components: [
+		{kind: FittableRows, classes: 'enyo-fit', components: [
 			{components: [
 				{kind: FittableColumns, tag: 'label', style: 'width: 90%;', components: [
 					{name: 'searchInput', fit: true, kind: Input, value: 'Japan', onchange: 'search'},


### PR DESCRIPTION
### Issue

Previously, the `PanelsFlickrSample` had been functioning because the ordering of the CSS had allowed the styles for children of `Arranger` kinds to override the styles for those of `FittableRows` kinds (specifically, the `position: relative` declaration was being overwritten by the `position: absolute` declaration). With the change to a modular system, this ordering was no longer guaranteed, and resulted in the container expanding to the height of its children, as they were both `position: relative`. Due to the nature of how the fittables logic behaves, the fittable child is assigned the height of its container (minus the height of the non-fit children), which resulted in the child (the list) being assigned its full, default height of 1000000px, rather than having its height constrained to the viewport.
### Fix

Similar to how the other panel in this sample, the `pictureView`, has the `enyo-fit` class applied, we also apply the `enyo-fit` class to our first panel, the `FittableRows` kind, as we want the panel to fill the available space.
### Notes

Thought about increasing the specificity of the selector for the `Arranger` style, but did not see a clean way to do this, and could potentially introduce the opposite effect where the desired `FittableRows` styles become overwritten by `Arranger` styles.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
