### PR TITLE
PLAT-43864: [iOS] Overlay items not aligned properly

### DIFF
--- a/src/moonstone-samples/lib/OverlaySample.css
+++ b/src/moonstone-samples/lib/OverlaySample.css
@@ -4,6 +4,7 @@
 		width: 312px;
 		margin: 10px;
 		position: relative;
+		vertical-align: middle;
 
 		.moon-image {
 			height: 300px;


### PR DESCRIPTION
### Issue Resolved / Feature Added
Overlay: items not aligned properly

### Resolution
'vertical-align: middle;' to OverlayItem will resolve this issue

### Links
PLAT-43864

### Comments
Enyo-DCO-1.1-Signed-off-by: Anish TD(anish.td@lge.com)