### PR TITLE
ENYO-3203: Set delay for reading first panel title

### DIFF
--- a/src/moonstone-extra-samples/src/ActivityPanelsWithVideoSample.js
+++ b/src/moonstone-extra-samples/src/ActivityPanelsWithVideoSample.js
@@ -115,7 +115,10 @@ module.exports = kind({
 	],
 	rendered: function () {
 		this.inherited(arguments);
-		Spotlight.spot(this.$.panels);
+		// set delay in order to read focused item after reading a panel title
+		setTimeout(this.bindSafely(function () {
+			Spotlight.spot(this.$.panels);
+		}), 200);
 	},
 	// custom next handler for each panel to avoid switching from one active panel
 	// to another with no visible change for demo

--- a/src/moonstone-extra-samples/src/HistorySample.js
+++ b/src/moonstone-extra-samples/src/HistorySample.js
@@ -247,7 +247,10 @@ module.exports = kind({
 	},
 	rendered: function () {
 		Control.prototype.rendered.apply(this, arguments);
-		Spotlight.spot(this.$.panels);
+		// set delay in order to read focused item after reading a panel title
+		setTimeout(this.bindSafely(function () {
+			Spotlight.spot(this.$.panels);
+		}), 200);
 	},
 	// custom next handler for each panel to avoid switching from one active panel
 	// to another with no visible change for demo


### PR DESCRIPTION
TV reads focused item when sample is opened, because explicitly call spot().
However, First TV shoud read panel title according to TV UX guide, so
we set delay for giving a spotlight focus later.

https://jira2.lgsvl.com/browse/ENYO-3203
Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com
