### PR TITLE
ENYO-3055: Convert string kind references to module references.

### DIFF
--- a/src/enyo-ilib-samples/src/AdvDateFormatting/AdvDateFormatting.js
+++ b/src/enyo-ilib-samples/src/AdvDateFormatting/AdvDateFormatting.js
@@ -16,6 +16,7 @@ var
 	ResBundle = require('enyo-ilib/ResBundle')  ;
 
 var
+	ChooseLocale = require('../ChooseLocale'),
 	ChooseTimeZone = require('../ChooseTimeZone'),
 	rb = require('../ResBundle');
 
@@ -61,8 +62,8 @@ module.exports = kind({
 			]},
 
 			/* Header with selecting locale */
-			{kind: 'ilib.sample.ChooseLocale', name: 'localeSelector'},
-			{kind: 'ilib.sample.ChooseTimeZone', name: 'formatZonesSelector', label: rb.getString('Format Time Zone')},
+			{kind: ChooseLocale, name: 'localeSelector'},
+			{kind: ChooseTimeZone, name: 'formatZonesSelector', label: rb.getString('Format Time Zone')},
 			{content: rb.getString('Length'), classes: 'ilib-onyx-sample-divider'},
 			{kind: Group, defaultKind: Button, name: 'length', components: [
 				{content: 'short'},

--- a/src/enyo-ilib-samples/src/ChooseTimeZone.js
+++ b/src/enyo-ilib-samples/src/ChooseTimeZone.js
@@ -3,6 +3,9 @@ var
 	Select = require('enyo/Select');
 
 var
+	TimePicker = require('onyx/TimePicker');
+
+var
 	TimeZone = require('enyo-ilib/TimeZone');
 
 var
@@ -21,7 +24,7 @@ module.exports = kind({
 		{name: 'timeZones', kind: Select, onselect: 'setTimeZone', components: [
 			{content: rb.getString('local'), active: true}
 		]},
-		{kind: 'onyx.TimePicker', name: 'timePickerFake', content: rb.getString('Time'), showing: false}
+		{kind: TimePicker, name: 'timePickerFake', content: rb.getString('Time'), showing: false}
 	],
 
 	create: function () {

--- a/src/enyo-ilib-samples/src/DateFormatting/DateFormatting.js
+++ b/src/enyo-ilib-samples/src/DateFormatting/DateFormatting.js
@@ -6,6 +6,7 @@ var
 
 var
 	DatePicker = require('onyx/DatePicker'),
+	GroupboxHeader = require('onyx/GroupboxHeader'),
 	TimePicker = require('onyx/TimePicker');
 
 var
@@ -102,7 +103,7 @@ module.exports = kind({
 		]},
 
 		{kind: Group, classes:'onyx-sample-result-box', components: [
-			{kind: 'onyx.GroupboxHeader', content: rb.getString('Format result:')},
+			{kind: GroupboxHeader, content: rb.getString('Format result:')},
 			{name: 'rtlResult', fit: true, content: '-', style: 'padding: 10px'}
 		]}
 	],

--- a/src/layout-samples/src/FittableAppLayout1.js
+++ b/src/layout-samples/src/FittableAppLayout1.js
@@ -6,7 +6,8 @@ var
 	FittableRows = require('layout/FittableRows'),
 	Button = require('enyo/Button'),
 	Control = require('enyo/Control'),
-	Input = require('enyo/Input');
+	Input = require('enyo/Input'),
+	ToolDecorator = require('enyo/ToolDecorator');
 
 module.exports = kind({
 	name: 'enyo.sample.FittableAppLayout1',
@@ -16,7 +17,7 @@ module.exports = kind({
 		{kind: Control, classes: 'layout-sample-toolbar', components: [
 			{content: 'Header'},
 			{kind: Button, content: 'Button'},
-			{kind: 'enyo.ToolDecorator', tag: 'label', components: [
+			{kind: ToolDecorator, tag: 'label', components: [
 				{kind: Input}
 			]}
 		]},

--- a/src/layout-samples/src/ImageViewSample/ImageViewSample.js
+++ b/src/layout-samples/src/ImageViewSample/ImageViewSample.js
@@ -1,5 +1,6 @@
 var
-	kind = require('enyo/kind');
+	kind = require('enyo/kind'),
+	EnyoImage = require('enyo/Image');
 
 var
 	ImageView = require('layout/ImageView'),
@@ -16,10 +17,10 @@ module.exports = kind({
 	components: [
 		{name: 'sampleImageView', kind: ImageView, src: '@../../assets/globe.jpg', scale: 'auto', classes: 'enyo-fit', components: [
 			{kind: ImageViewPin, highlightAnchorPoint:true, anchor: {top:79, right:224}, position: {bottom:0, left:-16}, components: [
-				{kind: 'Image', src: '@../../assets/pin.png'}
+				{kind: EnyoImage, src: '@../../assets/pin.png'}
 			]},
 			{kind: ImageViewPin, anchor: {top:280, left:415}, position: {bottom:0, right:-16}, components: [
-				{kind: 'Image', src: '@../../assets/pin.png'}
+				{kind: EnyoImage, src: '@../../assets/pin.png'}
 			]},
 			{kind: ImageViewPin, highlightAnchorPoint:true, anchor: {bottom: '20%', left: '400px'}, position: {bottom:0, left:0}, components: [
 				{style: 'background:rgba(255,255,255,0.8);border:1px solid #888;margin:0px;padding:0px;width:300px', components: [

--- a/src/onyx-samples/src/ButtonSample.js
+++ b/src/onyx-samples/src/ButtonSample.js
@@ -4,7 +4,8 @@ var
 var
 	Button = require('onyx/Button'),
 	Groupbox = require('onyx/Groupbox'),
-	GroupboxHeader = require('onyx/GroupboxHeader');
+	GroupboxHeader = require('onyx/GroupboxHeader'),
+	Icon = require('onyx/Icon');
 
 module.exports = kind({
 	name: 'onyx.sample.ButtonSample',
@@ -36,7 +37,7 @@ module.exports = kind({
 				{content: 'There is an image here'}
 			]},
 			{kind: Button, name:'Fishbowl Button', ontap:'buttonTapped', components: [
-				{kind: 'onyx.Icon', src: '@../assets/fish_bowl.png'}
+				{kind: Icon, src: '@../assets/fish_bowl.png'}
 			]}
 		]},
 		{kind: Groupbox, classes:'onyx-sample-result-box', components: [

--- a/src/onyx-samples/src/TabBarSample.js
+++ b/src/onyx-samples/src/TabBarSample.js
@@ -13,7 +13,7 @@ var SimpleTabBar = kind({
 	kind: Control,
 	fit: true,
 	components: [
-		{name: 'bar',kind: 'onyx.TabBar'},
+		{name: 'bar',kind: TabBar},
 		{style: 'border: 2px solid grey; ', components: [
 			{content: 'Only the content of this kind is changed', style: 'padding: 1em'},
 			{name: 'stuff', content: 'empty', style: 'padding: 1em'}
@@ -45,7 +45,7 @@ var DynamicTabBar = kind({
 		kind: Control,
 		fit: true,
 		components: [
-			{name: 'bar', kind: 'onyx.TabBar', maxMenuHeight: 200},
+			{name: 'bar', kind: TabBar, maxMenuHeight: 200},
 			{style: 'border: 2px solid grey; ', components: [
 				{content: 'create many tabs and reduce the width of the browser'},
 				{name: 'stuff', content: 'empty', style: 'padding: 1em'},


### PR DESCRIPTION
### Issue

There were a few stragglers in our samples that had string kind references, instead of module references.
### Fix

Converted the stragglers (with the exception of some commented out code in `ListLanguagesSample`).

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
