### PR TITLE
Fixes ENYO-3206

### DIFF
--- a/src/spotlight-samples/src/HoldSample.js
+++ b/src/spotlight-samples/src/HoldSample.js
@@ -46,6 +46,10 @@ module.exports = kind({
 			this.reset(display);
 		}, 2000);
 	},
+	reset: function (display) {
+		var d = this.$[display];
+		d.set('content', d.get('idleContent'));
+	},
 	tapped: function (sender, ev) {
 		this.report(sender, 'tapped', 'd3');
 	},


### PR DESCRIPTION
The reset method was missed when the sample was cloned into spotlight
from enyo causing exceptions when trying to reset the display.

Adding it back fixes the issue.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
