### PR TITLE
PLAT-16233: Updated sample to use new VideoTitle components

### DIFF
--- a/src/moonstone-extra-samples/src/ActivityPanelsWithVideoSample.js
+++ b/src/moonstone-extra-samples/src/ActivityPanelsWithVideoSample.js
@@ -5,14 +5,10 @@ var
 	Spotlight = require('spotlight');
 
 var
-	ChannelInfo = require('moonstone/ChannelInfo'),
-	Clock = require('moonstone/Clock'),
 	IconButton = require('moonstone/IconButton'),
 	Item = require('moonstone/Item'),
 	Panels = require('moonstone/Panels'),
 	ToggleItem = require('moonstone/ToggleItem'),
-	VideoInfoBackground = require('moonstone/VideoInfoBackground'),
-	VideoInfoHeader = require('moonstone/VideoInfoHeader'),
 	VideoPlayer = require('moonstone-extra/VideoPlayer');
 
 var sources = [
@@ -25,30 +21,12 @@ module.exports = kind({
 	name: 'moon.sample.ActivityPanelsWithVideoSample',
 	classes: 'moon enyo-fit enyo-unselectable',
 	components: [
-		{name: 'player', kind: VideoPlayer, sources: sources, poster: '@../assets/video-poster.png', autoplay: true, showing: false, infoComponents: [
-			{kind: VideoInfoBackground, orient: 'left', background: true, fit: true, components: [
-				{
-					kind: ChannelInfo,
-					channelNo: '13',
-					channelName: 'AMC',
-					components: [
-						{content: '3D'},
-						{content: 'Live'},
-						{content: 'REC 08:22', classes: 'redicon'}
-					]
-				},
-				{
-					kind: VideoInfoHeader,
-					title: 'Downton Abbey - Extra Title',
-					subTitle: 'Mon June 21, 7:00 - 8:00pm',
-					subSubTitle: 'R - TV 14, V, L, SC',
-					description: 'The series, set in the Youkshire country estate of Downton Abbey, depicts the lives of the aristocratic Crawley famiry and'
-				}
-			]},
-			{kind: VideoInfoBackground, orient: 'right', background: true, components: [
-				{kind: Clock}
-			]}
-		], components: [
+		{name: 'player', kind: VideoPlayer, sources: sources, poster: '@../assets/video-poster.png', autoplay: true, showing: false, title: 'Downton Abbey', infoComponents: [
+				{content: 'DTV'},
+				{content: 'REC 08:22', classes: 'redicon'},
+				{content: '&#42279;', accessibilityLabel: 'THX Certified Audio', classes: 'font-lg-icons'},
+				{content: '&#42295;', accessibilityLabel: '16 by 9 Aspect Ratio', classes: 'font-lg-icons'}
+			], components: [
 			{kind: IconButton, small: false, backgroundOpacity: 'translucent'},
 			{kind: IconButton, small: false, backgroundOpacity: 'translucent'},
 			{kind: IconButton, small: false, backgroundOpacity: 'translucent'},

--- a/src/moonstone-extra-samples/src/AlwaysViewingPanelsWithVideoSample.js
+++ b/src/moonstone-extra-samples/src/AlwaysViewingPanelsWithVideoSample.js
@@ -3,8 +3,6 @@ var
 
 var
 	Button = require('moonstone/Button'),
-	ChannelInfo = require('moonstone/ChannelInfo'),
-	Clock = require('moonstone/Clock'),
 	ContextualPopup = require('moonstone/ContextualPopup'),
 	ContextualPopupDecorator = require('moonstone/ContextualPopupDecorator'),
 	IconButton = require('moonstone/IconButton'),
@@ -13,8 +11,6 @@ var
 	ToggleItem = require('moonstone/ToggleItem'),
 	Tooltip = require('moonstone/Tooltip'),
 	TooltipDecorator = require('moonstone/TooltipDecorator'),
-	VideoInfoBackground = require('moonstone/VideoInfoBackground'),
-	VideoInfoHeader = require('moonstone/VideoInfoHeader'),
 	VideoPlayer = require('moonstone-extra/VideoPlayer');
 
 var sources = [
@@ -27,30 +23,12 @@ module.exports = kind({
     name: 'moon.sample.AlwaysViewingPanelsWithVideoSample',
     classes: 'moon enyo-fit enyo-unselectable',
     components: [
-        {name: 'player', kind: VideoPlayer, sources: sources, poster: '@../assets/video-poster.png', autoplay: true, infoComponents: [
-			{kind: VideoInfoBackground, orient: 'left', background: true, fit: true, components: [
-				{
-					kind: ChannelInfo,
-					channelNo: '13',
-					channelName: 'AMC',
-					components: [
-						{content: '3D'},
-						{content: 'Live'},
-						{content: 'REC 08:22', classes: 'redicon'}
-					]
-				},
-				{
-					kind: VideoInfoHeader,
-					title: 'Downton Abbey - Extra Title',
-					subTitle: 'Mon June 21, 7:00 - 8:00pm',
-					subSubTitle: 'R - TV 14, V, L, SC',
-					description: 'The series, set in the Youkshire country estate of Downton Abbey, depicts the lives of the aristocratic Crawley famiry and'
-				}
-			]},
-			{kind: VideoInfoBackground, orient: 'right', background: true, components: [
-				{kind: Clock}
-			]}
-		], components: [
+        {name: 'player', kind: VideoPlayer, sources: sources, poster: '@../assets/video-poster.png', autoplay: true, title: 'Downton Abbey', infoComponents: [
+				{content: 'DTV'},
+				{content: 'REC 08:22', classes: 'redicon'},
+				{content: '&#42279;', accessibilityLabel: 'THX Certified Audio', classes: 'font-lg-icons'},
+				{content: '&#42295;', accessibilityLabel: '16 by 9 Aspect Ratio', classes: 'font-lg-icons'}
+			], components: [
 			{kind: IconButton, icon: 'list', small: false, backgroundOpacity: 'translucent'},
 			{kind: TooltipDecorator, components: [
 				{kind: ContextualPopupDecorator, components: [

--- a/src/moonstone-extra-samples/src/HistorySample.js
+++ b/src/moonstone-extra-samples/src/HistorySample.js
@@ -7,9 +7,7 @@ var
 	DataRepeater = require('enyo/DataRepeater'),
 	Spotlight = require('spotlight'),
 	Button = require('moonstone/Button'),
-	ChannelInfo = require('moonstone/ChannelInfo'),
 	CheckboxItem = require('moonstone/CheckboxItem'),
-	Clock = require('moonstone/Clock'),
 	ContextualPopup = require('moonstone/ContextualPopup'),
 	ContextualPopupDecorator = require('moonstone/ContextualPopupDecorator'),
 	DataList = require('moonstone/DataList'),
@@ -30,8 +28,6 @@ var
 	Scroller = require('moonstone/Scroller'),
 	TimePicker = require('moonstone/TimePicker'),
 	ToggleItem = require('moonstone/ToggleItem'),
-	VideoInfoBackground = require('moonstone/VideoInfoBackground'),
-	VideoInfoHeader = require('moonstone/VideoInfoHeader'),
 	VideoPlayer = require('moonstone-extra/VideoPlayer');
 
 module.exports = kind({
@@ -75,34 +71,12 @@ module.exports = kind({
 				}
 			],
 			components: [
-				{name: 'player', kind: VideoPlayer, src: 'http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4', poster: '@../assets/video-poster.png', autoplay: true, showing: false, infoComponents: [
-					{kind: VideoInfoBackground, orient: 'left', background: true, fit: true, components: [
-						{
-							kind: ChannelInfo,
-							channelNo: '789-123',
-							channelName: 'AMC',
-							channelDesc: 'KRON-HD',
-							channelMoreDesc: '4:30 - 5:30PM',
-							components: [
-								{content: 'DTV'},
-								{content: 'Cinema'},
-								{content: '3D'}
-							]
-						},
-						{
-							kind: VideoInfoHeader,
-							title: 'Downton Abbey',
-							uppercase: false,
-							// Todo, we can remove below comment out after policy of samples is decided.
-							// In latest tag like 2.6.0-pre.5, we don't have samples.
-							// src: '$lib/moonstone/samples/assets/default-music.png',
-							description: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
-						}
-					]},
-					{kind: VideoInfoBackground, orient: 'right', background: true, components: [
-						{kind: Clock}
-					]}
-				], components: [
+				{name: 'player', kind: VideoPlayer, src: 'http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4', poster: '@../assets/video-poster.png', autoplay: true, showing: false, title: 'Downton Abbey', infoComponents: [
+				{content: 'DTV'},
+				{content: 'REC 08:22', classes: 'redicon'},
+				{content: '&#42279;', accessibilityLabel: 'THX Certified Audio', classes: 'font-lg-icons'},
+				{content: '&#42295;', accessibilityLabel: '16 by 9 Aspect Ratio', classes: 'font-lg-icons'}
+			], components: [
 					{kind: IconButton, small: false, backgroundOpacity: 'translucent'},
 					{kind: IconButton, small: false, backgroundOpacity: 'translucent'},
 					{kind: IconButton, small: false, backgroundOpacity: 'translucent'},

--- a/src/moonstone-extra-samples/src/PanelsVideoPlayerSample.js
+++ b/src/moonstone-extra-samples/src/PanelsVideoPlayerSample.js
@@ -8,8 +8,6 @@ var
 
 var
 	Button = require('moonstone/Button'),
-	ChannelInfo = require('moonstone/ChannelInfo'),
-	Clock = require('moonstone/Clock'),
 	Divider = require('moonstone/Divider'),
 	IconButton = require('moonstone/IconButton'),
 	Panel = require('moonstone/Panel'),
@@ -17,8 +15,6 @@ var
 	SelectableItem = require('moonstone/SelectableItem'),
 	ToggleButton = require('moonstone/ToggleButton'),
 	VideoFullscreenToggleButton = require('moonstone/VideoFullscreenToggleButton'),
-	VideoInfoBackground = require('moonstone/VideoInfoBackground'),
-	VideoInfoHeader = require('moonstone/VideoInfoHeader'),
 	VideoPlayer = require('moonstone-extra/VideoPlayer');
 
 module.exports = kind({
@@ -54,38 +50,17 @@ module.exports = kind({
 							inline:true,
 							classes: 'moon-8h',
 							poster: '@../assets/video-poster.png',
-							infoComponents: [{
-								kind: VideoInfoBackground,
-								orient: 'left',
-								fit: true,
-								components: [
-									{
-										kind: ChannelInfo,
-										channelNo: '13',
-										channelName: 'AMC',
-										components: [
-											{content: '3D'},
-											{content: 'Live'},
-											{content: 'REC 08:22', classes: 'redicon'}
-										]
-									},
-									{
-										kind: VideoInfoHeader,
-										title: 'Downton Abbey',
-										subTitle: 'Mon June 21, 7:00 - 8:00pm',
-										subSubTitle: 'R - TV 14, V, L, SC',
-										description: 'The series, set in the Youkshire country estate of Downton Abbey, depicts the lives of the aristocratic Crawley famiry and'
-									}
-								]
-							}, {
-								kind: VideoInfoBackground,
-								orient: 'right',
-								components: [
-									{kind: Clock}
-								]
-							}],
+							title: 'Downton Abbey',
+							infoComponents: [
+								{content: 'DTV'},
+								{content: 'REC 08:22', classes: 'redicon'},
+								{content: '&#42279;', accessibilityLabel: 'THX Certified Audio', classes: 'font-lg-icons'},
+								{content: '&#42295;', accessibilityLabel: '16 by 9 Aspect Ratio', classes: 'font-lg-icons'}
+							],
+							leftComponents: [
+								{kind: VideoFullscreenToggleButton, backgroundOpacity: 'translucent'}
+							],
 							components: [
-								{kind: VideoFullscreenToggleButton, backgroundOpacity: 'translucent'},
 								{kind: IconButton, backgroundOpacity: 'translucent'},
 								{kind: IconButton, backgroundOpacity: 'translucent'},
 								{kind: IconButton, backgroundOpacity: 'translucent'},
@@ -123,7 +98,7 @@ module.exports = kind({
 			{src: 'http://media.w3.org/2010/05/video/movie_300.webm', type: 'video/webm'}
 		];
 		this.$.player.setSources(this.sources);
-		this.$.videoInfoHeader.setTitle('Ticking Counter Video');
+		this.$.player.set('title', 'Ticking Counter Video');
 	},
 	webMovieBunny: function (sender, ev) {
 		if (!ev.originator.active) {
@@ -136,7 +111,7 @@ module.exports = kind({
 			{src: 'http://clips.vorwaerts-gmbh.de/big_buck_bunny.webm', type: 'video/webm'}
 		];
 		this.$.player.setSources(this.sources);
-		this.$.videoInfoHeader.setTitle('Bunny Video');
+		this.$.player.set('title', 'Bunny Video');
 	},
 	webMovieSintel: function (sender, ev) {
 		if (!ev.originator.active) {
@@ -149,7 +124,7 @@ module.exports = kind({
 			{src: 'http://media.w3.org/2010/05/sintel/trailer.webm', type: 'video/webm'}
 		];
 		this.$.player.setSources(this.sources);
-		this.$.videoInfoHeader.setTitle('The Sintel Video');
+		this.$.player.set('title', 'The Sintel Video');
 	},
 	error: function (sender, ev) {
 		if (!ev.originator.active) {
@@ -157,7 +132,7 @@ module.exports = kind({
 		}
 		this.src = 'http://foo.bar';
 		this.$.player.setSrc(this.src);
-		this.$.videoInfoHeader.setTitle('Error video');
+		this.$.player.set('title', 'Error video');
 	}
 });
 

--- a/src/moonstone-extra-samples/src/VideoPlayerInlineSample.js
+++ b/src/moonstone-extra-samples/src/VideoPlayerInlineSample.js
@@ -2,12 +2,8 @@ var
 	kind = require('enyo/kind');
 
 var
-	ChannelInfo = require('moonstone/ChannelInfo'),
-	Clock = require('moonstone/Clock'),
 	IconButton = require('moonstone/IconButton'),
-	VideoFullscreenToggleButton = require('moonstone/VideoFullscreenToggleButton'),
-	VideoInfoBackground = require('moonstone/VideoInfoBackground'),
-	VideoInfoHeader = require('moonstone/VideoInfoHeader'),
+	VideoFullscreenToggleButton = require('moonstone-extra/VideoFullscreenToggleButton'),
 	VideoPlayer = require('moonstone-extra/VideoPlayer');
 
 var sources = [
@@ -29,29 +25,12 @@ module.exports = kind({
 			inline: true,
 			classes: 'moon-8h',
 			autoplay: true,
+			title: 'Downton Abbey',
 			infoComponents: [
-				{kind: VideoInfoBackground, orient: 'left', fit: true, components: [
-					{
-						kind: ChannelInfo,
-						channelNo: '13',
-						channelName: 'AMC',
-						components: [
-							{content: 'DTV'},
-							{content: 'Cinema'},
-							{content: '3D'}
-						]
-					},
-					{
-						kind: VideoInfoHeader,
-						title: 'Downton Abbey',
-						subTitle: 'Mon June 21, 7:00 - 8:00pm',
-						subSubTitle: 'R - TV 14, V, L, SC',
-						description: 'The series, set in the Yorukshire country estate of Downton Abbey, depicts the lives of the aristocratic Crawley famiry and'
-					}
-				]},
-				{kind: VideoInfoBackground, orient: 'right', components: [
-					{kind: Clock}
-				]}
+				{content: 'DTV'},
+				{content: 'REC 08:22', classes: 'redicon'},
+				{content: '&#42279;', accessibilityLabel: 'THX Certified Audio', classes: 'font-lg-icons'},
+				{content: '&#42295;', accessibilityLabel: '16 by 9 Aspect Ratio', classes: 'font-lg-icons'}
 			],
 			components: [
 				{kind: VideoFullscreenToggleButton, backgroundOpacity: 'translucent'},

--- a/src/moonstone-extra-samples/src/VideoPlayerSample.js
+++ b/src/moonstone-extra-samples/src/VideoPlayerSample.js
@@ -3,8 +3,6 @@ var
 
 var
 	Button = require('moonstone/Button'),
-	ChannelInfo = require('moonstone/ChannelInfo'),
-	Clock = require('moonstone/Clock'),
 	ContextualPopup = require('moonstone/ContextualPopup'),
 	ContextualPopupDecorator = require('moonstone/ContextualPopupDecorator'),
 	Dialog = require('moonstone/Dialog'),
@@ -13,8 +11,6 @@ var
 	ToggleButton = require('moonstone/ToggleButton'),
 	Tooltip = require('moonstone/Tooltip'),
 	TooltipDecorator = require('moonstone/TooltipDecorator'),
-	VideoInfoBackground = require('moonstone/VideoInfoBackground'),
-	VideoInfoHeader = require('moonstone/VideoInfoHeader'),
 	VideoPlayer = require('moonstone-extra/VideoPlayer');
 
 var sources = [
@@ -35,35 +31,21 @@ module.exports = kind({
 			poster: '@../assets/video-poster.png',
 			autoplay: true,
 			onPlaybackControlsTapped: 'controlsTapped',
+			title: 'Downton Abbey',
 			infoComponents: [
-				{kind: VideoInfoBackground, orient: 'left', background: true, fit: true, components: [
-					{
-						kind: ChannelInfo,
-						channelNo: '789-123',
-						channelName: 'AMC',
-						channelDesc: 'KRON-HD',
-						channelMoreDesc: '4:30 - 5:30PM',
-						components: [
-							{content: 'DTV'},
-							{content: 'Cinema'},
-							{content: '3D'}
-						]
-					},
-					{
-						kind: VideoInfoHeader,
-						title: 'Downton Abbey',
-						uppercase: false,
-						// Todo, we can remove below comment out after policy of samples is decided.
-						// In latest tag like 2.6.0-pre.5, we don't have samples.
-						// src: '$lib/moonstone/samples/assets/default-music.png',
-						description: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
-					}
-				]},
-				{kind: VideoInfoBackground, orient: 'right', background: true, components: [
-					{kind: Clock}
-				]}
+				{content: 'DTV'},
+				{content: 'REC 08:22', classes: 'redicon'},
+				{content: '&#42279;', accessibilityLabel: 'THX Certified Audio', classes: 'font-lg-icons'},
+				{content: '&#42295;', accessibilityLabel: '16 by 9 Aspect Ratio', classes: 'font-lg-icons'}
 			],
-	   		components: [
+			leftComponents: [
+				{kind: IconButton, icon: 'list', small: false, backgroundOpacity: 'translucent'},
+				{kind: IconButton, icon: 'search', small: false, backgroundOpacity: 'translucent'}
+			],
+			rightComponents: [
+				{kind: IconButton, icon: 'hollowstar', small: false, backgroundOpacity: 'translucent'}
+			],
+			components: [
 				{kind: IconButton, small: false, backgroundOpacity: 'translucent'},
 				{kind: ToggleButton, name: 'controlsToggleButton', content: 'Controls', backgroundOpacity: 'translucent'},
 				{kind: Button, content: 'Unload', backgroundOpacity: 'translucent', ontap: 'unload'},


### PR DESCRIPTION
This is now the prescribed way to use the VideoPlayer control.
Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
