### PR TITLE
ENYO-1633: Fix sizing of no-image items.

### DIFF
--- a/src/moonstone-samples/src/NewDataListSample.js
+++ b/src/moonstone-samples/src/NewDataListSample.js
@@ -31,7 +31,7 @@ var NoImageItem = kind({
 		{from: 'model.bgColor', to: 'bgColor'}
 	],
 	componentOverrides: {
-		image: {kind: Control, mixins: [Overlay.Support, Overlay.Selection], style: 'padding-top: 100%; background: gray;'}
+		image: {kind: Control, mixins: [Overlay.Support, Overlay.Selection]}
 	},
 	imageSizingChanged: function () {},
 	bgColorChanged: function () {


### PR DESCRIPTION
### Issue

The caption and sub-caption of each item was being hidden.
### Fix

We removed all of the styling on the no-image item.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
