### PR TITLE
ENYO-2921: PlatformSample(W2+): Unable to Navigate Back to Sample Lis…

### DIFF
--- a/garnet/css/all.less
+++ b/garnet/css/all.less
@@ -55,6 +55,9 @@
 .g-sample .g-panel {
 	background-color: #000000;
 }
+.g-sample .g-back-enyo {
+	display:none;
+}
 }
 
 // 320
@@ -118,5 +121,11 @@
 
 .g-sample .g-panel {
 	background-color: #000000;
+}
+.g-sample .platform-sample {
+	padding:2rem;
+	& > :last-child {
+		padding-bottom:60px;
+	}
 }
 }

--- a/garnet/css/all.less
+++ b/garnet/css/all.less
@@ -56,7 +56,7 @@
 	background-color: #000000;
 }
 .g-sample .g-back-enyo {
-	display:none;
+	display: none;
 }
 }
 
@@ -123,9 +123,9 @@
 	background-color: #000000;
 }
 .g-sample .platform-sample {
-	padding:2rem;
+	padding: 2rem;
 	& > :last-child {
-		padding-bottom:60px;
+		padding-bottom: 60px;
 	}
 }
 }

--- a/garnet/index.js
+++ b/garnet/index.js
@@ -31,19 +31,20 @@ var
 
 ready(function () {
 	var names = window.document.location.search.substring(1).split('&'),
-		name = names[0];
-	
-	if(samples[name] && names.length===2 && name !== "Garnet") {
-		var Sample = kind({
-			classes:'enyo-fit g-sample',
-			style:'background:white;',
+		name = names[0],
+		Sample;
+
+	if (samples[name] && names.length === 2 && name !== 'Garnet') {
+		Sample = kind({
+			classes: 'enyo-fit g-sample',
+			style: 'background:white;',
 			components: [
 				{content: '<', classes: 'g-sample-header g-back-enyo', ontap: 'goBack'},
-				{kind:Scroller, style:"width:100%; height:100%", components:[
-					{kind:samples[name], style:"padding-bottom:60px;"},
+				{kind:Scroller, style: 'width:100%; height:100%;', components:[
+					{kind:samples[name], style: 'padding-bottom: 60px;'},
 				]}
 			],
-			goBack: function(inSender, inEvent) {
+			goBack: function() {
 				global.history.go(-1);
 				return false;
 			}

--- a/garnet/index.js
+++ b/garnet/index.js
@@ -2,6 +2,7 @@ require('enyo/options').accessibility = true;
 
 var
 	ready = require('enyo/ready'),
+	Scroller = require('garnet/Scroller'),
 	kind = require('enyo/kind');
 
 var
@@ -30,8 +31,26 @@ var
 
 ready(function () {
 	var names = window.document.location.search.substring(1).split('&'),
-		name = names[0],
+		name = names[0];
+	
+	if(samples[name] && names.length===2 && name !== "Garnet") {
+		var Sample = kind({
+			classes:'enyo-fit g-sample',
+			style:'background:white;',
+			components: [
+				{content: '<', classes: 'g-sample-header g-back-enyo', ontap: 'goBack'},
+				{kind:Scroller, style:"width:100%; height:100%", components:[
+					{kind:samples[name], style:"padding-bottom:60px;"},
+				]}
+			],
+			goBack: function(inSender, inEvent) {
+				global.history.go(-1);
+				return false;
+			}
+		});
+	} else {
 		Sample = samples[name] || List;
+	}
 	new Sample().renderInto(document.body);
 });
 

--- a/src/strawman/List/List.less
+++ b/src/strawman/List/List.less
@@ -34,6 +34,14 @@
 	}
 
 	@media only screen and (max-width: @strawman-screen-max-size-wearable) {
+		// Items inside a grid
+		.grid .link {
+			height: 2.4em;
+			line-height: 2.4em;
+			margin: 0.2em;
+			padding: 0 0.8em;
+		}
+		
 		.list-frame:not(.grid) .link {
 			font-size: 1.5rem;
 		}

--- a/src/strawman/SampleList/SampleList.less
+++ b/src/strawman/SampleList/SampleList.less
@@ -25,7 +25,7 @@
 			opacity: 0.01;
 			width: 100%;
 			margin: 0;
-			line-height: 2em;
+			line-height: 1.5em;
 			font-size: 3em;
 			border-radius: 0;
 		}


### PR DESCRIPTION
…t from PlatformSample.
ENYO-2920: PlatformSample(W2+): Unable to Scroll Sample to View
ENYO-2897: PlatformSample (W2+): Text Needs Visible Color For a Black Background

To add the back button for Garnet-only builds off strawman (and only visible on non-Garnet sample sections), the samples are put in a wrapper, in the process also giving it a white background and scroller.

Enyo-DCO-1.1-Signed-off-by: Jason Robitaille jason.robitaille@lge.com
