### PR TITLE
ENYO-3200 Cancel Spotlight.TestMode on sample destroy

### DIFF
--- a/src/spotlight-samples/src/SpotlightSandboxSample/SpotlightSandboxSample.js
+++ b/src/spotlight-samples/src/SpotlightSandboxSample/SpotlightSandboxSample.js
@@ -113,6 +113,10 @@ module.exports = kind({
 			}
 		}
 	},
+	destroy: function () {
+		Spotlight.TestMode.disable();
+		this.inherited(arguments);
+	},
 	addBarracuda: function () {
 		var b = this.$.container.createComponent({kind: Barracuda}).render();
 		b.applyStyle('z-index:'+this.$.container.getClientControls().length+';');


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Roy Sutton roy.sutton@lge.com
## Issue

Spotlight Sandbox sample leaves `Spotlight.TestMode` enabled when closing
## Solution

Disable it on destroy
