### PR TITLE
ENYO-3102: Allow Garnet and Sunstone strawman to build without unnecessary dependencies.

### DIFF
--- a/garnet/index.js
+++ b/garnet/index.js
@@ -1,12 +1,14 @@
 require('enyo/options').accessibility = true;
 
 var
-	ready = require('enyo/ready'),
-	Scroller = require('garnet/Scroller'),
-	kind = require('enyo/kind');
+	kind = require('enyo/kind'),
+	ready = require('enyo/ready');
 
 var
-	strawman = require('../src');
+	Scroller = require('garnet/Scroller');
+
+var
+	SampleList = require('../src/strawman/SampleList');
 
 var
 	samples = {
@@ -22,7 +24,10 @@ var
 
 var
 	List = kind({
-		kind: strawman.List,
+		kind: SampleList,
+		title: 'Enyo Strawman - Samples Gallery',
+		classes: 'home',
+		listType: 'grid',
 		samples: samples
 	});
 
@@ -37,8 +42,8 @@ ready(function () {
 			style: 'background:white;',
 			components: [
 				{content: '<', classes: 'g-sample-header g-back-enyo', ontap: 'goBack'},
-				{kind:Scroller, style: 'width:100%; height:100%;', components:[
-					{kind:samples[name], style: 'padding-bottom: 60px;'},
+				{kind: Scroller, style: 'width:100%; height:100%;', components: [
+					{kind: samples[name], style: 'padding-bottom: 60px;'}
 				]}
 			],
 			goBack: function() {

--- a/sunstone/index.js
+++ b/sunstone/index.js
@@ -1,9 +1,9 @@
 var
-	ready = require('enyo/ready'),
-	kind = require('enyo/kind');
+	kind = require('enyo/kind'),
+	ready = require('enyo/ready');
 
 var
-	strawman = require('../src');
+	SampleList = require('../src/strawman/SampleList');
 
 var
 	samples = {
@@ -19,7 +19,10 @@ var
 
 var
 	List = kind({
-		kind: strawman.List,
+		kind: SampleList,
+		title: 'Enyo Strawman - Samples Gallery',
+		classes: 'home',
+		listType: 'grid',
 		samples: samples
 	});
 


### PR DESCRIPTION
### Issue

When making some recent changes (https://github.com/enyojs/enyo-strawman/pull/247) to generalize the scrolling mechanism in strawman, we unintentionally caused Garnet and Sunstone strawman builds to require unnecessary libraries (i.e. Moonstone, Onyx), as our default `index.js` for strawman loads the samples for these libraries.
### Fix

We wanted to do some further refactoring to more cleanly separate things, while reusing as much as possible, but with the pending changes from https://github.com/enyojs/enyo-strawman/pull/252, it might not be necessary and/or is moot. Instead, we reversed the changes made for Garnet and Sunstone strawman in the previous PR.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
