### PR TITLE
Fixes ENYO-3180

### DIFF
--- a/src/onyx-samples/src/DatePickerSample.js
+++ b/src/onyx-samples/src/DatePickerSample.js
@@ -1,6 +1,7 @@
 var
 	kind = require('enyo/kind'),
-	$L = require('enyo/i18n').$L;
+	i18n = require('enyo/i18n'),
+	$L = i18n.$L;
 
 var
 	FittableColumns = require('layout/FittableColumns'),
@@ -52,7 +53,6 @@ module.exports = kind({
 				]}
 			]}
 		]},
-		{kind: Button, content: 'Get Dates', style: 'margin: 10px;', ontap: 'getDates'},
 		{kind: Button, content: 'Reset Dates', ontap: 'resetDates'},
 		{style: 'width: 100%;height: 5px;background-color: black;margin-bottom: 5px;'},
 		{caption: 'Dates', style: 'padding: 10px', components: [
@@ -86,18 +86,13 @@ module.exports = kind({
 			]}
 		]}
 	],
-	bindings: [
-		{from: '.$.localePicker.selected.content', to: '.locale'}
-	],
 	rendered: function () {
 		this.inherited(arguments);
 		this.localeChanged();
 	},
 	localeChanged: function () {
-		this.$.datePicker1.setLocale(this.locale);
-		this.$.datePicker2.setLocale(this.locale);
-		this.$.datePicker3.setLocale(this.locale);
-		this.$.datePicker4.setLocale(this.locale);
+		i18n.updateLocale(this.$.localePicker.get('selected').content);
+		this.getDates();
 		return true;
 	},
 	resetDates: function (date) {
@@ -109,22 +104,21 @@ module.exports = kind({
 		this.getDates();
 	},
 	getDates: function () {
-		var fmt = this.format();
-		this.$.datePicker1Value.setContent(fmt.format(this.$.datePicker1.getValue()));
-		this.$.datePicker2Value.setContent(fmt.format(this.$.datePicker2.getValue()));
-		// reformat the formatter to display the Date wiht only Month and year
-		fmt = this.format('my');
-		this.$.datePicker3Value.setContent(fmt.format(this.$.datePicker3.getValue()));
+		this.updateDateValue(this.$.datePicker1);
+		this.updateDateValue(this.$.datePicker2);
+		this.updateDateValue(this.$.datePicker3);
 	},
-	updateDateValues: function (sender, ev){
-		var fmt = ev.name != 'datePicker3' ? this.format() :  this.format('my');
-		this.$[ev.name + 'Value'].setContent(fmt.format(ev.value));
+	updateDateValues: function (sender, ev) {
+		this.updateDateValue(ev);
+	},
+	updateDateValue: function (picker) {
+		var fmt = picker.name != 'datePicker3' ? this.format() :  this.format('my');
+		this.$[picker.name + 'Value'].setContent(fmt.format(picker.value));
 	},
 	format: function (dateComponents) {
 		var fmt = new DateFmt({
 			dateComponents: dateComponents || undefined,
 			date: 'short',
-			locale: this.locale,
 			timezone: 'local'
 		});
 		return fmt;

--- a/src/onyx-samples/src/TimePickerSample.js
+++ b/src/onyx-samples/src/TimePickerSample.js
@@ -1,6 +1,7 @@
 var
 	kind = require('enyo/kind'),
-	$L = require('enyo/i18n').$L;
+	i18n = require('enyo/i18n'),
+	$L = i18n.$L;
 
 var
 	FittableColumns = require('layout/FittableColumns'),
@@ -53,7 +54,6 @@ module.exports = kind({
 			]}
 		]},
 
-		{kind: Button, content: 'Get Times', style: 'margin: 10px;', ontap: 'getTimes'},
 		{kind: Button, content: 'Reset Times', ontap: 'resetTimes'},
 
 		{style: 'width: 100%;height: 5px;background-color: black;margin-bottom: 5px;'},
@@ -81,18 +81,15 @@ module.exports = kind({
 			]}
 		]}
 	],
-	bindings: [
-		{from: '.$.localePicker.selected.content', to: '.locale'}
-	],
 	rendered: function () {
 		FittableRows.prototype.rendered.apply(this, arguments);
 		this.localeChanged();
 	},
 	localeChanged: function () {
-		this.$.timePicker1.setLocale(this.locale);
-		this.$.timePicker2.setLocale(this.locale);
-		this.$.timePicker2.setIs24HrMode(true);
-		this.$.timePicker3.setLocale(this.locale);
+		this.fmt = null;
+		i18n.updateLocale(this.$.localePicker.get('selected').content);
+		this.$.timePicker2.set('is24HrMode', true);
+		this.getTimes();
 		return true;
 	},
 	resetTimes: function (date) {
@@ -104,24 +101,19 @@ module.exports = kind({
 		this.getTimes();
 	},
 	getTimes: function () {
-		var fmt = new DateFmt({
-			type: 'time',
-			length: 'short',
-			locale: this.locale,
-			timezone: 'local'
-		});
-
-		this.$.timePicker1Value.setContent(fmt.format(this.$.timePicker1.getValue()));
-		this.$.timePicker2Value.setContent(fmt.format(this.$.timePicker2.getValue()));
+		this.updateTimeValue(this.$.timePicker1);
+		this.updateTimeValue(this.$.timePicker2);
 	},
-	updateTimeValues: function (sender, date){
-		var fmt = new DateFmt({
+	updateTimeValues: function (sender, ev) {
+		this.updateTimeValue(ev);
+	},
+	updateTimeValue: function (picker) {
+		var fmt = this.fmt || new DateFmt({
 			type: 'time',
 			length: 'short',
-			locale: this.locale,
 			timezone: 'local'
 		});
 
-		this.$[date.name + 'Value'].setContent(fmt.format(date.value));
+		this.$[picker.name + 'Value'].set('content', fmt.format(picker.value));
 	}
 });


### PR DESCRIPTION
Removing the locale property from the pickers and instead updating the
locale via enyo/i18n.updateLocale()

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
