### PR TITLE
ENYO-3128: enyo-strawman: launcher links should expressly go to lib/index.html

### DIFF
--- a/src/strawman/List/List.js
+++ b/src/strawman/List/List.js
@@ -20,7 +20,7 @@ module.exports = kind({
 			{kind: Link, classes: 'item', bindings: [
 				{from: 'model.name', to: 'href', transform: function (v) {
 						var href = "#" + v;
-						if (!this.owner.libraryName) { href = v + "/"; }
+						if (!this.owner.libraryName) { href = v + "/index.html"; }
 						return href;
 					}
 				},

--- a/src/strawman/List/List.js
+++ b/src/strawman/List/List.js
@@ -20,7 +20,7 @@ module.exports = kind({
 			{kind: Link, classes: 'item', bindings: [
 				{from: 'model.name', to: 'href', transform: function (v) {
 						var href = "#" + v;
-						if (!this.owner.libraryName) { href = v + "/index.html"; }
+						if (!this.owner.libraryName) { href = v + '/index.html'; }
 						return href;
 					}
 				},


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Jason Robitaille jason.robitaille@lge.com
