### PR TITLE
ENYO-3434: Add class to corresponding control

### DIFF
--- a/src/moonstone-samples/lib/PopupSample.js
+++ b/src/moonstone-samples/lib/PopupSample.js
@@ -70,8 +70,8 @@ module.exports = kind({
 				{kind: Button, content: 'Goodbye'}
 			]}
 		]},
-		{name: 'panelsPopup', kind: Popup, showCloseButton: true, classes: 'moon-12v', components: [
-			{kind: Panels, name: 'panels', defaultKind: FittableRows, arrangerKind: CardArranger, animate:false, hasCloseButton: false, components: [
+		{name: 'panelsPopup', kind: Popup, showCloseButton: true, components: [
+			{kind: Panels, name: 'panels', defaultKind: FittableRows, arrangerKind: CardArranger, animate:false, hasCloseButton: false, classes: 'moon-12v', components: [
 				{components: [
 					{kind: Divider, content: 'Step 1: Terms of Service'},
 					{kind: Scroller, fit: true, spotlightPagingControls: true, horizontal: 'hidden', style: 'margin-bottom:20px;', components: [


### PR DESCRIPTION
There was a regression that moon-12v class is moved to unexpected control.
It caused broken layout on Popup Sample.
To fix it, I re-moved moon-12v class to Panels, not Popup.

Enyo-DCO-1.1-Signed-off-by: Yeram Choi (yeram.choi@lge.com)
