### PR TITLE
PLAT-43859: Fix Text is cropped in data grid list on iOS

### DIFF
--- a/src/moonstone-samples/lib/DataGridListSample.less
+++ b/src/moonstone-samples/lib/DataGridListSample.less
@@ -8,7 +8,7 @@
 		> .caption,
 		> .sub-caption {
 			position: relative;
-			top: 18%;
+			top: 5px;
 			overflow: hidden;
 		}
 	}

--- a/src/moonstone-samples/lib/DataGridListSample.less
+++ b/src/moonstone-samples/lib/DataGridListSample.less
@@ -8,7 +8,7 @@
 		> .caption,
 		> .sub-caption {
 			position: relative;
-			top: 5px;
+			top: 6px;
 			overflow: hidden;
 		}
 	}


### PR DESCRIPTION
### Issue Resolved / Feature Added
 Fix Text is cropped in data grid list when itemtype is Horizontal item/imageItem.


### Resolution
Changed the `top` from 18% to 5px.


### Additional Considerations


### Links
PLAT-43859


### Comments
Enyo-DCO-1.1-Signed-off-by: Srirama Singeri(srirama.singeri@lge.com)