### PR TITLE
ENYO-3142: Remove unnecessary guards.

### DIFF
--- a/src/moonstone-samples/src/DatePickerSample.js
+++ b/src/moonstone-samples/src/DatePickerSample.js
@@ -96,9 +96,7 @@ module.exports = kind({
 		this.$.picker.set('value', new Date());
 	},
 	changed: function (sender, ev) {
-		if (this.$.result && ev.value){
-			this.$.result.setContent(ev.name + ' changed to ' + ev.value.toDateString());
-		}
+		this.$.result.setContent(ev.name + ' changed to ' + (ev.value && ev.value.toDateString()));
 	},
 	resetTapped: function (sender, ev) {
 		this.$.picker.set('value', null);

--- a/src/moonstone-samples/src/TimePickerSample.js
+++ b/src/moonstone-samples/src/TimePickerSample.js
@@ -85,19 +85,15 @@ module.exports = kind({
 	},
 	timeChanged: function (sender, ev) {
 		var time;
-		if (this.$.result && ev.value){
-			if (sender.localeValue) {
-				time = sender._tf.format(dateFactory({unixtime: sender.localeValue.getTime(), timezone:'Etc/UTC'})).toString();
-			} else {
-				time = ev.value.toTimeString();
-			}
-			this.$.result.setContent(ev.name + ' changed to ' + time);
+		if (sender.localeValue) {
+			time = sender._tf.format(dateFactory({unixtime: sender.localeValue.getTime(), timezone:'Etc/UTC'})).toString();
+		} else {
+			time = ev.value && ev.value.toTimeString();
 		}
+		this.$.result.setContent(ev.name + ' changed to ' + time);
 	},
 	dateChanged: function (sender, ev) {
-		if (this.$.result && ev.value){
-			this.$.result.setContent(ev.name + ' changed to ' + ev.value.toDateString());
-		}
+		this.$.result.setContent(ev.name + ' changed to ' + (ev.value && ev.value.toDateString()));
 	},
 	resetTapped: function (sender, ev) {
 		this.$.pickerTime.set('open', false);


### PR DESCRIPTION
### Issue

There were guards in our samples to handle the case where change events were fired at create time. We want to be aware of these events firing at create time, as they are undesired.
### Fix

The guards have been removed and the changing back to a falsy value is also displayed.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
