### PR TITLE
Fixes ENYO-3203 add delay before spotting panels

### DIFF
--- a/moonstone-extra/src/ActivityPanelsWithVideoSample.js
+++ b/moonstone-extra/src/ActivityPanelsWithVideoSample.js
@@ -109,7 +109,9 @@ module.exports = kind({
 	],
 	rendered: function() {
 		this.inherited(arguments);
-		Spotlight.spot(this.$.panels);
+		setTimeout(this.bindSafely(function () {
+			Spotlight.spot(this.$.panels);
+		}), 200);
 	},
 	// custom next handler for each panel to avoid switching from one active panel
 	// to another with no visible change for demo

--- a/moonstone-extra/src/HistorySample.js
+++ b/moonstone-extra/src/HistorySample.js
@@ -218,7 +218,9 @@ module.exports = kind({
 	},
 	rendered: function () {
 		Control.prototype.rendered.apply(this, arguments);
-		Spotlight.spot(this.$.panels);
+		setTimeout(this.bindSafely(function () {
+			Spotlight.spot(this.$.panels);
+		}), 200);
 	},
 	// custom next handler for each panel to avoid switching from one active panel
 	// to another with no visible change for demo


### PR DESCRIPTION
TV reads focused item when sample is opened, because explicitly call spot().
However, First TV shoud read panel title according to TV UX guide, so
we set delay for giving a spotlight focus later.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
