### PR TITLE
ENYO-3015: Switch video source back to standard, working videos.

### DIFF
--- a/moonstone-extra/src/VideoPlayerSample.js
+++ b/moonstone-extra/src/VideoPlayerSample.js
@@ -18,9 +18,9 @@ var
 	VideoPlayer = require('moonstone-extra/VideoPlayer');
 
 var sources = [
-	{src: 'http://media.w3.org/2010/05/bunny/movie.ogv', type: 'video/ogg'},
-	{src: 'http://media.w3.org/2010/05/bunny/movie_hd.ogv', type: 'video/ogg'},
-	{src: 'http://media.w3.org/2010/05/bunny/movie.mp4', type: 'video/mp4'}
+	{src: 'http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4', type: 'video/mp4'},
+	{src: 'http://clips.vorwaerts-gmbh.de/big_buck_bunny.ogv', type: 'video/ogg'},
+	{src: 'http://clips.vorwaerts-gmbh.de/big_buck_bunny.webm', type: 'video/webm'}
 ];
 
 module.exports = kind({

--- a/src/enyo-samples/src/VideoSample/VideoSample.js
+++ b/src/enyo-samples/src/VideoSample/VideoSample.js
@@ -4,13 +4,12 @@ var
 var
 	Anchor = require('enyo/Anchor'),
 	Button = require('enyo/Button'),
-	Video = require('enyo/Video'),
-	platform = require('enyo/platform');
+	Video = require('enyo/Video');
 
 var sources = [
-	{src: 'http://media.w3.org/2010/05/bunny/movie.ogv', type: 'video/ogg'},
-	{src: 'http://media.w3.org/2010/05/bunny/movie_hd.ogv', type: 'video/ogg'},
-	{src: 'http://media.w3.org/2010/05/bunny/movie.mp4', type: 'video/mp4'}
+	{src: 'http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4', type: 'video/mp4'},
+	{src: 'http://clips.vorwaerts-gmbh.de/big_buck_bunny.ogv', type: 'video/ogg'},
+	{src: 'http://clips.vorwaerts-gmbh.de/big_buck_bunny.webm', type: 'video/webm'}
 ];
 
 module.exports = kind({
@@ -23,7 +22,7 @@ module.exports = kind({
 				kind: Video,
 				poster: 'http://media.w3.org/2010/05/bunny/poster.png',
 				preload: 'auto',
-				src: getPrimarySource(),
+				src: sources[0].src,
 				onratechange: 'rateChanged',
 				ontimeupdate: 'timeChanged',
 				ondurationchange: 'durationChanged',
@@ -120,7 +119,7 @@ module.exports = kind({
 	},
 	buttonUseSrcTapped: function (sender, ev) {
 		this.pauseVideo();
-		this.$.video.set('src', getPrimarySource());
+		this.$.video.set('src', sources[0].src);
 	},
 	buttonUseSourceComponentsTapped: function (sender, ev) {
 		this.pauseVideo();
@@ -139,15 +138,3 @@ module.exports = kind({
 		return true;
 	}
 });
-
-function getPrimarySource () {
-		if(['ie', 'edge', 'safari'].filter(
-			function (browser) {
-				return platform[browser];
-			}
-		).length > 0) {
-			return sources[2].src;	// IE and Safari don't support OGV
-		} else {
-			return sources[0].src;
-		}
-}


### PR DESCRIPTION
### Issue

We had recently updated the video sources to be consistent across Enyo and Moonstone, but the videos from W3C are problematic and don't load properly in Safari for autoplay.
### Fix

We have switched back to the videos from http://camendesign.com/code/video_for_everybody/test.html. They are lower quality, but are encoded properly and load reliably.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
