### PR TITLE
PLAT-17872: Fixed to work when strict mode

### DIFF
--- a/src/strawman/List/List.js
+++ b/src/strawman/List/List.js
@@ -42,7 +42,7 @@ module.exports = kind({
 		return function () {
 			sup.apply(this, arguments);
 			this.listTypeChanged();
-		}
+		};
 	}),
 	listTypeChanged: function (old) {
 		this.$.repeater.removeClass(old);

--- a/src/strawman/List/List.js
+++ b/src/strawman/List/List.js
@@ -38,10 +38,12 @@ module.exports = kind({
 			}
 		}
 	],
-	create: function () {
-		this.inherited(arguments);
-		this.listTypeChanged();
-	},
+	create: kind.inherit(function (sup) {
+		return function () {
+			sup.apply(this, arguments);
+			this.listTypeChanged();
+		}
+	}),
 	listTypeChanged: function (old) {
 		this.$.repeater.removeClass(old);
 		this.$.repeater.addClass(this.get('listType'));

--- a/src/strawman/SampleList/SampleList.js
+++ b/src/strawman/SampleList/SampleList.js
@@ -43,6 +43,6 @@ module.exports = kind({
 			if (!this._libList && this.version) { // only display version information for individual libraries that are versioned
 				console.log('%c%s%s: %s', 'color:blue', (name ? name + ' - ' : ''), this.libraryName, this.version);
 			}
-		}
-	}),
+		};
+	})
 });

--- a/src/strawman/SampleList/SampleList.js
+++ b/src/strawman/SampleList/SampleList.js
@@ -14,33 +14,35 @@ module.exports = kind({
 		{name: 'list', kind: List}
 	],
 	_libList: false,
-	create: function () {
-		this.inherited(arguments);
+	create: kind.inherit(function (sup) {
+		return function () {
+			sup.apply(this, arguments);
 
-		var names = window.document.location.search.substring(1).split('&'),
-			name = names[1] || names[0];
+			var names = window.document.location.search.substring(1).split('&'),
+				name = names[1] || names[0];
 
-		// Set whether we're looking at a list of libraries or the root
-		this._libList = !name;
+			// Set whether we're looking at a list of libraries or the root
+			this._libList = !name;
 
-		if (this.samples[name]) {
-			global.sample = this.createComponent({kind: this.samples[name]});
-		} else {
-			name = null; // not a valid sample name
+			if (this.samples[name]) {
+				global.sample = this.createComponent({kind: this.samples[name]});
+			} else {
+				name = null; // not a valid sample name
 
-			this.addClass('strawman');
-			this.createComponents(this.listComponents);
-			this.binding({from: 'title',       to: '$.title.content'});
-			this.binding({from: 'samples',     to: '$.list.samples'});
-			this.binding({from: 'listType',    to: '$.list.listType'});
-			this.binding({from: 'libraryName', to: '$.list.libraryName'});
+				this.addClass('strawman');
+				this.createComponents(this.listComponents);
+				this.binding({from: 'title',       to: '$.title.content'});
+				this.binding({from: 'samples',     to: '$.list.samples'});
+				this.binding({from: 'listType',    to: '$.list.listType'});
+				this.binding({from: 'libraryName', to: '$.list.libraryName'});
 
-			// Don't show back if we're at home.
-			this.$.back.set('showing', !this._libList);
+				// Don't show back if we're at home.
+				this.$.back.set('showing', !this._libList);
+			}
+
+			if (!this._libList && this.version) { // only display version information for individual libraries that are versioned
+				console.log('%c%s%s: %s', 'color:blue', (name ? name + ' - ' : ''), this.libraryName, this.version);
+			}
 		}
-
-		if (!this._libList && this.version) { // only display version information for individual libraries that are versioned
-			console.log('%c%s%s: %s', 'color:blue', (name ? name + ' - ' : ''), this.libraryName, this.version);
-		}
-	}
+	}),
 });


### PR DESCRIPTION
## Issue

: Throws error when 'strice mode' is on.
Uncaught TypeError: 'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions or the arguments objects for calls to them
## Fix

: Replaced kind.inherited to kind.inherit

https://jira2.lgsvl.com/browse/PLAT-17872
Enyo-DCO-1.1-Signed-off-by: Mikyung Kim mikyung27.kim@lge.com
