### PR TITLE
ENYO-3123: Badge size is now relative to its parent element size

### DIFF
--- a/src/strawman/List/List.less
+++ b/src/strawman/List/List.less
@@ -33,8 +33,7 @@
 				font-family: @strawman-list-badge-font-family;
 				font-weight: @strawman-list-badge-font-weight;
 				font-style: @strawman-list-badge-font-style;
-				font-size: 27px;
-				width: 81px;
+				width: 4em;
 				text-align: center;
 			}
 		}


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
