### PR TITLE
ENYO-3174: Remove use of deprecated API.

### DIFF
--- a/src/enyo-samples/src/RichTextSample/RichTextSample.js
+++ b/src/enyo-samples/src/RichTextSample/RichTextSample.js
@@ -29,8 +29,6 @@ module.exports = kind({
 		]},
 		{kind: Button, content: 'Select All', ontap: 'buttonSelectAllTapped'},
 		{kind: Button, content: 'Deselect All', ontap: 'buttonDeselectAllTapped'},
-		{kind: Button, content: 'Home', ontap: 'buttonHomeTapped'},
-		{kind: Button, content: 'End', ontap: 'buttonEndTapped'},
 		{kind: RichText, value: 'Input <em>any</em> text (HTML tags will be preserved)'},
 		{kind: Button, content: 'Show RichText Value', classes: 'button-value', ontap: 'buttonValueTapped'},
 		{name: 'results', classes: 'results'}
@@ -42,14 +40,6 @@ module.exports = kind({
 	buttonDeselectAllTapped: function (sender, ev) {
 		this.$.richText.focus();
 		this.$.richText.removeSelection();
-	},
-	buttonHomeTapped: function (sender, ev) {
-		this.$.richText.focus();
-		this.$.richText.moveCursorToStart();
-	},
-	buttonEndTapped: function (sender, ev) {
-		this.$.richText.focus();
-		this.$.richText.moveCursorToEnd();
 	},
 	buttonFormatTapped: function (sender, ev) {
 		this.$.richText.focus();


### PR DESCRIPTION
### Issue

We are deprecating some APIs as part of https://github.com/enyojs/enyo/pull/1407, and this sample utilizes some of those APIs.
### Fix

We removed the use of the deprecated APIs, and their associated features in the sample.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
