### PR TITLE
ENYO-3149: Hide close button in sample list.

### DIFF
--- a/src/moonstone-samples/src/All/All.js
+++ b/src/moonstone-samples/src/All/All.js
@@ -135,7 +135,7 @@ module.exports = kind({
 		{from: 'title', to: '$.listpanel.title'}
 	],
 	listTools: [
-		{kind: Panels, pattern: 'activity', classes: 'enyo-fit', components: [
+		{kind: Panels, pattern: 'activity', hasCloseButton: false, classes: 'enyo-fit', components: [
 			{kind: Panel, name: 'listpanel', headerType: 'small',
 				headerComponents: [
 					{kind: Button, content: 'Back', small: true, href: '../index.html', mixins: [LinkSupport]}


### PR DESCRIPTION
### Issue

Due to the recent collapsing of `moonstone-extra` into the `moonstone` repository, strawman is now using `moonstone-extra` panels instead of `moonstone` panels. As a result, the close button and panels handle are now showing in the Moonstone samples list.
### Fix

We explicitly set `hasCloseButton: false` for the sample list panel, and have made a related change in `moonstone` to correct the default value of `useHandle`: https://github.com/enyojs/moonstone/pull/2738.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
