### PR TITLE
ENYO-3168: Build sourcemaps

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -117,7 +117,6 @@ function buildStrawman(samples) {
 		}
 		var opts = {
 			package: '.',
-			sourceMaps: false,
 			clean: true,
 			cache: false,
 			production: args.P,


### PR DESCRIPTION
### Issue

We had previously built source maps by default, when building strawman. This is useful for debugging and is not harmful to include; if we want to, we have the option of specifying production mode for any of the gulp build tasks.
### Fix

We have removed the explicit option `sourceMaps: false` from the gulp build configuration.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
