### PR TITLE
ENYO-3043: Make Spotlight a hard dependency.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+require('spotlight');
+
 var
 	kind = require('enyo/kind'),
 	platform = require('enyo/platform');


### PR DESCRIPTION
### Issue

We rely on Spotlight for 5-way key navigation in Strawman, but have made library samples lazily-loaded, so Spotlight is not always present.
### Fix

We make sure to always include Spotlight when loading Strawman.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
