### PR TITLE
ENYO-3193: Restore close button for panels.

### DIFF
--- a/src/moonstone-extra-samples/src/ActivityPanelsWithVideoSample.js
+++ b/src/moonstone-extra-samples/src/ActivityPanelsWithVideoSample.js
@@ -60,7 +60,7 @@ module.exports = kind({
 			{kind: IconButton, small: false, backgroundOpacity: 'translucent'},
 			{kind: IconButton, small: false, backgroundOpacity: 'translucent'}
 		]},
-		{name: 'panels', kind: Panels, pattern: 'activity', classes: 'enyo-fit', useHandle: true, hasCloseButton: false, onShowingChanged: 'panelsShowingChanged', components: [
+		{name: 'panels', kind: Panels, pattern: 'activity', classes: 'enyo-fit', useHandle: true, onShowingChanged: 'panelsShowingChanged', components: [
 			{title: 'First Panel', titleBelow:'Sub-title', subTitleBelow:'Sub-sub title', components: [
 				{kind: Item, content: 'Item One', ontap: 'next1'},
 				{kind: Item, content: 'Item Two', ontap: 'next1'},

--- a/src/moonstone-samples/src/ActivityPanelsSample.js
+++ b/src/moonstone-samples/src/ActivityPanelsSample.js
@@ -11,7 +11,7 @@ module.exports = kind({
 	name: 'moon.sample.ActivityPanelsSample',
 	classes: 'moon enyo-fit enyo-unselectable',
 	components: [
-		{name: 'panels', kind: Panels, pattern: 'activity', hasCloseButton: false, components: [
+		{name: 'panels', kind: Panels, pattern: 'activity', components: [
 			{title: 'First Panel', titleBelow:'Sub-title', subTitleBelow:'Sub-sub title', headerComponents: [
 				{kind: ToggleButton, small:true, content:'Medium', name:'mediumHeaderToggle', ontap: 'typeTapped'},
 				{kind: ToggleButton, small:true, content:'Small', name:'smallHeaderToggle', ontap: 'typeTapped'}

--- a/src/moonstone-samples/src/ActivityPanelsWithVideoSample.js
+++ b/src/moonstone-samples/src/ActivityPanelsWithVideoSample.js
@@ -60,7 +60,7 @@ module.exports = kind({
 			{kind: IconButton, small: false, backgroundOpacity: 'translucent'},
 			{kind: IconButton, small: false, backgroundOpacity: 'translucent'}
 		]},
-		{name: 'panels', kind: Panels, pattern: 'activity', classes: 'enyo-fit', useHandle: true, hasCloseButton: false, onShowingChanged: 'panelsShowingChanged', components: [
+		{name: 'panels', kind: Panels, pattern: 'activity', classes: 'enyo-fit', useHandle: true, onShowingChanged: 'panelsShowingChanged', components: [
 			{title: 'First Panel', titleBelow:'Sub-title', subTitleBelow:'Sub-sub title', components: [
 				{kind: Item, content: 'Item One', ontap: 'next1'},
 				{kind: Item, content: 'Item Two', ontap: 'next1'},

--- a/src/moonstone-samples/src/All/All.js
+++ b/src/moonstone-samples/src/All/All.js
@@ -135,7 +135,7 @@ module.exports = kind({
 		{from: 'title', to: '$.listpanel.title'}
 	],
 	listTools: [
-		{kind: Panels, pattern: 'activity', hasCloseButton: false, components: [
+		{kind: Panels, pattern: 'activity', components: [
 			{kind: Panel, name: 'listpanel', headerType: 'small',
 				headerComponents: [
 					{kind: Button, content: 'Back', small: true, href: '../index.html', mixins: [LinkSupport]}

--- a/src/moonstone-samples/src/DataGridListSample.js
+++ b/src/moonstone-samples/src/DataGridListSample.js
@@ -87,7 +87,6 @@ var dataTypes = [
 module.exports = kind({
 	name: 'moon.sample.DataGridListSample',
 	kind: Panels,
-	hasCloseButton: false,
 	pattern: 'activity',
 	classes: 'moon enyo-unselectable moon-datagridlist-sample',
 	components: [

--- a/src/moonstone-samples/src/DataListSample.js
+++ b/src/moonstone-samples/src/DataListSample.js
@@ -35,7 +35,7 @@ module.exports = kind({
 				]}
 			]}
 		], components: [
-			{kind: Panels, pattern: 'activity', hasCloseButton: false, components: [
+			{kind: Panels, pattern: 'activity', components: [
 				{name: 'repeaterContainer', kind: Control}
 			]}
 		]},

--- a/src/moonstone-samples/src/DrawerSample.js
+++ b/src/moonstone-samples/src/DrawerSample.js
@@ -54,7 +54,6 @@ module.exports = kind({
 				{
 					name: 'panels',
 					kind: Panels,
-					hasCloseButton: false,
 					pattern: 'activity',
 					components: [
 						{title: 'First Panel', components: [

--- a/src/moonstone-samples/src/DynamicPanelsSample.js
+++ b/src/moonstone-samples/src/DynamicPanelsSample.js
@@ -15,7 +15,7 @@ module.exports = kind({
 	name: 'moon.sample.DynamicPanelsSample',
 	classes: 'moon enyo-fit enyo-unselectable',
 	components: [
-		{name: 'panels', kind: Panels, popOnBack:true, wrap: true, hasCloseButton: false, pattern: 'activity'}
+		{name: 'panels', kind: Panels, popOnBack:true, wrap: true, pattern: 'activity'}
 	],
 	rendered: function () {
 		this.inherited(arguments);


### PR DESCRIPTION
### Issue

After some discussion, we agreed that it would be best to have the close button appear in all the `moonstone/Panels` kinds that appear in samples (including the sample list), for the sake of consistency and demonstration of the feature for applications.
### Fix

The `hasCloseButton: false` setting has been removed in almost all samples, except for `PopupSample`, as the use case here is not a fullscreen panel.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
