### PR TITLE
ENYO-3222: Use updated cancelAnimationFrame API.

### DIFF
--- a/src/canvas-samples/src/CanvasBallsSample/CanvasBallsSample.js
+++ b/src/canvas-samples/src/CanvasBallsSample/CanvasBallsSample.js
@@ -40,7 +40,7 @@ module.exports = kind({
 	setupBalls: function () {
 		// pause loop to update the balls
 		if (this.cancel) {
-			animation.cancelRequestAnimationFrame(this.cancel);
+			animation.cancelAnimationFrame(this.cancel);
 		}
 		this.loopStart = Date.now();
 		this.frame = 0;
@@ -71,7 +71,7 @@ module.exports = kind({
 	},
 	destroy: function () {
 		if (this.cancel) {
-			animation.cancelRequestAnimationFrame(this.cancel);
+			animation.cancelAnimationFrame(this.cancel);
 		}
 		this.inherited(arguments);
 	},


### PR DESCRIPTION
### Issue

Due to the changes in https://github.com/enyojs/enyo/pull/1414, the API being used has been deprecated.
### Fix

Updated to use `cancelAnimationFrame`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
